### PR TITLE
rename config parameters and make indexer_name a processor-level constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Aptos Indexer Client Guide
 This guide will get you started with creating an Aptos indexer with custom parsing. We have several endpoints that provided a streaming RPC of transaction data. 
 
-## Indexer Endpoints(all endpoints are in GCP us-central1 unless specified)
-* devent: 35.225.218.95:50051
+## GRPC Data Stream Endpoints(all endpoints are in GCP us-central1 unless specified)
+* devnet: 35.225.218.95:50051
 
 * testnet: 35.223.137.149:50051
   * Asia(GCP asia-northeast3): 34.64.252.224:50051
@@ -12,8 +12,8 @@ This guide will get you started with creating an Aptos indexer with custom parsi
 ## Request
  - `config.yaml`
    - `chain_id`: ID of the chain used for validation purposes. 
-   - `indexer_endpoint`: Replace with the indexer endpoints for mainnet, devnet, testnet, or previewnet. 
-   - `indexer_api_key`: Replace `YOUR_TOKEN` with your auth token.
+   - `grpc_data_stream_endpoint`: Replace with the grpc data stream endpoints for mainnet, devnet, testnet, or previewnet. 
+   - `grpc_data_stream_api_key`: Replace `YOUR_TOKEN` with your auth token.
    - `db_connection_uri`: The DB connection used to write the processed data 
    - (optional) `starting-version`
      - If `starting-version` is set, the processor will begin indexing from transaction version = `starting_version`.

--- a/python/config.yaml.example
+++ b/python/config.yaml.example
@@ -1,7 +1,6 @@
 chain_id: 1
-indexer_endpoint: "34.30.218.153:50051"
-indexer_api_key: "<INDEXER_API_KEY>"
-indexer_name: "<INDEXER_NAME>"
+grpc_data_stream_endpoint: "34.30.218.153:50051"
+grpc_data_stream_api_key: "<grpc_data_stream_api_key>"
 db_connection_uri: "postgresql://<your_connection_uri_to_postgres>"
 # If there is no version in the DB, start processor from starting_version_default
 # starting_version_default: <starting_version_default>

--- a/python/processors/aptos_ambassador_token/processor.py
+++ b/python/processors/aptos_ambassador_token/processor.py
@@ -20,7 +20,7 @@ if config.starting_version_default != None:
 if config.starting_version_override != None:
     starting_version = config.starting_version_override
 metadata = (
-    ("x-aptos-data-authorization", config.indexer_api_key),
+    ("x-aptos-data-authorization", config.grpc_data_stream_api_key),
     ("x-aptos-request-name", "ambassador token indexer"),
 )
 options = [("grpc.max_receive_message_length", -1)]
@@ -29,7 +29,7 @@ qualified_module_name = "0x9bfdd4efe15f4d8aa145bef5f64588c7c391bcddaf34f9e977f59
 qualified_event_name = qualified_module_name + "::LevelUpdateEvent"
 qualified_resource_name = qualified_module_name + "::AmbassadorLevel"
 
-with grpc.insecure_channel(config.indexer_endpoint, options=options) as channel:
+with grpc.insecure_channel(config.grpc_data_stream_endpoint, options=options) as channel:
     stub = raw_data_pb2_grpc.RawDataStub(channel)
     current_transaction_version = starting_version
 

