### PR TITLE
change config name from indexer to processor

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -5,8 +5,8 @@ from pydantic.env_settings import SettingsSourceCallable
 
 class Config(BaseSettings):
     chain_id: int
-    indexer_endpoint: str
-    indexer_api_key: str
+    processor_endpoint: str
+    processor_api_key: str
     starting_version: int | None = None
     db_connection_uri: str
 

--- a/python/processor.py
+++ b/python/processor.py
@@ -19,7 +19,7 @@ args = parser.parse_args()
 config = Config.from_yaml_file(args.config)
 
 metadata = (
-    ("x-aptos-data-authorization", config.indexer_api_key),
+    ("x-aptos-data-authorization", config.processor_api_key),
     ("x-aptos-request-name", INDEXER_NAME),
 )
 options = [("grpc.max_receive_message_length", -1)]
@@ -47,7 +47,7 @@ print(
     )
 )
 # Connect to grpc
-with grpc.insecure_channel(config.indexer_endpoint, options=options) as channel:
+with grpc.insecure_channel(config.processor_endpoint, options=options) as channel:
     stub = raw_data_pb2_grpc.RawDataStub(channel)
     current_transaction_version = starting_version
 


### PR DESCRIPTION
change some config fields' names to align with [this file](https://github.com/aptos-labs/internal-ops/blob/5d523bd0e705a3426dc01176d8526061dbeafc2e/infra/apps/aptos-indexer-processors/src/aptos-indexer-processors-k8s.ts)