### PR TITLE
Change cursor table to track next version to process 

### DIFF
--- a/python/create_table.py
+++ b/python/create_table.py
@@ -30,11 +30,11 @@ class Event(Base):
     event_index: Mapped[int] = mapped_column(BigInteger)
 
 
-class LatestProcessedVersion(Base):
-    __tablename__ = "latest_processed_versions"
+class NextVersionToProcess(Base):
+    __tablename__ = "next_versions_to_process"
 
     indexer_name: Mapped[str] = mapped_column(primary_key=True)
-    latest_processed_version: Mapped[int] = mapped_column(BigInteger)
+    next_version: Mapped[int] = mapped_column(BigInteger)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=func.now(),

--- a/python/processor.py
+++ b/python/processor.py
@@ -1,5 +1,5 @@
 from config import Config
-from create_table import LatestProcessedVersion
+from create_table import NextVersionToProcess
 from event_parser import INDEXER_NAME, parse
 from aptos.indexer.v1 import raw_data_pb2_grpc
 
@@ -27,13 +27,13 @@ if config.starting_version != None:
     # Start from config's starting version if set
     starting_version = config.starting_version
 else:
-    # Start from latest processed version in db
+    # Start from next version to process in db
     with Session(engine) as session, session.begin():
-        latest_processed_version_from_db = session.get(
-            LatestProcessedVersion, INDEXER_NAME
+        next_version_to_process_from_db = session.get(
+            NextVersionToProcess, INDEXER_NAME
         )
-        if latest_processed_version_from_db != None:
-            starting_version = latest_processed_version_from_db.latest_processed_version
+        if next_version_to_process_from_db != None:
+            starting_version = next_version_to_process_from_db.next_version
 
 print(
     json.dumps(
@@ -89,9 +89,9 @@ with grpc.insecure_channel(config.indexer_endpoint, options=options) as channel:
 
                 # Update latest processed version
                 session.merge(
-                    LatestProcessedVersion(
+                    NextVersionToProcess(
                         indexer_name=INDEXER_NAME,
-                        latest_processed_version=current_transaction_version,
+                        next_version=current_transaction_version + 1,
                     )
                 )
 


### PR DESCRIPTION
Change cursor table to track next version to process instead of latest processed version, which is confusing. 

## Testing
1. `docker compose up --build --force-recreate ` on fresh db and existing db
2. `python processor.py -c config.yaml` on fresh db and existing db
3. `poetry run poe pyright`