--- a/python/processors/example_event_processor/models.py
+++ b/python/processors/example_event_processor/models.py
@@ -1,3 +1,4 @@
+from utils.models.annotated_types import StringType
 from utils.models.annotated_types import (
     StringPrimaryKeyType,
     BigIntegerType,
@@ -17,7 +18,7 @@ class Event(Base):
     transaction_version: BigIntegerType
     transaction_block_height: BigIntegerType
     transaction_timestamp: TimestampType
-    type: str
-    data: str
+    type: StringType
+    data: StringType
     inserted_at: InsertedAtType
     event_index: BigIntegerType

--- a/python/processors/example_event_processor/processor.py
+++ b/python/processors/example_event_processor/processor.py
@@ -48,6 +48,7 @@ def parse(transaction: transaction_pb2.Transaction) -> List[Event]:
 
 if __name__ == "__main__":
     transactions_processor = TransactionsProcessor(
-        parse,
+        parser_function=parse,
+        processor_name="python-example-event-processor",
     )
     transactions_processor.process()

--- a/python/processors/nft_orderbooks/nft_marketplace_activities_processor.py
+++ b/python/processors/nft_orderbooks/nft_marketplace_activities_processor.py
@@ -105,6 +105,7 @@ def parse(
 
 if __name__ == "__main__":
     transactions_processor = TransactionsProcessor(
-        parse,
+        parser_function=parse,
+        processor_name="nft-marketplace-activities",
     )
     transactions_processor.process()

--- a/python/utils/config.py
+++ b/python/utils/config.py
@@ -10,9 +10,8 @@ from typing import Any, Dict, List, Optional
 
 class Config(BaseSettings):
     chain_id: int
-    indexer_endpoint: str
-    indexer_api_key: str
-    indexer_name: str
+    grpc_data_stream_endpoint: str
+    grpc_data_stream_api_key: str
     db_connection_uri: str
     starting_version_default: Optional[int] = None
     starting_version_override: Optional[int] = None
@@ -37,7 +36,7 @@ class Config(BaseSettings):
 
         return cls(**config)
 
-    def get_starting_version(self) -> int:
+    def get_starting_version(self, processor_name: str) -> int:
         next_version_to_process = None
 
         if self.db_connection_uri is not None:
@@ -46,7 +45,7 @@ class Config(BaseSettings):
 
                 with Session(engine) as session, session.begin():
                     next_version_to_process_from_db = session.get(
-                        NextVersionToProcess, self.indexer_name
+                        NextVersionToProcess, processor_name
                     )
                     if next_version_to_process_from_db != None:
                         next_version_to_process = (

--- a/python/utils/transactions_processor.py
+++ b/python/utils/transactions_processor.py
@@ -2,25 +2,33 @@ import argparse
 import grpc
 import json
 
-from collections import defaultdict
 from utils.models.general_models import NextVersionToProcess
 from aptos.indexer.v1 import raw_data_pb2, raw_data_pb2_grpc
 from aptos.transaction.v1 import transaction_pb2
 from utils.config import Config
 from utils.models.general_models import Base
-from sqlalchemy import create_engine, inspect, MetaData, Table
-from sqlalchemy.dialects import postgresql
+from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session
 from typing import Any, Callable
 
 
 class TransactionsProcessor:
-    def __init__(self, parser_function: Callable[[transaction_pb2.Transaction], Any]):
+    parser_function: Callable[[transaction_pb2.Transaction], list[Any]]
+    config: Config
+    processor_name: str
+    engine: Engine | None
+
+    def __init__(
+        self,
+        parser_function: Callable[[transaction_pb2.Transaction], list[Any]],
+        processor_name: str,
+    ):
         parser = argparse.ArgumentParser()
         parser.add_argument("-c", "--config", help="Path to config file", required=True)
         args = parser.parse_args()
         self.config = Config.from_yaml_file(args.config)
         self.parser_function = parser_function
+        self.processor_name = processor_name
         self.engine = None
 
         self.init_db_tables()
@@ -40,28 +48,31 @@ class TransactionsProcessor:
 
     def process(self) -> None:
         # Setup the GetTransactionsRequest
-        starting_version = self.config.get_starting_version()
+
+        starting_version = self.config.get_starting_version(self.processor_name)
+
         request = raw_data_pb2.GetTransactionsRequest(starting_version=starting_version)
 
         # Setup GRPC settings
         metadata = (
-            ("x-aptos-data-authorization", self.config.indexer_api_key),
-            ("x-aptos-request-name", self.config.indexer_name),
+            ("x-aptos-data-authorization", self.config.grpc_data_stream_api_key),
+            ("x-aptos-request-name", self.processor_name),
         )
         options = [("grpc.max_receive_message_length", -1)]
 
         print(
             json.dumps(
                 {
-                    "message": "Connected to the indexer grpc",
+                    "message": f"Connected to grpc data stream endpoint: {self.config.grpc_data_stream_endpoint}",
                     "starting_version": starting_version,
                 }
-            )
+            ),
+            flush=True,
         )
 
         # Connect to indexer grpc endpoint
         with grpc.insecure_channel(
-            self.config.indexer_endpoint, options=options
+            self.config.grpc_data_stream_endpoint, options=options
         ) as channel:
             stub = raw_data_pb2_grpc.RawDataStub(channel)
             current_transaction_version = starting_version
@@ -127,8 +138,6 @@ class TransactionsProcessor:
                     current_transaction_version += 1
 
     def insert_to_db(self, parsed_objs, txn_version) -> None:
-        indexer_name = self.config.indexer_name
-
         # If we find relevant transactions add them and update latest processed version
         if parsed_objs is not None:
             with Session(self.engine) as session, session.begin():
@@ -138,7 +147,7 @@ class TransactionsProcessor:
                 # Update latest processed version
                 session.merge(
                     NextVersionToProcess(
-                        indexer_name=indexer_name,
+                        indexer_name=self.processor_name,
                         next_version=txn_version + 1,
                     )
                 )
@@ -148,7 +157,7 @@ class TransactionsProcessor:
                 # Update latest processed version
                 session.merge(
                     NextVersionToProcess(
-                        indexer_name=indexer_name,
+                        indexer_name=self.processor_name,
                         next_version=txn_version + 1,
                     )
                 )

--- a/typescript/config.yaml.example
+++ b/typescript/config.yaml.example
@@ -1,5 +1,5 @@
 chain_id: 2
-indexer_endpoint: "35.223.137.149:50051"
-indexer_api_key: <api_key>
+grpc_data_stream_endpoint: "35.223.137.149:50051"
+grpc_data_stream_api_key: <api_key>
 db_connection_uri: <e.g. postgresql://postgres:123456@localhost/postgres>
 starting_version: <e.g. 516294465>

--- a/typescript/processors/example-write-set-change-processor/processor.ts
+++ b/typescript/processors/example-write-set-change-processor/processor.ts
@@ -83,7 +83,7 @@ program
 
     // Create the grpc client
     const client = new services.RawDataClient(
-      config.indexer_endpoint,
+      config.grpc_data_stream_endpoint,
       new CustomChannelCred(),
       {
         "grpc.keepalive_time_ms": 1000,
@@ -107,7 +107,7 @@ program
     const request = new GetTransactionsRequest();
     request.setStartingVersion(config.starting_version.toString());
     const metadata = new Metadata();
-    metadata.set("x-aptos-data-authorization", config.indexer_api_key);
+    metadata.set("x-aptos-data-authorization", config.grpc_data_stream_api_key);
 
     // Create and start the streaming RPC
     let currentTxnVersion = config.starting_version || 0;

--- a/typescript/utils/config.ts
+++ b/typescript/utils/config.ts
@@ -4,8 +4,8 @@ import * as fs from "fs";
 class Config {
   constructor(
     public chain_id: number,
-    public indexer_endpoint: string,
-    public indexer_api_key: string,
+    public grpc_data_stream_endpoint: string,
+    public grpc_data_stream_api_key: string,
     public starting_version: number,
     public db_connection_uri: string,
     public cursor_filename: string


### PR DESCRIPTION
This PR does a few things:
1. Fix crashing example processor (verified via docker compose) by adding Mapped[str] to event column names: https://github.com/aptos-labs/aptos-indexer-processors/pull/36/files#diff-a95726e6e182fd11c7bcaf79632ec6d3e8304f33b3f13efe5e3a845a3c299568L20-L21
2. rename config parameters to more clearly distinguish between processor-specific config and config to connect to remote indexer-grpc data stream service.
3. make indexer_name a processor level constant instead of runtime config.