### PR TITLE
[EI-226] Add multithreading to python processor

### DIFF
--- a/python/config.yaml.example
+++ b/python/config.yaml.example
@@ -1,4 +1,3 @@
-chain_id: 1
 grpc_data_stream_endpoint: "34.30.218.153:50051"
 grpc_data_stream_api_key: "<grpc_data_stream_api_key>"
 db_connection_uri: "postgresql://<your_connection_uri_to_postgres>"

--- a/python/processors/example_event_processor/processor.py
+++ b/python/processors/example_event_processor/processor.py
@@ -1,6 +1,7 @@
 from aptos.transaction.v1 import transaction_pb2
 from processors.example_event_processor.models import Event
 from typing import List
+from utils.worker import IndexerProcessorServer
 
 from utils import general_utils
 from utils.transactions_processor import TransactionsProcessor
@@ -72,4 +73,7 @@ class ExampleEventProcessor(TransactionsProcessor):
 
 if __name__ == "__main__":
     example_event_processor = ExampleEventProcessor()
-    example_event_processor.run()
+    indexer_server = IndexerProcessorServer(
+        processor=example_event_processor,
+    )
+    indexer_server.run()

--- a/python/processors/example_event_processor/processor.py
+++ b/python/processors/example_event_processor/processor.py
@@ -6,51 +6,70 @@ from utils import general_utils
 from utils.transactions_processor import TransactionsProcessor
 from utils.models.general_models import NextVersionToProcess, Base
 from utils.models.schema_names import EXAMPLE
+from utils.session import Session
 
 
-# Define the parser function that will be used by the TransactionProcessor
-def parse(transaction: transaction_pb2.Transaction) -> List[Event]:
-    # Custom filtering
-    # Here we filter out all transactions that are not of type TRANSACTION_TYPE_USER
-    if transaction.type != transaction_pb2.Transaction.TRANSACTION_TYPE_USER:
-        return []
+class ExampleEventProcessor(TransactionsProcessor):
+    def name(self) -> str:
+        return "python-example-event-processor"
 
-    # Parse Transaction struct
-    transaction_version = transaction.version
-    transaction_block_height = transaction.block_height
-    transaction_timestamp = general_utils.parse_pb_timestamp(transaction.timestamp)
-    user_transaction = transaction.user
+    def schema(self) -> str:
+        return EXAMPLE
 
-    # Parse Event struct
-    event_db_objs: list[Event] = []
-    for event_index, event in enumerate(user_transaction.events):
-        creation_number = event.key.creation_number
-        sequence_number = event.sequence_number
-        account_address = general_utils.standardize_address(event.key.account_address)
-        type = event.type_str
-        data = event.data
+    def process_transactions(
+        self,
+        transactions: list[transaction_pb2.Transaction],
+        start_version: int,
+        end_version: int,
+    ) -> None:
+        event_db_objs: List[Event] = []
 
-        # Create an instance of Event
-        event_db_obj = Event(
-            creation_number=creation_number,
-            sequence_number=sequence_number,
-            account_address=account_address,
-            transaction_version=transaction_version,
-            transaction_block_height=transaction_block_height,
-            type=type,
-            data=data,
-            transaction_timestamp=transaction_timestamp,
-            event_index=event_index,
-        )
-        event_db_objs.append(event_db_obj)
+        for transaction in transactions:
+            # Custom filtering
+            # Here we filter out all transactions that are not of type TRANSACTION_TYPE_USER
+            if transaction.type != transaction_pb2.Transaction.TRANSACTION_TYPE_USER:
+                continue
 
-    return event_db_objs
+            # Parse Transaction struct
+            transaction_version = transaction.version
+            transaction_block_height = transaction.block_height
+            transaction_timestamp = general_utils.parse_pb_timestamp(
+                transaction.timestamp
+            )
+            user_transaction = transaction.user
+
+            # Parse Event struct
+            for event_index, event in enumerate(user_transaction.events):
+                creation_number = event.key.creation_number
+                sequence_number = event.sequence_number
+                account_address = general_utils.standardize_address(
+                    event.key.account_address
+                )
+                type = event.type_str
+                data = event.data
+
+                # Create an instance of Event
+                event_db_obj = Event(
+                    creation_number=creation_number,
+                    sequence_number=sequence_number,
+                    account_address=account_address,
+                    transaction_version=transaction_version,
+                    transaction_block_height=transaction_block_height,
+                    type=type,
+                    data=data,
+                    transaction_timestamp=transaction_timestamp,
+                    event_index=event_index,
+                )
+                event_db_objs.append(event_db_obj)
+
+        self.insert_to_db(event_db_objs)
+
+    def insert_to_db(self, parsed_objs: List[Event]) -> None:
+        with Session() as session, session.begin():
+            for obj in parsed_objs:
+                session.merge(obj)
 
 
 if __name__ == "__main__":
-    transactions_processor = TransactionsProcessor(
-        parser_function=parse,
-        processor_name="python-example-event-processor",
-        schema_name=EXAMPLE,
-    )
-    transactions_processor.process()
+    example_event_processor = ExampleEventProcessor()
+    example_event_processor.run()

--- a/python/processors/nft_marketplace_v2/processor.py
+++ b/python/processors/nft_marketplace_v2/processor.py
@@ -52,851 +52,905 @@ from processors.nft_orderbooks.nft_marketplace_enums import (
 from utils.token_utils import TokenStandard
 from utils.models.schema_names import NFT_MARKETPLACE_V2_SCHEMA_NAME
 from processors.nft_marketplace_v2.constants import MARKETPLCE_SMART_CONTRACT_ADDRESS
+from utils.session import Session
 
 
-def parse(
-    transaction: transaction_pb2.Transaction,
-) -> List[
-    NFTMarketplaceActivities
-    | CurrentNFTMarketplaceListing
-    | CurrentNFTMarketplaceTokenOffer
-    | CurrentNFTMarketplaceCollectionOffer
-    | CurrentNFTMarketplaceAuction
-]:
-    user_transaction = transaction_utils.get_user_transaction(transaction)
+class NFTMarketplaceV2Processor(TransactionsProcessor):
+    def name(self) -> str:
+        return "nft-marketplace-v2"
 
-    if not user_transaction:
-        return []
+    def schema(self) -> str:
+        return NFT_MARKETPLACE_V2_SCHEMA_NAME
 
-    # Token metadatas parsed from events. The key is generated token_data_id for token v1,
-    # and token address for token v2.
-    token_metadatas: Dict[str, TokenMetadata] = {}
-    # Collection metaddatas parsed from events. The key is generated collection_id for token v1,
-    # and collection address for token v2.
-    collection_metadatas: Dict[str, CollectionMetadata] = {}
+    def process_transactions(
+        self,
+        transactions: list[transaction_pb2.Transaction],
+        start_version: int,
+        end_version: int,
+    ) -> None:
+        parsed_objs = []
 
-    nft_marketplace_activities: List[NFTMarketplaceActivities] = []
-    current_nft_marketplace_listings: List[CurrentNFTMarketplaceListing] = []
-    current_token_offers: List[CurrentNFTMarketplaceTokenOffer] = []
-    current_collection_offers: List[CurrentNFTMarketplaceCollectionOffer] = []
-    current_auctions: List[CurrentNFTMarketplaceAuction] = []
+        for transaction in transactions:
+            user_transaction = transaction_utils.get_user_transaction(transaction)
 
-    collection_offer_filled_metadatas: Dict[str, CollectionOfferEventMetadata] = {}
-
-    transaction_metadata = parse_transaction_metadata(transaction)
-    events = user_transaction.events
-    write_set_changes = transaction_utils.get_write_set_changes(transaction)
-
-    # Loop 1
-    # Parse all activities related to token listings, token and collection offers
-    # The contract actually gives token/collection related metadata so we don't have to
-    # look up anything
-    for event_index, event in enumerate(events):
-        qualified_event_type = event.type_str
-
-        if MARKETPLCE_SMART_CONTRACT_ADDRESS not in qualified_event_type:
-            continue
-
-        event_type_short = event_utils.get_event_type_short(event)
-        if event_type_short not in [
-            "events::ListingFilledEvent",
-            "events::ListingCanceledEvent",
-            "events::ListingPlacedEvent",
-            "events::CollectionOfferPlacedEvent",
-            "events::CollectionOfferCanceledEvent",
-            "events::CollectionOfferFilledEvent",
-            "events::TokenOfferPlacedEvent",
-            "events::TokenOfferCanceledEvent",
-            "events::TokenOfferFilledEvent",
-            "events::AuctionBidEvent",
-        ]:
-            continue
-
-        data = json.loads(event.data)
-        price = data.get("price")
-        offer_or_listing_id = standardize_address(
-            data.get("listing")
-            or data.get("collection_offer")
-            or data.get("token_offer")
-        )
-        fee_schedule_id = standardize_address(event.key.account_address)
-
-        activity = None
-        current_listing = None
-        current_token_offer = None
-        current_auction = None
-
-        token_metadata = get_token_metadata_from_event(data)
-        collection_metadata = get_collection_metadata_from_event(data)
-
-        if token_metadata:
-            token_metadatas[token_metadata["token_data_id"]] = token_metadata
-
-        if collection_metadata:
-            collection_metadatas[
-                collection_metadata["collection_id"]
-            ] = collection_metadata
-
-        match event_type_short:
-            case "events::ListingFilledEvent":
-                assert token_metadata
-
-                listing_type = data.get("type")
-                assert listing_type
-
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=token_metadata["collection_id"],
-                    token_data_id=token_metadata["token_data_id"],
-                    creator_address=token_metadata["creator_address"],
-                    collection_name=token_metadata["collection_name"],
-                    token_name=token_metadata["token_name"],
-                    property_version=token_metadata["property_version"],
-                    price=price,
-                    token_amount=1,
-                    token_standard=token_metadata["token_standard"].value,
-                    seller=standardize_address(data.get("seller")),
-                    buyer=standardize_address(data.get("purchaser")),
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.LISTING_FILLED.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-
-                if listing_type == "auction":
-                    current_auction = CurrentNFTMarketplaceAuction(
-                        listing_id=offer_or_listing_id,
-                        token_data_id=token_metadata["token_data_id"],
-                        collection_id=token_metadata["collection_id"],
-                        fee_schedule_id=fee_schedule_id,
-                        seller=standardize_address(data.get("seller")),
-                        current_bid_price=price,
-                        current_bidder=standardize_address(data.get("purchaser")),
-                        starting_bid_price=0,
-                        buy_it_now_price=None,
-                        token_amount=1,
-                        expiration_time=0,
-                        is_deleted=True,
-                        token_standard=TokenStandard.V2.value,
-                        marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                        contract_address=transaction_metadata.contract_address,
-                        entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                        last_transaction_version=transaction.version,
-                        last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                    )
-                else:
-                    current_listing = CurrentNFTMarketplaceListing(
-                        token_data_id=token_metadata["token_data_id"],
-                        listing_id=offer_or_listing_id,
-                        fee_schedule_id=fee_schedule_id,
-                        collection_id=token_metadata["collection_id"],
-                        price=price,
-                        token_amount=0,
-                        token_standard=token_metadata["token_standard"].value,
-                        seller=standardize_address(data.get("seller")),
-                        is_deleted=True,
-                        marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                        contract_address=transaction_metadata.contract_address,
-                        entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                        last_transaction_version=transaction.version,
-                        last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                    )
-            case "events::ListingCanceledEvent":
-                assert token_metadata
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=token_metadata["collection_id"],
-                    token_data_id=token_metadata["token_data_id"],
-                    creator_address=token_metadata["creator_address"],
-                    collection_name=token_metadata["collection_name"],
-                    token_name=token_metadata["token_name"],
-                    property_version=token_metadata["property_version"],
-                    price=price,
-                    token_amount=1,
-                    token_standard=token_metadata["token_standard"].value,
-                    seller=standardize_address(data.get("seller")),
-                    buyer=None,
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.LISTING_CANCEL.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-                current_listing = CurrentNFTMarketplaceListing(
-                    token_data_id=token_metadata["token_data_id"],
-                    listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=token_metadata["collection_id"],
-                    price=price,
-                    token_amount=0,
-                    token_standard=token_metadata["token_standard"].value,
-                    seller=standardize_address(data.get("seller")),
-                    is_deleted=True,
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    last_transaction_version=transaction.version,
-                    last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-            case "events::ListingPlacedEvent":
-                assert token_metadata
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=token_metadata["collection_id"],
-                    token_data_id=token_metadata["token_data_id"],
-                    creator_address=token_metadata["creator_address"],
-                    collection_name=token_metadata["collection_name"],
-                    token_name=token_metadata["token_name"],
-                    property_version=token_metadata["property_version"],
-                    price=price,
-                    token_amount=1,
-                    token_standard=token_metadata["token_standard"].value,
-                    seller=standardize_address(data.get("seller")),
-                    buyer=None,
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.LISTING_PLACE.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-            case "events::CollectionOfferPlacedEvent":
-                assert collection_metadata
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=collection_metadata["collection_id"],
-                    token_data_id=None,
-                    creator_address=collection_metadata["creator_address"],
-                    collection_name=collection_metadata["collection_name"],
-                    token_name=None,
-                    property_version=None,
-                    price=price,
-                    token_amount=data.get("token_amount"),
-                    token_standard=collection_metadata["token_standard"].value,
-                    seller=None,
-                    buyer=standardize_address(data.get("purchaser")),
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.BID_PLACE.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-            case "events::CollectionOfferCanceledEvent":
-                assert collection_metadata
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=collection_metadata["collection_id"],
-                    token_data_id=None,
-                    creator_address=collection_metadata["creator_address"],
-                    collection_name=collection_metadata["collection_name"],
-                    token_name=None,
-                    property_version=None,
-                    price=price,
-                    token_amount=data.get("remaining_token_amount"),
-                    token_standard=collection_metadata["token_standard"].value,
-                    seller=None,
-                    buyer=standardize_address(data.get("purchaser")),
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.BID_CHANGE.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-                current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
-                    collection_offer_id=offer_or_listing_id,
-                    collection_id=collection_metadata["collection_id"],
-                    fee_schedule_id=fee_schedule_id,
-                    buyer=standardize_address(data.get("purchaser")),
-                    item_price=price,
-                    remaining_token_amount=data.get("remaining_token_amount"),
-                    expiration_time=0,
-                    is_deleted=True,
-                    token_standard=collection_metadata["token_standard"].value,
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    last_transaction_version=transaction.version,
-                    last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-                current_collection_offers.append(current_collection_offer)
-            case "events::CollectionOfferFilledEvent":
-                assert token_metadata
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=token_metadata["collection_id"],
-                    token_data_id=token_metadata["token_data_id"],
-                    creator_address=token_metadata["creator_address"],
-                    collection_name=token_metadata["collection_name"],
-                    token_name=token_metadata["token_name"],
-                    property_version=token_metadata["property_version"],
-                    price=price,
-                    token_amount=data.get("remaining_token_amount", 0),
-                    token_standard=token_metadata["token_standard"].value,
-                    seller=standardize_address(data.get("seller")),
-                    buyer=standardize_address(data.get("purchaser")),
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.BID_CHANGE.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-
-                # The collection offer resource may be deleted after it is filled,
-                # so we need to parse collection offer metadata from the event
-                collection_offer_filled_metadata: CollectionOfferEventMetadata = {
-                    "collection_offer_id": offer_or_listing_id,
-                    "collection_metadata": {
-                        "collection_id": token_metadata["collection_id"],
-                        "creator_address": token_metadata["creator_address"],
-                        "collection_name": token_metadata["collection_name"],
-                        "token_standard": token_metadata["token_standard"],
-                    },
-                    "item_price": price,
-                    "buyer": standardize_address(data.get("purchaser")),
-                    "fee_schedule_id": fee_schedule_id,
-                }
-                collection_offer_filled_metadatas[
-                    offer_or_listing_id
-                ] = collection_offer_filled_metadata
-            case "events::TokenOfferPlacedEvent":
-                assert token_metadata
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=token_metadata["collection_id"],
-                    token_data_id=token_metadata["token_data_id"],
-                    creator_address=token_metadata["creator_address"],
-                    collection_name=token_metadata["collection_name"],
-                    token_name=token_metadata["token_name"],
-                    property_version=token_metadata["property_version"],
-                    price=price,
-                    token_amount=1,
-                    token_standard=token_metadata["token_standard"].value,
-                    seller=None,
-                    buyer=standardize_address(data.get("purchaser")),
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.BID_PLACE.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-            case "events::TokenOfferCanceledEvent":
-                assert token_metadata
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=token_metadata["collection_id"],
-                    token_data_id=token_metadata["token_data_id"],
-                    creator_address=token_metadata["creator_address"],
-                    collection_name=token_metadata["collection_name"],
-                    token_name=token_metadata["token_name"],
-                    property_version=token_metadata["property_version"],
-                    price=price,
-                    token_amount=0,
-                    token_standard=token_metadata["token_standard"].value,
-                    seller=None,
-                    buyer=standardize_address(data.get("purchaser")),
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.BID_CHANGE.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-                current_token_offer = CurrentNFTMarketplaceTokenOffer(
-                    offer_id=offer_or_listing_id,
-                    token_data_id=token_metadata["token_data_id"],
-                    collection_id=token_metadata["collection_id"],
-                    fee_schedule_id=fee_schedule_id,
-                    buyer=standardize_address(data.get("purchaser")),
-                    price=price,
-                    token_amount=0,
-                    expiration_time=0,
-                    is_deleted=True,
-                    token_standard=token_metadata["token_standard"].value,
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    last_transaction_version=transaction.version,
-                    last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-            case "events::TokenOfferFilledEvent":
-                assert token_metadata
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=token_metadata["collection_id"],
-                    token_data_id=token_metadata["token_data_id"],
-                    creator_address=token_metadata["creator_address"],
-                    collection_name=token_metadata["collection_name"],
-                    token_name=token_metadata["token_name"],
-                    property_version=token_metadata["property_version"],
-                    price=price,
-                    token_amount=1,
-                    token_standard=token_metadata["token_standard"].value,
-                    seller=standardize_address(data.get("seller")),
-                    buyer=standardize_address(data.get("purchaser")),
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.BID_FILLED.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-                current_token_offer = CurrentNFTMarketplaceTokenOffer(
-                    offer_id=offer_or_listing_id,
-                    token_data_id=token_metadata["token_data_id"],
-                    collection_id=token_metadata["collection_id"],
-                    fee_schedule_id=fee_schedule_id,
-                    buyer=standardize_address(data.get("purchaser")),
-                    price=price,
-                    token_amount=0,
-                    expiration_time=0,
-                    is_deleted=True,
-                    token_standard=token_metadata["token_standard"].value,
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    last_transaction_version=transaction.version,
-                    last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-            case "events::AuctionBidEvent":
-                assert token_metadata
-                activity = NFTMarketplaceActivities(
-                    transaction_version=transaction.version,
-                    event_index=event_index,
-                    offer_or_listing_id=offer_or_listing_id,
-                    fee_schedule_id=fee_schedule_id,
-                    collection_id=token_metadata["collection_id"],
-                    token_data_id=token_metadata["token_data_id"],
-                    creator_address=token_metadata["creator_address"],
-                    collection_name=token_metadata["collection_name"],
-                    token_name=token_metadata["token_name"],
-                    property_version=token_metadata["property_version"],
-                    price=data.get("new_bid"),
-                    token_amount=1,
-                    token_standard=token_metadata["token_standard"].value,
-                    seller=None,
-                    buyer=standardize_address(data.get("new_bidder")),
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    event_type=StandardMarketplaceEventType.BID_PLACE.value,
-                    transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-            case _:
+            if not user_transaction:
                 continue
 
-        nft_marketplace_activities.append(activity)
-        if current_listing:
-            current_nft_marketplace_listings.append(current_listing)
-        if current_token_offer:
-            current_token_offers.append(current_token_offer)
-        if current_auction:
-            current_auctions.append(current_auction)
+            # Token metadatas parsed from events. The key is generated token_data_id for token v1,
+            # and token address for token v2.
+            token_metadatas: Dict[str, TokenMetadata] = {}
+            # Collection metaddatas parsed from events. The key is generated collection_id for token v1,
+            # and collection address for token v2.
+            collection_metadatas: Dict[str, CollectionMetadata] = {}
 
-    # Object, listing and offer models. The key is the resource address
-    object_metadatas: Dict[str, ObjectCore] = {}
-    listing_metadatas: Dict[str, ListingMetadata] = {}
-    fixed_price_listings: Dict[str, FixedPriceListing] = {}
-    listing_token_v1_containers: Dict[str, ListingTokenV1Container] = {}
-    token_offer_metadatas: Dict[str, TokenOfferMetadata] = {}
-    token_offer_v1s: Dict[str, TokenOfferV1] = {}
-    token_offer_v2s: Dict[str, TokenOfferV2] = {}
-    collection_offer_metadatas: Dict[str, CollectionOfferMetadata] = {}
-    collection_offer_v1s: Dict[str, CollectionOfferV1] = {}
-    collection_offer_v2s: Dict[str, CollectionOfferV2] = {}
-    auction_listings: Dict[str, AuctionListing] = {}
+            nft_marketplace_activities: List[NFTMarketplaceActivities] = []
+            current_nft_marketplace_listings: List[CurrentNFTMarketplaceListing] = []
+            current_token_offers: List[CurrentNFTMarketplaceTokenOffer] = []
+            current_collection_offers: List[CurrentNFTMarketplaceCollectionOffer] = []
+            current_auctions: List[CurrentNFTMarketplaceAuction] = []
 
-    # Loop 2
-    # Parse out all the listing, auction, bid, and offer data from write set changes.
-    # This is a bit more complicated than the other parsers because the data is spread out across multiple write set changes,
-    # so we need a first loop to get all the data.
-    for _, wsc in enumerate(write_set_changes):
-        write_resource = write_set_change_utils.get_write_resource(wsc)
-        if write_resource:
-            move_resource_address = standardize_address(write_resource.address)
-            move_resource_type = write_resource.type_str
-            move_resource_type_address = write_resource.type.address
-            data = json.loads(write_resource.data)
+            collection_offer_filled_metadatas: Dict[
+                str, CollectionOfferEventMetadata
+            ] = {}
 
-            # Parse object metadata
-            object_core = get_object_core(move_resource_type, data)
+            transaction_metadata = parse_transaction_metadata(transaction)
+            events = user_transaction.events
+            write_set_changes = transaction_utils.get_write_set_changes(transaction)
 
-            if object_core:
-                object_metadatas[move_resource_address] = object_core
+            # Loop 1
+            # Parse all activities related to token listings, token and collection offers
+            # The contract actually gives token/collection related metadata so we don't have to
+            # look up anything
+            for event_index, event in enumerate(events):
+                qualified_event_type = event.type_str
 
-            if move_resource_type_address != MARKETPLCE_SMART_CONTRACT_ADDRESS:
-                continue
+                if MARKETPLCE_SMART_CONTRACT_ADDRESS not in qualified_event_type:
+                    continue
 
-            # Parse listing metadata
-            listing_metadata = get_listing_metadata(move_resource_type, data)
-            fixed_price_listing = get_fixed_priced_listing(move_resource_type, data)
-            listing_token_v1_container = get_listing_token_v1_container(
-                move_resource_type, data
-            )
+                event_type_short = event_utils.get_event_type_short(event)
+                if event_type_short not in [
+                    "events::ListingFilledEvent",
+                    "events::ListingCanceledEvent",
+                    "events::ListingPlacedEvent",
+                    "events::CollectionOfferPlacedEvent",
+                    "events::CollectionOfferCanceledEvent",
+                    "events::CollectionOfferFilledEvent",
+                    "events::TokenOfferPlacedEvent",
+                    "events::TokenOfferCanceledEvent",
+                    "events::TokenOfferFilledEvent",
+                    "events::AuctionBidEvent",
+                ]:
+                    continue
 
-            if listing_metadata:
-                listing_metadatas[move_resource_address] = listing_metadata
-            if fixed_price_listing:
-                fixed_price_listings[move_resource_address] = fixed_price_listing
-            if listing_token_v1_container:
-                listing_token_v1_containers[
-                    move_resource_address
-                ] = listing_token_v1_container
+                data = json.loads(event.data)
+                price = data.get("price")
+                offer_or_listing_id = standardize_address(
+                    data.get("listing")
+                    or data.get("collection_offer")
+                    or data.get("token_offer")
+                )
+                fee_schedule_id = event.key.account_address
 
-            # Parse token offer metadata
-            token_offer_metadata = get_token_offer_metadata(move_resource_type, data)
-            token_offer_v1 = get_token_offer_v1(move_resource_type, data)
-            token_offer_v2 = get_token_offer_v2(move_resource_type, data)
+                activity = None
+                current_listing = None
+                current_token_offer = None
+                current_auction = None
 
-            if token_offer_metadata:
-                token_offer_metadatas[move_resource_address] = token_offer_metadata
-            if token_offer_v1:
-                token_offer_v1s[move_resource_address] = token_offer_v1
-            if token_offer_v2:
-                token_offer_v2s[move_resource_address] = token_offer_v2
+                token_metadata = get_token_metadata_from_event(data)
+                collection_metadata = get_collection_metadata_from_event(data)
 
-            # Parse collection offer metadata
-            collection_offer_metadata = get_collection_offer_metadata(
-                move_resource_type, data
-            )
-            collection_offer_v1 = get_collection_offer_v1(move_resource_type, data)
-            collection_offer_v2 = get_collection_offer_v2(move_resource_type, data)
+                if token_metadata:
+                    token_metadatas[token_metadata["token_data_id"]] = token_metadata
 
-            if collection_offer_metadata:
-                collection_offer_metadatas[
-                    move_resource_address
-                ] = collection_offer_metadata
-            if collection_offer_v1:
-                collection_offer_v1s[move_resource_address] = collection_offer_v1
-            if collection_offer_v2:
-                collection_offer_v2s[move_resource_address] = collection_offer_v2
+                if collection_metadata:
+                    collection_metadatas[
+                        collection_metadata["collection_id"]
+                    ] = collection_metadata
 
-            # Parse auction metadata
-            auction_listing = get_auction_listing(move_resource_type, data)
+                match event_type_short:
+                    case "events::ListingFilledEvent":
+                        assert token_metadata
 
-            if auction_listing:
-                auction_listings[move_resource_address] = auction_listing
+                        listing_type = data.get("type")
+                        assert listing_type
 
-    # Loop 3
-    # Reconstruct the full listing and offer models and create DB objects
-    for _, wsc in enumerate(write_set_changes):
-        write_resource = write_set_change_utils.get_write_resource(wsc)
-        if write_resource:
-            move_type_address = write_resource.type.address
-            if move_type_address != MARKETPLCE_SMART_CONTRACT_ADDRESS:
-                continue
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=token_metadata["collection_id"],
+                            token_data_id=token_metadata["token_data_id"],
+                            creator_address=token_metadata["creator_address"],
+                            collection_name=token_metadata["collection_name"],
+                            token_name=token_metadata["token_name"],
+                            property_version=token_metadata["property_version"],
+                            price=price,
+                            token_amount=1,
+                            token_standard=token_metadata["token_standard"].value,
+                            seller=standardize_address(data.get("seller")),
+                            buyer=standardize_address(data.get("purchaser")),
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.LISTING_FILLED.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
 
-            move_resource_address = standardize_address(write_resource.address)
-            move_resource_type = write_resource.type_str
-
-            if (
-                move_resource_type
-                == f"{MARKETPLCE_SMART_CONTRACT_ADDRESS}::listing::Listing"
-            ):
-                # Get the data related to this listing that was parsed from loop 2
-                listing_metadata = listing_metadatas.get(move_resource_address)
-                fixed_price_listing = fixed_price_listings.get(move_resource_address)
-                auction_listing = auction_listings.get(move_resource_address)
-
-                assert (
-                    listing_metadata
-                ), f"Listing metadata not found for txn {transaction.version}"
-
-                # If the listing is an auction, it will have an coin_listing::AuctionListing resource, otherwise
-                # it's a fixed price listing.
-                if auction_listing:
-                    token_metadata = token_metadatas.get(
-                        listing_metadata["token_address"]
-                    )
-                    assert (
-                        token_metadata
-                    ), f"Token metadata not found for txn {transaction.version}"
-
-                    # Parses when auction is placed and when a bid is placed on an auction
-                    current_auction = CurrentNFTMarketplaceAuction(
-                        listing_id=move_resource_address,
-                        token_data_id=listing_metadata["token_address"],
-                        collection_id=token_metadata["collection_id"],
-                        fee_schedule_id=listing_metadata["fee_schedule_id"],
-                        seller=listing_metadata["seller"],
-                        current_bid_price=auction_listing["current_bid_price"],
-                        current_bidder=auction_listing["current_bidder"],
-                        starting_bid_price=auction_listing["starting_bid_price"],
-                        buy_it_now_price=auction_listing["buy_it_now_price"],
-                        token_amount=1,
-                        expiration_time=auction_listing["auction_end_time"],
-                        is_deleted=False,
-                        token_standard=TokenStandard.V2.value,
-                        marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                        contract_address=transaction_metadata.contract_address,
-                        entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                        last_transaction_version=transaction.version,
-                        last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                    )
-                    current_auctions.append(current_auction)
-                else:
-                    assert (
-                        fixed_price_listing
-                    ), f"Fixed price listing not found for txn {transaction.version}"
-
-                    token_address = listing_metadata["token_address"]
-                    token_v1_container = listing_token_v1_containers.get(token_address)
-
-                    current_listing = None
-
-                    if token_v1_container:
-                        token_v1_metadata = token_v1_container["token_metadata"]
+                        if listing_type == "auction":
+                            current_auction = CurrentNFTMarketplaceAuction(
+                                listing_id=offer_or_listing_id,
+                                token_data_id=token_metadata["token_data_id"],
+                                collection_id=token_metadata["collection_id"],
+                                fee_schedule_id=fee_schedule_id,
+                                seller=standardize_address(data.get("seller")),
+                                current_bid_price=price,
+                                current_bidder=standardize_address(
+                                    data.get("purchaser")
+                                ),
+                                starting_bid_price=0,
+                                buy_it_now_price=None,
+                                token_amount=1,
+                                expiration_time=0,
+                                is_deleted=True,
+                                token_standard=TokenStandard.V2.value,
+                                marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                                contract_address=transaction_metadata.contract_address,
+                                entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                                last_transaction_version=transaction.version,
+                                last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                            )
+                        else:
+                            current_listing = CurrentNFTMarketplaceListing(
+                                token_data_id=token_metadata["token_data_id"],
+                                listing_id=offer_or_listing_id,
+                                fee_schedule_id=fee_schedule_id,
+                                collection_id=token_metadata["collection_id"],
+                                price=price,
+                                token_amount=0,
+                                token_standard=token_metadata["token_standard"].value,
+                                seller=standardize_address(data.get("seller")),
+                                is_deleted=True,
+                                marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                                contract_address=transaction_metadata.contract_address,
+                                entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                                last_transaction_version=transaction.version,
+                                last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                            )
+                    case "events::ListingCanceledEvent":
+                        assert token_metadata
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=token_metadata["collection_id"],
+                            token_data_id=token_metadata["token_data_id"],
+                            creator_address=token_metadata["creator_address"],
+                            collection_name=token_metadata["collection_name"],
+                            token_name=token_metadata["token_name"],
+                            property_version=token_metadata["property_version"],
+                            price=price,
+                            token_amount=1,
+                            token_standard=token_metadata["token_standard"].value,
+                            seller=standardize_address(data.get("seller")),
+                            buyer=None,
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.LISTING_CANCEL.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
                         current_listing = CurrentNFTMarketplaceListing(
-                            token_data_id=token_v1_metadata["token_data_id"],
-                            listing_id=move_resource_address,
-                            collection_id=token_v1_metadata["collection_id"],
-                            fee_schedule_id=listing_metadata["fee_schedule_id"],
-                            price=fixed_price_listing["price"],
-                            token_amount=token_v1_container["amount"],
-                            token_standard=TokenStandard.V1.value,
-                            seller=listing_metadata["seller"],
-                            is_deleted=False,
+                            token_data_id=token_metadata["token_data_id"],
+                            listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=token_metadata["collection_id"],
+                            price=price,
+                            token_amount=0,
+                            token_standard=token_metadata["token_standard"].value,
+                            seller=standardize_address(data.get("seller")),
+                            is_deleted=True,
                             marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
                             contract_address=transaction_metadata.contract_address,
                             entry_function_id_str=transaction_metadata.entry_function_id_str_short,
                             last_transaction_version=transaction.version,
                             last_transaction_timestamp=transaction_metadata.transaction_timestamp,
                         )
-                    else:
-                        token_v2_metadata = token_metadatas.get(token_address)
+                    case "events::ListingPlacedEvent":
+                        assert token_metadata
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=token_metadata["collection_id"],
+                            token_data_id=token_metadata["token_data_id"],
+                            creator_address=token_metadata["creator_address"],
+                            collection_name=token_metadata["collection_name"],
+                            token_name=token_metadata["token_name"],
+                            property_version=token_metadata["property_version"],
+                            price=price,
+                            token_amount=1,
+                            token_standard=token_metadata["token_standard"].value,
+                            seller=standardize_address(data.get("seller")),
+                            buyer=None,
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.LISTING_PLACE.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                    case "events::CollectionOfferPlacedEvent":
+                        assert collection_metadata
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=collection_metadata["collection_id"],
+                            token_data_id=None,
+                            creator_address=collection_metadata["creator_address"],
+                            collection_name=collection_metadata["collection_name"],
+                            token_name=None,
+                            property_version=None,
+                            price=price,
+                            token_amount=data.get("token_amount"),
+                            token_standard=collection_metadata["token_standard"].value,
+                            seller=None,
+                            buyer=standardize_address(data.get("purchaser")),
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.BID_PLACE.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                    case "events::CollectionOfferCanceledEvent":
+                        assert collection_metadata
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=collection_metadata["collection_id"],
+                            token_data_id=None,
+                            creator_address=collection_metadata["creator_address"],
+                            collection_name=collection_metadata["collection_name"],
+                            token_name=None,
+                            property_version=None,
+                            price=price,
+                            token_amount=data.get("remaining_token_amount"),
+                            token_standard=collection_metadata["token_standard"].value,
+                            seller=None,
+                            buyer=standardize_address(data.get("purchaser")),
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.BID_CHANGE.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                        current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
+                            collection_offer_id=offer_or_listing_id,
+                            collection_id=collection_metadata["collection_id"],
+                            fee_schedule_id=fee_schedule_id,
+                            buyer=standardize_address(data.get("purchaser")),
+                            item_price=price,
+                            remaining_token_amount=data.get("remaining_token_amount"),
+                            expiration_time=0,
+                            is_deleted=True,
+                            token_standard=collection_metadata["token_standard"].value,
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            last_transaction_version=transaction.version,
+                            last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                        current_collection_offers.append(current_collection_offer)
+                    case "events::CollectionOfferFilledEvent":
+                        assert token_metadata
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            collection_id=token_metadata["collection_id"],
+                            fee_schedule_id=fee_schedule_id,
+                            token_data_id=token_metadata["token_data_id"],
+                            creator_address=token_metadata["creator_address"],
+                            collection_name=token_metadata["collection_name"],
+                            token_name=token_metadata["token_name"],
+                            property_version=token_metadata["property_version"],
+                            price=price,
+                            token_amount=data.get("remaining_token_amount", 0),
+                            token_standard=token_metadata["token_standard"].value,
+                            seller=standardize_address(data.get("seller")),
+                            buyer=standardize_address(data.get("purchaser")),
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.BID_CHANGE.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+
+                        # The collection offer resource may be deleted after it is filled,
+                        # so we need to parse collection offer metadata from the event
+                        collection_offer_filled_metadata: CollectionOfferEventMetadata = {
+                            "collection_offer_id": offer_or_listing_id,
+                            "collection_metadata": {
+                                "collection_id": token_metadata["collection_id"],
+                                "creator_address": token_metadata["creator_address"],
+                                "collection_name": token_metadata["collection_name"],
+                                "token_standard": token_metadata["token_standard"],
+                            },
+                            "item_price": price,
+                            "buyer": standardize_address(data.get("purchaser")),
+                            "fee_schedule_id": fee_schedule_id,
+                        }
+                        collection_offer_filled_metadatas[
+                            offer_or_listing_id
+                        ] = collection_offer_filled_metadata
+                    case "events::TokenOfferPlacedEvent":
+                        assert token_metadata
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=token_metadata["collection_id"],
+                            token_data_id=token_metadata["token_data_id"],
+                            creator_address=token_metadata["creator_address"],
+                            collection_name=token_metadata["collection_name"],
+                            token_name=token_metadata["token_name"],
+                            property_version=token_metadata["property_version"],
+                            price=price,
+                            token_amount=1,
+                            token_standard=token_metadata["token_standard"].value,
+                            seller=None,
+                            buyer=standardize_address(data.get("purchaser")),
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.BID_PLACE.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                    case "events::TokenOfferCanceledEvent":
+                        assert token_metadata
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=token_metadata["collection_id"],
+                            token_data_id=token_metadata["token_data_id"],
+                            creator_address=token_metadata["creator_address"],
+                            collection_name=token_metadata["collection_name"],
+                            token_name=token_metadata["token_name"],
+                            property_version=token_metadata["property_version"],
+                            price=price,
+                            token_amount=0,
+                            token_standard=token_metadata["token_standard"].value,
+                            seller=None,
+                            buyer=standardize_address(data.get("purchaser")),
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.BID_CHANGE.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                        current_token_offer = CurrentNFTMarketplaceTokenOffer(
+                            offer_id=offer_or_listing_id,
+                            token_data_id=token_metadata["token_data_id"],
+                            collection_id=token_metadata["collection_id"],
+                            fee_schedule_id=fee_schedule_id,
+                            buyer=standardize_address(data.get("purchaser")),
+                            price=price,
+                            token_amount=0,
+                            expiration_time=0,
+                            is_deleted=True,
+                            token_standard=token_metadata["token_standard"].value,
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            last_transaction_version=transaction.version,
+                            last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                    case "events::TokenOfferFilledEvent":
+                        assert token_metadata
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=token_metadata["collection_id"],
+                            token_data_id=token_metadata["token_data_id"],
+                            creator_address=token_metadata["creator_address"],
+                            collection_name=token_metadata["collection_name"],
+                            token_name=token_metadata["token_name"],
+                            property_version=token_metadata["property_version"],
+                            price=price,
+                            token_amount=1,
+                            token_standard=token_metadata["token_standard"].value,
+                            seller=standardize_address(data.get("seller")),
+                            buyer=standardize_address(data.get("purchaser")),
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.BID_FILLED.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                        current_token_offer = CurrentNFTMarketplaceTokenOffer(
+                            offer_id=offer_or_listing_id,
+                            token_data_id=token_metadata["token_data_id"],
+                            collection_id=token_metadata["collection_id"],
+                            fee_schedule_id=fee_schedule_id,
+                            buyer=standardize_address(data.get("purchaser")),
+                            price=price,
+                            token_amount=0,
+                            expiration_time=0,
+                            is_deleted=True,
+                            token_standard=token_metadata["token_standard"].value,
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            last_transaction_version=transaction.version,
+                            last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                    case "events::AuctionBidEvent":
+                        assert token_metadata
+                        activity = NFTMarketplaceActivities(
+                            transaction_version=transaction.version,
+                            event_index=event_index,
+                            offer_or_listing_id=offer_or_listing_id,
+                            fee_schedule_id=fee_schedule_id,
+                            collection_id=token_metadata["collection_id"],
+                            token_data_id=token_metadata["token_data_id"],
+                            creator_address=token_metadata["creator_address"],
+                            collection_name=token_metadata["collection_name"],
+                            token_name=token_metadata["token_name"],
+                            property_version=token_metadata["property_version"],
+                            price=data.get("new_bid"),
+                            token_amount=1,
+                            token_standard=token_metadata["token_standard"].value,
+                            seller=None,
+                            buyer=standardize_address(data.get("new_bidder")),
+                            marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                            contract_address=transaction_metadata.contract_address,
+                            entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                            event_type=StandardMarketplaceEventType.BID_PLACE.value,
+                            transaction_timestamp=transaction_metadata.transaction_timestamp,
+                        )
+                    case _:
+                        continue
+
+                nft_marketplace_activities.append(activity)
+                if current_listing:
+                    current_nft_marketplace_listings.append(current_listing)
+                if current_token_offer:
+                    current_token_offers.append(current_token_offer)
+                if current_auction:
+                    current_auctions.append(current_auction)
+
+            # Object, listing and offer models. The key is the resource address
+            object_metadatas: Dict[str, ObjectCore] = {}
+            listing_metadatas: Dict[str, ListingMetadata] = {}
+            fixed_price_listings: Dict[str, FixedPriceListing] = {}
+            listing_token_v1_containers: Dict[str, ListingTokenV1Container] = {}
+            token_offer_metadatas: Dict[str, TokenOfferMetadata] = {}
+            token_offer_v1s: Dict[str, TokenOfferV1] = {}
+            token_offer_v2s: Dict[str, TokenOfferV2] = {}
+            collection_offer_metadatas: Dict[str, CollectionOfferMetadata] = {}
+            collection_offer_v1s: Dict[str, CollectionOfferV1] = {}
+            collection_offer_v2s: Dict[str, CollectionOfferV2] = {}
+            auction_listings: Dict[str, AuctionListing] = {}
+
+            # Loop 2
+            # Parse out all the listing, auction, bid, and offer data from write set changes.
+            # This is a bit more complicated than the other parsers because the data is spread out across multiple write set changes,
+            # so we need a first loop to get all the data.
+            for wsc_index, wsc in enumerate(write_set_changes):
+                write_resource = write_set_change_utils.get_write_resource(wsc)
+                if write_resource:
+                    move_resource_address = standardize_address(write_resource.address)
+                    move_resource_type = write_resource.type_str
+                    move_resource_type_address = write_resource.type.address
+                    data = json.loads(write_resource.data)
+
+                    # Parse object metadata
+                    object_core = get_object_core(move_resource_type, data)
+
+                    if object_core:
+                        object_metadatas[move_resource_address] = object_core
+
+                    if move_resource_type_address != MARKETPLCE_SMART_CONTRACT_ADDRESS:
+                        continue
+
+                    # Parse listing metadata
+                    listing_metadata = get_listing_metadata(move_resource_type, data)
+                    fixed_price_listing = get_fixed_priced_listing(
+                        move_resource_type, data
+                    )
+                    listing_token_v1_container = get_listing_token_v1_container(
+                        move_resource_type, data
+                    )
+
+                    if listing_metadata:
+                        listing_metadatas[move_resource_address] = listing_metadata
+                    if fixed_price_listing:
+                        fixed_price_listings[
+                            move_resource_address
+                        ] = fixed_price_listing
+                    if listing_token_v1_container:
+                        listing_token_v1_containers[
+                            move_resource_address
+                        ] = listing_token_v1_container
+
+                    # Parse token offer metadata
+                    token_offer_metadata = get_token_offer_metadata(
+                        move_resource_type, data
+                    )
+                    token_offer_v1 = get_token_offer_v1(move_resource_type, data)
+                    token_offer_v2 = get_token_offer_v2(move_resource_type, data)
+
+                    if token_offer_metadata:
+                        token_offer_metadatas[
+                            move_resource_address
+                        ] = token_offer_metadata
+                    if token_offer_v1:
+                        token_offer_v1s[move_resource_address] = token_offer_v1
+                    if token_offer_v2:
+                        token_offer_v2s[move_resource_address] = token_offer_v2
+
+                    # Parse collection offer metadata
+                    collection_offer_metadata = get_collection_offer_metadata(
+                        move_resource_type, data
+                    )
+                    collection_offer_v1 = get_collection_offer_v1(
+                        move_resource_type, data
+                    )
+                    collection_offer_v2 = get_collection_offer_v2(
+                        move_resource_type, data
+                    )
+
+                    if collection_offer_metadata:
+                        collection_offer_metadatas[
+                            move_resource_address
+                        ] = collection_offer_metadata
+                    if collection_offer_v1:
+                        collection_offer_v1s[
+                            move_resource_address
+                        ] = collection_offer_v1
+                    if collection_offer_v2:
+                        collection_offer_v2s[
+                            move_resource_address
+                        ] = collection_offer_v2
+
+                    # Parse auction metadata
+                    auction_listing = get_auction_listing(move_resource_type, data)
+
+                    if auction_listing:
+                        auction_listings[move_resource_address] = auction_listing
+
+            # Loop 3
+            # Reconstruct the full listing and offer models and create DB objects
+            for _, wsc in enumerate(write_set_changes):
+                write_resource = write_set_change_utils.get_write_resource(wsc)
+                if write_resource:
+                    move_type_address = write_resource.type.address
+                    if move_type_address != MARKETPLCE_SMART_CONTRACT_ADDRESS:
+                        continue
+
+                    move_resource_address = standardize_address(write_resource.address)
+                    move_resource_type = write_resource.type_str
+
+                    if (
+                        move_resource_type
+                        == f"{MARKETPLCE_SMART_CONTRACT_ADDRESS}::listing::Listing"
+                    ):
+                        # Get the data related to this listing that was parsed from loop 2
+                        listing_metadata = listing_metadatas.get(move_resource_address)
+                        fixed_price_listing = fixed_price_listings.get(
+                            move_resource_address
+                        )
+                        auction_listing = auction_listings.get(move_resource_address)
 
                         assert (
-                            token_v2_metadata
-                        ), f"Token v2 metadata not found for txn {transaction.version}"
+                            listing_metadata
+                        ), f"Listing metadata not found for txn {transaction.version}"
 
-                        current_listing = CurrentNFTMarketplaceListing(
-                            token_data_id=token_v2_metadata["token_data_id"],
-                            listing_id=move_resource_address,
-                            fee_schedule_id=listing_metadata["fee_schedule_id"],
-                            collection_id=token_v2_metadata["collection_id"],
-                            price=fixed_price_listing["price"],
-                            token_amount=1,
-                            token_standard=TokenStandard.V2.value,
-                            seller=listing_metadata["seller"],
-                            is_deleted=False,
+                        # If the listing is an auction, it will have an coin_listing::AuctionListing resource, otherwise
+                        # it's a fixed price listing.
+                        if auction_listing:
+                            token_metadata = token_metadatas.get(
+                                listing_metadata["token_address"]
+                            )
+                            assert (
+                                token_metadata
+                            ), f"Token metadata not found for txn {transaction.version}"
+
+                            # Parses when auction is placed and when a bid is placed on an auction
+                            current_auction = CurrentNFTMarketplaceAuction(
+                                listing_id=move_resource_address,
+                                token_data_id=listing_metadata["token_address"],
+                                collection_id=token_metadata["collection_id"],
+                                fee_schedule_id=listing_metadata["fee_schedule_id"],
+                                seller=listing_metadata["seller"],
+                                current_bid_price=auction_listing["current_bid_price"],
+                                current_bidder=auction_listing["current_bidder"],
+                                starting_bid_price=auction_listing[
+                                    "starting_bid_price"
+                                ],
+                                buy_it_now_price=auction_listing["buy_it_now_price"],
+                                token_amount=1,
+                                expiration_time=auction_listing["auction_end_time"],
+                                is_deleted=False,
+                                token_standard=TokenStandard.V2.value,
+                                marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                                contract_address=transaction_metadata.contract_address,
+                                entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                                last_transaction_version=transaction.version,
+                                last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                            )
+                            current_auctions.append(current_auction)
+                        else:
+                            assert (
+                                fixed_price_listing
+                            ), f"Fixed price listing not found for txn {transaction.version}"
+
+                            token_address = listing_metadata["token_address"]
+                            token_v1_container = listing_token_v1_containers.get(
+                                token_address
+                            )
+
+                            current_listing = None
+
+                            if token_v1_container:
+                                token_v1_metadata = token_v1_container["token_metadata"]
+                                current_listing = CurrentNFTMarketplaceListing(
+                                    token_data_id=token_v1_metadata["token_data_id"],
+                                    listing_id=move_resource_address,
+                                    fee_schedule_id=listing_metadata["fee_schedule_id"],
+                                    collection_id=token_v1_metadata["collection_id"],
+                                    price=fixed_price_listing["price"],
+                                    token_amount=token_v1_container["amount"],
+                                    token_standard=TokenStandard.V1.value,
+                                    seller=listing_metadata["seller"],
+                                    is_deleted=False,
+                                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                                    contract_address=transaction_metadata.contract_address,
+                                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                                    last_transaction_version=transaction.version,
+                                    last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                                )
+                            else:
+                                token_v2_metadata = token_metadatas.get(token_address)
+
+                                assert (
+                                    token_v2_metadata
+                                ), f"Token v2 metadata not found for txn {transaction.version}"
+
+                                current_listing = CurrentNFTMarketplaceListing(
+                                    token_data_id=token_v2_metadata["token_data_id"],
+                                    listing_id=move_resource_address,
+                                    fee_schedule_id=listing_metadata["fee_schedule_id"],
+                                    collection_id=token_v2_metadata["collection_id"],
+                                    price=fixed_price_listing["price"],
+                                    token_amount=1,
+                                    token_standard=TokenStandard.V2.value,
+                                    seller=listing_metadata["seller"],
+                                    is_deleted=False,
+                                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                                    contract_address=transaction_metadata.contract_address,
+                                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                                    last_transaction_version=transaction.version,
+                                    last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                                )
+
+                            current_nft_marketplace_listings.append(current_listing)
+
+                    elif (
+                        move_resource_type
+                        == f"{MARKETPLCE_SMART_CONTRACT_ADDRESS}::token_offer::TokenOffer"
+                    ):
+                        # Get the data related to this token offer that was parsed from loop 2
+                        token_offer_object = object_metadatas.get(move_resource_address)
+                        token_offer_metadata = token_offer_metadatas.get(
+                            move_resource_address
+                        )
+                        token_offer_v1 = token_offer_v1s.get(move_resource_address)
+
+                        assert (
+                            token_offer_object
+                        ), f"Token offer object not found for txn {transaction.version}"
+                        assert (
+                            token_offer_metadata
+                        ), f"Token offer metadata not found for txn {transaction.version}"
+
+                        current_token_offer = None
+
+                        if token_offer_v1:
+                            token_metadata = token_offer_v1["token_metadata"]
+                            current_token_offer = CurrentNFTMarketplaceTokenOffer(
+                                offer_id=move_resource_address,
+                                token_data_id=token_metadata["token_data_id"],
+                                collection_id=token_metadata["collection_id"],
+                                fee_schedule_id=token_offer_metadata["fee_schedule_id"],
+                                buyer=token_offer_object["owner"],
+                                price=token_offer_metadata["price"],
+                                token_amount=1,
+                                expiration_time=token_offer_metadata["expiration_time"],
+                                is_deleted=False,
+                                token_standard=TokenStandard.V1.value,
+                                marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                                contract_address=transaction_metadata.contract_address,
+                                entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                                last_transaction_version=transaction.version,
+                                last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                            )
+                        else:
+                            token_offer_v2 = token_offer_v2s.get(move_resource_address)
+
+                            assert (
+                                token_offer_v2
+                            ), f"Token offer v2 metadata not found for txn {transaction.version}"
+                            
+                            token_v2_metadata = token_metadatas.get(
+                                token_offer_v2["token_address"]
+                            )
+                            assert (
+                                token_v2_metadata
+                            ), f"Token v2 metadata not found for txn {transaction.version}"
+
+                            current_token_offer = CurrentNFTMarketplaceTokenOffer(
+                                offer_id=move_resource_address,
+                                token_data_id=token_offer_v2["token_address"],
+                                collection_id=token_v2_metadata["collection_id"],
+                                fee_schedule_id=token_offer_metadata["fee_schedule_id"],
+                                buyer=token_offer_object["owner"],
+                                price=token_offer_metadata["price"],
+                                token_amount=1,
+                                expiration_time=token_offer_metadata["expiration_time"],
+                                is_deleted=False,
+                                token_standard=TokenStandard.V2.value,
+                                marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                                contract_address=transaction_metadata.contract_address,
+                                entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                                last_transaction_version=transaction.version,
+                                last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                            )
+
+                        current_token_offers.append(current_token_offer)
+                    elif (
+                        move_resource_type
+                        == f"{MARKETPLCE_SMART_CONTRACT_ADDRESS}::collection_offer::CollectionOffer"
+                    ):
+                        # Get the data related to this collection offer that was parsed from loop 2
+                        collection_offer_metadata = collection_offer_metadatas.get(
+                            move_resource_address
+                        )
+                        collection_object = object_metadatas.get(move_resource_address)
+                        collection_offer_v1 = collection_offer_v1s.get(
+                            move_resource_address
+                        )
+
+                        assert (
+                            collection_offer_metadata
+                        ), f"Collection offer metadata not found for txn {transaction.version}"
+                        assert (
+                            collection_object
+                        ), f"Collection object not found for txn {transaction.version}"
+
+                        current_collection_offer = None
+
+                        if collection_offer_v1:
+                            current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
+                                collection_offer_id=move_resource_address,
+                                collection_id=collection_offer_v1[
+                                    "collection_metadata"
+                                ]["collection_id"],
+                                fee_schedule_id=collection_offer_metadata["fee_schedule_id"],
+                                buyer=collection_object["owner"],
+                                item_price=collection_offer_metadata["item_price"],
+                                remaining_token_amount=collection_offer_metadata[
+                                    "remaining_token_amount"
+                                ],
+                                expiration_time=collection_offer_metadata[
+                                    "expiration_time"
+                                ],
+                                is_deleted=False,
+                                token_standard=TokenStandard.V1.value,
+                                marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                                contract_address=transaction_metadata.contract_address,
+                                entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                                last_transaction_version=transaction.version,
+                                last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                            )
+                        else:
+                            collection_offer_v2 = collection_offer_v2s.get(
+                                move_resource_address
+                            )
+                            assert (
+                                collection_offer_v2
+                            ), f"Collection offer v2 not found for txn {transaction.version}"
+
+                            current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
+                                collection_offer_id=move_resource_address,
+                                collection_id=collection_offer_v2["collection_address"],
+                                fee_schedule_id=collection_offer_metadata["fee_schedule_id"],
+                                buyer=collection_object["owner"],
+                                item_price=collection_offer_metadata["item_price"],
+                                remaining_token_amount=collection_offer_metadata[
+                                    "remaining_token_amount"
+                                ],
+                                expiration_time=collection_offer_metadata[
+                                    "expiration_time"
+                                ],
+                                is_deleted=False,
+                                token_standard=TokenStandard.V2.value,
+                                marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
+                                contract_address=transaction_metadata.contract_address,
+                                entry_function_id_str=transaction_metadata.entry_function_id_str_short,
+                                last_transaction_version=transaction.version,
+                                last_transaction_timestamp=transaction_metadata.transaction_timestamp,
+                            )
+                        current_collection_offers.append(current_collection_offer)
+
+                delete_resource = write_set_change_utils.get_delete_resource(wsc)
+                if delete_resource:
+                    move_resource_address = standardize_address(delete_resource.address)
+
+                    # If a collection offer resource gets deleted, that means it the offer was filled completely
+                    # and we handle that here.
+                    maybe_collection_offer_filled_metadata = (
+                        collection_offer_filled_metadatas.get(move_resource_address)
+                    )
+                    if maybe_collection_offer_filled_metadata:
+                        collection_metadata = maybe_collection_offer_filled_metadata[
+                            "collection_metadata"
+                        ]
+                        current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
+                            collection_offer_id=move_resource_address,
+                            collection_id=collection_metadata["collection_id"],
+                            fee_schedule_id=maybe_collection_offer_filled_metadata["fee_schedule_id"],
+                            buyer=maybe_collection_offer_filled_metadata["buyer"],
+                            item_price=maybe_collection_offer_filled_metadata[
+                                "item_price"
+                            ],
+                            remaining_token_amount=0,
+                            expiration_time=0,
+                            is_deleted=True,
+                            token_standard=collection_metadata["token_standard"].value,
                             marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
                             contract_address=transaction_metadata.contract_address,
                             entry_function_id_str=transaction_metadata.entry_function_id_str_short,
                             last_transaction_version=transaction.version,
                             last_transaction_timestamp=transaction_metadata.transaction_timestamp,
                         )
+                        current_collection_offers.append(current_collection_offer)
 
-                    current_nft_marketplace_listings.append(current_listing)
-
-            elif (
-                move_resource_type
-                == f"{MARKETPLCE_SMART_CONTRACT_ADDRESS}::token_offer::TokenOffer"
-            ):
-                # Get the data related to this token offer that was parsed from loop 2
-                token_offer_object = object_metadatas.get(move_resource_address)
-                token_offer_metadata = token_offer_metadatas.get(move_resource_address)
-                token_offer_v1 = token_offer_v1s.get(move_resource_address)
-
-                assert (
-                    token_offer_object
-                ), f"Token offer object not found for txn {transaction.version}"
-                assert (
-                    token_offer_metadata
-                ), f"Token offer metadata not found for txn {transaction.version}"
-
-                current_token_offer = None
-
-                if token_offer_v1:
-                    token_metadata = token_offer_v1["token_metadata"]
-                    current_token_offer = CurrentNFTMarketplaceTokenOffer(
-                        offer_id=move_resource_address,
-                        token_data_id=token_metadata["token_data_id"],
-                        collection_id=token_metadata["collection_id"],
-                        fee_schedule_id=token_offer_metadata["fee_schedule_id"],
-                        buyer=token_offer_object["owner"],
-                        price=token_offer_metadata["price"],
-                        token_amount=1,
-                        expiration_time=token_offer_metadata["expiration_time"],
-                        is_deleted=False,
-                        token_standard=TokenStandard.V1.value,
-                        marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                        contract_address=transaction_metadata.contract_address,
-                        entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                        last_transaction_version=transaction.version,
-                        last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                    )
-                else:
-                    token_offer_v2 = token_offer_v2s.get(move_resource_address)
-
-                    assert (
-                        token_offer_v2
-                    ), f"Token offer v2 metadata not found for txn {transaction.version}"
-
-                    token_v2_metadata = token_metadatas.get(
-                        token_offer_v2["token_address"]
-                    )
-                    assert (
-                        token_v2_metadata
-                    ), f"Token v2 metadata not found for txn {transaction.version}"
-
-                    current_token_offer = CurrentNFTMarketplaceTokenOffer(
-                        offer_id=move_resource_address,
-                        token_data_id=token_offer_v2["token_address"],
-                        collection_id=token_v2_metadata["collection_id"],
-                        fee_schedule_id=token_offer_metadata["fee_schedule_id"],
-                        buyer=token_offer_object["owner"],
-                        price=token_offer_metadata["price"],
-                        token_amount=1,
-                        expiration_time=token_offer_metadata["expiration_time"],
-                        is_deleted=False,
-                        token_standard=TokenStandard.V2.value,
-                        marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                        contract_address=transaction_metadata.contract_address,
-                        entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                        last_transaction_version=transaction.version,
-                        last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                    )
-
-                current_token_offers.append(current_token_offer)
-            elif (
-                move_resource_type
-                == f"{MARKETPLCE_SMART_CONTRACT_ADDRESS}::collection_offer::CollectionOffer"
-            ):
-                # Get the data related to this collection offer that was parsed from loop 2
-                collection_offer_metadata = collection_offer_metadatas.get(
-                    move_resource_address
-                )
-                collection_object = object_metadatas.get(move_resource_address)
-                collection_offer_v1 = collection_offer_v1s.get(move_resource_address)
-
-                assert (
-                    collection_offer_metadata
-                ), f"Collection offer metadata not found for txn {transaction.version}"
-                assert (
-                    collection_object
-                ), f"Collection object not found for txn {transaction.version}"
-
-                current_collection_offer = None
-
-                if collection_offer_v1:
-                    current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
-                        collection_offer_id=move_resource_address,
-                        collection_id=collection_offer_v1["collection_metadata"][
-                            "collection_id"
-                        ],
-                        fee_schedule_id=collection_offer_metadata["fee_schedule_id"],
-                        buyer=collection_object["owner"],
-                        item_price=collection_offer_metadata["item_price"],
-                        remaining_token_amount=collection_offer_metadata[
-                            "remaining_token_amount"
-                        ],
-                        expiration_time=collection_offer_metadata["expiration_time"],
-                        is_deleted=False,
-                        token_standard=TokenStandard.V1.value,
-                        marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                        contract_address=transaction_metadata.contract_address,
-                        entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                        last_transaction_version=transaction.version,
-                        last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                    )
-                else:
-                    collection_offer_v2 = collection_offer_v2s.get(
-                        move_resource_address
-                    )
-                    assert (
-                        collection_offer_v2
-                    ), f"Collection offer v2 not found for txn {transaction.version}"
-
-                    current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
-                        collection_offer_id=move_resource_address,
-                        collection_id=collection_offer_v2["collection_address"],
-                        fee_schedule_id=collection_offer_metadata["fee_schedule_id"],
-                        buyer=collection_object["owner"],
-                        item_price=collection_offer_metadata["item_price"],
-                        remaining_token_amount=collection_offer_metadata[
-                            "remaining_token_amount"
-                        ],
-                        expiration_time=collection_offer_metadata["expiration_time"],
-                        is_deleted=False,
-                        token_standard=TokenStandard.V2.value,
-                        marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                        contract_address=transaction_metadata.contract_address,
-                        entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                        last_transaction_version=transaction.version,
-                        last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                    )
-                current_collection_offers.append(current_collection_offer)
-
-        delete_resource = write_set_change_utils.get_delete_resource(wsc)
-        if delete_resource:
-            move_resource_address = standardize_address(delete_resource.address)
-
-            # If a collection offer resource gets deleted, that means it the offer was filled completely
-            # and we handle that here.
-            maybe_collection_offer_filled_metadata = (
-                collection_offer_filled_metadatas.get(move_resource_address)
+            # TODO: Sort values by PK to avoid postgres deadlock
+            parsed_objs.extend(
+                nft_marketplace_activities
+                + current_nft_marketplace_listings
+                + current_token_offers
+                + current_collection_offers
+                + current_auctions
             )
-            if maybe_collection_offer_filled_metadata:
-                collection_metadata = maybe_collection_offer_filled_metadata[
-                    "collection_metadata"
-                ]
-                current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
-                    collection_offer_id=move_resource_address,
-                    collection_id=collection_metadata["collection_id"],
-                    fee_schedule_id=maybe_collection_offer_filled_metadata[
-                        "fee_schedule_id"
-                    ],
-                    buyer=maybe_collection_offer_filled_metadata["buyer"],
-                    item_price=maybe_collection_offer_filled_metadata["item_price"],
-                    remaining_token_amount=0,
-                    expiration_time=0,
-                    is_deleted=True,
-                    token_standard=collection_metadata["token_standard"].value,
-                    marketplace=MarketplaceName.EXAMPLE_V2_MARKETPLACE.value,
-                    contract_address=transaction_metadata.contract_address,
-                    entry_function_id_str=transaction_metadata.entry_function_id_str_short,
-                    last_transaction_version=transaction.version,
-                    last_transaction_timestamp=transaction_metadata.transaction_timestamp,
-                )
-                current_collection_offers.append(current_collection_offer)
 
-    return (
-        nft_marketplace_activities
-        + current_nft_marketplace_listings
-        + current_token_offers
-        + current_collection_offers
-        + current_auctions
-    )
+    def insert_to_db(
+        self,
+        parsed_objs: List[
+            NFTMarketplaceActivities
+            | CurrentNFTMarketplaceListing
+            | CurrentNFTMarketplaceTokenOffer
+            | CurrentNFTMarketplaceCollectionOffer
+            | CurrentNFTMarketplaceAuction
+        ],
+    ) -> None:
+        # TODO: Turn this into on conflict, update, to support backfilling
+        with Session() as session, session.begin():
+            for obj in parsed_objs:
+                session.merge(obj)
 
 
 if __name__ == "__main__":
-    transactions_processor = TransactionsProcessor(
-        parser_function=parse,
-        processor_name="nft-marketplace-v2",
-        schema_name=NFT_MARKETPLACE_V2_SCHEMA_NAME,
-    )
-    transactions_processor.process()
+    processor = NFTMarketplaceV2Processor()
+    processor.run()

--- a/python/processors/nft_marketplace_v2/processor.py
+++ b/python/processors/nft_marketplace_v2/processor.py
@@ -54,6 +54,7 @@ from utils.models.schema_names import NFT_MARKETPLACE_V2_SCHEMA_NAME
 from processors.nft_marketplace_v2.constants import MARKETPLCE_SMART_CONTRACT_ADDRESS
 from utils.session import Session
 from utils.worker import IndexerProcessorServer
+from sqlalchemy.dialects.postgresql import insert
 
 
 class NFTMarketplaceV2Processor(TransactionsProcessor):
@@ -792,7 +793,7 @@ class NFTMarketplaceV2Processor(TransactionsProcessor):
                             assert (
                                 token_offer_v2
                             ), f"Token offer v2 metadata not found for txn {transaction.version}"
-                            
+
                             token_v2_metadata = token_metadatas.get(
                                 token_offer_v2["token_address"]
                             )
@@ -847,7 +848,9 @@ class NFTMarketplaceV2Processor(TransactionsProcessor):
                                 collection_id=collection_offer_v1[
                                     "collection_metadata"
                                 ]["collection_id"],
-                                fee_schedule_id=collection_offer_metadata["fee_schedule_id"],
+                                fee_schedule_id=collection_offer_metadata[
+                                    "fee_schedule_id"
+                                ],
                                 buyer=collection_object["owner"],
                                 item_price=collection_offer_metadata["item_price"],
                                 remaining_token_amount=collection_offer_metadata[
@@ -875,7 +878,9 @@ class NFTMarketplaceV2Processor(TransactionsProcessor):
                             current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
                                 collection_offer_id=move_resource_address,
                                 collection_id=collection_offer_v2["collection_address"],
-                                fee_schedule_id=collection_offer_metadata["fee_schedule_id"],
+                                fee_schedule_id=collection_offer_metadata[
+                                    "fee_schedule_id"
+                                ],
                                 buyer=collection_object["owner"],
                                 item_price=collection_offer_metadata["item_price"],
                                 remaining_token_amount=collection_offer_metadata[
@@ -910,7 +915,9 @@ class NFTMarketplaceV2Processor(TransactionsProcessor):
                         current_collection_offer = CurrentNFTMarketplaceCollectionOffer(
                             collection_offer_id=move_resource_address,
                             collection_id=collection_metadata["collection_id"],
-                            fee_schedule_id=maybe_collection_offer_filled_metadata["fee_schedule_id"],
+                            fee_schedule_id=maybe_collection_offer_filled_metadata[
+                                "fee_schedule_id"
+                            ],
                             buyer=maybe_collection_offer_filled_metadata["buyer"],
                             item_price=maybe_collection_offer_filled_metadata[
                                 "item_price"
@@ -957,6 +964,36 @@ class NFTMarketplaceV2Processor(TransactionsProcessor):
         with Session() as session, session.begin():
             for obj in parsed_objs:
                 session.merge(obj)
+
+    def insert_nft_activities(
+        self,
+        activities: List[NFTMarketplaceActivities],
+    ) -> None:
+        pass
+
+    def insert_nft_listings(
+        self,
+        listings: List[CurrentNFTMarketplaceListing],
+    ) -> None:
+        pass
+
+    def insert_nft_token_offers(
+        self,
+        offers: List[CurrentNFTMarketplaceTokenOffer],
+    ) -> None:
+        pass
+
+    def insert_nft_collection_offers(
+        self,
+        offers: List[CurrentNFTMarketplaceCollectionOffer],
+    ) -> None:
+        pass
+
+    def insert_nft_auctions(
+        self,
+        auctions: List[CurrentNFTMarketplaceAuction],
+    ) -> None:
+        pass
 
 
 if __name__ == "__main__":

--- a/python/processors/nft_orderbooks/nft_marketplace_processor.py
+++ b/python/processors/nft_orderbooks/nft_marketplace_processor.py
@@ -33,96 +33,127 @@ from sqlalchemy.orm import Session
 from utils.transactions_processor import TransactionsProcessor
 from utils import event_utils, general_utils, transaction_utils, write_set_change_utils
 from utils.models.schema_names import NFT_MARKETPLACE_SCHEMA_NAME
+from utils.session import Session
 
 
-def parse(
-    transaction: transaction_pb2.Transaction,
-) -> List[
-    NFTMarketplaceEvent
-    | NFTMarketplaceListing
-    | CurrentNFTMarketplaceListing
-    | NFTMarketplaceBid
-    | CurrentNFTMarketplaceBid
-    | NFTMarketplaceCollectionBid
-    | CurrentNFTMarketplaceCollectionBid
-]:
-    parsed_objs = []
-    user_transaction = transaction_utils.get_user_transaction(transaction)
+class NFTMarketplaceProcesser(TransactionsProcessor):
+    def name(self) -> str:
+        return "nft-marketplace-processor"
 
-    # Filter user transactions
-    if not user_transaction:
-        return []
+    def schema(self) -> str:
+        return NFT_MARKETPLACE_SCHEMA_NAME
 
-    events = user_transaction.events
-    for event_index, event in enumerate(events):
-        contract_address = general_utils.standardize_address(
-            event_utils.get_event_type_address(event)
-        )
+    def process_transactions(
+        self,
+        transactions: list[transaction_pb2.Transaction],
+        start_version: int,
+        end_version: int,
+    ) -> None:
+        parsed_objs = []
 
-        if contract_address not in MARKETPLACE_SMART_CONTRACT_ADDRESSES_INV:
-            continue
+        for transaction in transactions:
+            user_transaction = transaction_utils.get_user_transaction(transaction)
 
-        marketplace_name = MARKETPLACE_SMART_CONTRACT_ADDRESSES_INV[contract_address]
-
-        match (marketplace_name):
-            case MarketplaceName.TOPAZ:
-                parsed_objs.extend(
-                    topaz_parser.parse_event(transaction, event, event_index)
-                )
-            case MarketplaceName.SOUFFLE:
-                parsed_objs.extend(
-                    souffle_parser.parse_event(transaction, event, event_index)
-                )
-            case MarketplaceName.BLUEMOVE:
-                parsed_objs.extend(
-                    bluemove_parser.parse_event(transaction, event, event_index)
-                )
-            case MarketplaceName.OKX:
-                parsed_objs.extend(okx_parser.parse_marketplace_events(transaction))
-            case MarketplaceName.OZOZOZ:
-                parsed_objs.extend(ozozoz_parser.parse_marketplace_events(transaction))
-            case MarketplaceName.ITSRARE:
-                parsed_objs.extend(itsrare_parser.parse_marketplace_events(transaction))
-
-    write_set_changes = transaction_utils.get_write_set_changes(transaction)
-    for wsc_index, wsc in enumerate(write_set_changes):
-        write_table_item = write_set_change_utils.get_write_table_item(wsc)
-
-        if write_table_item:
-            table_handle = str(write_table_item.handle)
-
-            if table_handle not in MARKETPLACE_TABLE_HANDLES_INV:
+            # Filter user transactions
+            if not user_transaction:
                 continue
 
-            marketplace_name = MARKETPLACE_TABLE_HANDLES_INV[table_handle]
+            events = user_transaction.events
+            for event_index, event in enumerate(events):
+                contract_address = general_utils.standardize_address(
+                    event_utils.get_event_type_address(event)
+                )
 
-            match (marketplace_name):
-                case MarketplaceName.TOPAZ:
-                    parsed_objs.extend(
-                        topaz_parser.parse_write_table_item(
-                            transaction, write_table_item, wsc_index
-                        )
-                    )
-                case MarketplaceName.SOUFFLE:
-                    parsed_objs.extend(
-                        souffle_parser.parse_write_table_item(
-                            transaction, write_table_item, wsc_index
-                        )
-                    )
-                case MarketplaceName.BLUEMOVE:
-                    parsed_objs.extend(
-                        bluemove_parser.parse_write_table_item(
-                            transaction, write_table_item, wsc_index
-                        )
-                    )
+                if contract_address not in MARKETPLACE_SMART_CONTRACT_ADDRESSES_INV:
+                    continue
 
-    return parsed_objs
+                marketplace_name = MARKETPLACE_SMART_CONTRACT_ADDRESSES_INV[
+                    contract_address
+                ]
+
+                # TODO: Optimize this; there's too many loops
+                match (marketplace_name):
+                    case MarketplaceName.TOPAZ:
+                        parsed_objs.extend(
+                            topaz_parser.parse_event(transaction, event, event_index)
+                        )
+                    case MarketplaceName.SOUFFLE:
+                        parsed_objs.extend(
+                            souffle_parser.parse_event(transaction, event, event_index)
+                        )
+                    case MarketplaceName.BLUEMOVE:
+                        parsed_objs.extend(
+                            bluemove_parser.parse_event(transaction, event, event_index)
+                        )
+                    case MarketplaceName.OKX:
+                        parsed_objs.extend(
+                            okx_parser.parse_marketplace_events(transaction)
+                        )
+                    case MarketplaceName.OZOZOZ:
+                        parsed_objs.extend(
+                            ozozoz_parser.parse_marketplace_events(transaction)
+                        )
+                    case MarketplaceName.ITSRARE:
+                        parsed_objs.extend(
+                            itsrare_parser.parse_marketplace_events(transaction)
+                        )
+
+            write_set_changes = transaction_utils.get_write_set_changes(transaction)
+            for wsc_index, wsc in enumerate(write_set_changes):
+                write_table_item = write_set_change_utils.get_write_table_item(wsc)
+
+                if write_table_item:
+                    table_handle = str(write_table_item.handle)
+
+                    if table_handle not in MARKETPLACE_TABLE_HANDLES_INV:
+                        continue
+
+                    marketplace_name = MARKETPLACE_TABLE_HANDLES_INV[table_handle]
+
+                    match (marketplace_name):
+                        case MarketplaceName.TOPAZ:
+                            parsed_objs.extend(
+                                topaz_parser.parse_write_table_item(
+                                    transaction, write_table_item, wsc_index
+                                )
+                            )
+                        case MarketplaceName.SOUFFLE:
+                            parsed_objs.extend(
+                                souffle_parser.parse_write_table_item(
+                                    transaction, write_table_item, wsc_index
+                                )
+                            )
+                        case MarketplaceName.BLUEMOVE:
+                            parsed_objs.extend(
+                                bluemove_parser.parse_write_table_item(
+                                    transaction, write_table_item, wsc_index
+                                )
+                            )
+
+        # TODO: Sort by pk for multi threaded postgres insert
+
+        self.insert_to_db(
+            parsed_objs,
+        )
+
+    def insert_to_db(
+        self,
+        parsed_objs: List[
+            NFTMarketplaceEvent
+            | NFTMarketplaceListing
+            | CurrentNFTMarketplaceListing
+            | NFTMarketplaceBid
+            | CurrentNFTMarketplaceBid
+            | NFTMarketplaceCollectionBid
+            | CurrentNFTMarketplaceCollectionBid
+        ],
+    ) -> None:
+        with Session() as session, session.begin():
+            # TODO: Turn this into on conflict, update, to support backfilling
+            for obj in parsed_objs:
+                session.merge(obj)
 
 
 if __name__ == "__main__":
-    transactions_processor = TransactionsProcessor(
-        parser_function=parse,
-        processor_name="nft-marketplace",
-        schema_name=NFT_MARKETPLACE_SCHEMA_NAME,
-    )
-    transactions_processor.process()
+    transactions_processor = NFTMarketplaceProcesser()
+    transactions_processor.run()

--- a/python/utils/config.py
+++ b/python/utils/config.py
@@ -55,18 +55,23 @@ class Config(BaseSettings):
                             next_version_to_process_from_db.next_version
                         )
             except:
-                print("Error getting NextVersionToProcess from db. Skipping...")
+                print("Database error when getting NextVersionToProcess. Skipping...")
 
         # By default, if nothing is set, start from 0
         starting_version = 0
         if self.starting_version_override != None:
             # Start from config's starting_version_override if set
+            print("[Config] Starting from starting_version_override")
             starting_version = self.starting_version_override
         elif next_version_to_process != None:
             # Start from next version to process in db
+            print("[Config] Starting from version from db")
             starting_version = next_version_to_process
         elif self.starting_version_default != None:
             # Start from config's starting_version_default if set
+            print("[Config] Starting from starting_version_default")
             starting_version = self.starting_version_default
+        else:
+            print("Starting from version 0")
 
         return starting_version

--- a/python/utils/transactions_processor.py
+++ b/python/utils/transactions_processor.py
@@ -2,6 +2,7 @@ import argparse
 import grpc
 import json
 
+from dataclasses import dataclass
 from utils.models.general_models import NextVersionToProcess
 from aptos.indexer.v1 import raw_data_pb2, raw_data_pb2_grpc
 from aptos.transaction.v1 import transaction_pb2
@@ -11,11 +12,8 @@ from utils.session import Session
 from utils.metrics import PROCESSED_TRANSACTIONS_COUNTER
 from sqlalchemy import DDL, Engine, create_engine
 from sqlalchemy import event
-from typing import Any, Callable
-from prometheus_client.twisted import MetricsResource
-from twisted.web.server import Site
-from twisted.web.resource import Resource
-from twisted.internet import reactor
+from typing import Any, Callable, TypedDict
+from prometheus_client import start_http_server
 import http.server
 import socketserver
 import threading
@@ -24,48 +22,15 @@ import traceback
 from abc import ABC, abstractmethod
 
 
+@dataclass
+class ProcessingResult:
+    start_version: int
+    end_version: int
+
+
 class TransactionsProcessor(ABC):
-    parser_function: Callable[[transaction_pb2.Transaction], list[Any]]
     config: Config
-    engine: Engine | None
-
-    def __init__(
-        self,
-    ):
-        parser = argparse.ArgumentParser()
-        parser.add_argument("-c", "--config", help="Path to config file", required=True)
-        args = parser.parse_args()
-        self.config = Config.from_yaml_file(args.config)
-        # self.parser_function = parser_function
-        # self.processor_name = processor_name
-        # self.schema_name = schema_name
-
-        self.init_db_tables()
-
-        # Start the health + metrics server.
-        def start_health_server() -> None:
-            # The kubelet uses liveness probes to know when to restart a container. In cases where the
-            # container is crashing or unresponsive, the kubelet receives timeout or error responses, and then
-            # restarts the container. It polls every 10 seconds by default.
-            root = Resource()
-            root.putChild(b"metrics", MetricsResource())  # type: ignore
-
-            class ServerOk(Resource):
-                isLeaf = True
-
-                def render_GET(self, request):
-                    return b"ok"
-
-            root.putChild(b"", ServerOk())  # type: ignore
-            factory = Site(root)
-            reactor.listenTCP(self.config.health_port, factory)  # type: ignore
-            reactor.run(installSignalHandlers=False)  # type: ignore
-
-        t = threading.Thread(target=start_health_server, daemon=True)
-        # TODO: Handles the exit signal and gracefully shutdown the server.
-        t.start()
-
-        self.init_db_tables()
+    num_concurrent_processing_tasks: int
 
     # Name of the processor for status logging
     # This will get stored in the database for each (`TransactionProcessor`, transaction_version) pair
@@ -87,135 +52,8 @@ class TransactionsProcessor(ABC):
         transactions: list[transaction_pb2.Transaction],
         start_version: int,
         end_version: int,
-    ) -> None:
-        # TODO: Make this return processing result
+    ) -> ProcessingResult:
         pass
-
-    # TODO: Move this to indexer worker
-    def init_db_tables(self) -> None:
-        engine = create_engine(self.config.db_connection_uri)
-        engine = engine.execution_options(
-            schema_translate_map={"per_schema": self.schema()}
-        )
-        Session.configure(bind=engine)
-        Base.metadata.create_all(engine, checkfirst=True)
-
-    # TODO: Move this to indexer worker
-    def run(self) -> None:
-        # Setup the GetTransactionsRequest
-
-        processor_name = self.name()
-        starting_version = self.config.get_starting_version(processor_name)
-        ending_version = self.config.ending_version
-
-        request = raw_data_pb2.GetTransactionsRequest(starting_version=starting_version)
-
-        # Setup GRPC settings
-        metadata = (
-            ("x-aptos-data-authorization", self.config.grpc_data_stream_api_key),
-            ("x-aptos-request-name", processor_name),
-        )
-        options = [
-            ("grpc.max_receive_message_length", -1),
-            (
-                "grpc.keepalive_time_ms",
-                self.config.indexer_grpc_http2_ping_interval_in_secs * 1000,
-            ),
-            (
-                "grpc.keepalive_timeout_ms",
-                self.config.indexer_grpc_http2_ping_timeout_in_secs * 1000,
-            ),
-        ]
-
-        print(
-            json.dumps(
-                {
-                    "message": f"Connected to grpc data stream endpoint: {self.config.grpc_data_stream_endpoint}",
-                    "starting_version": starting_version,
-                }
-            ),
-            flush=True,
-        )
-
-        # Connect to indexer grpc endpoint
-        # TODO: Move this to indexer worker
-        with grpc.insecure_channel(
-            self.config.grpc_data_stream_endpoint, options=options
-        ) as channel:
-            stub = raw_data_pb2_grpc.RawDataStub(channel)
-
-            last_processed_version = None
-
-            try:
-                for response in stub.GetTransactions(
-                    request,
-                    metadata=metadata,
-                ):
-                    self.validate_grpc_chain_id(response)
-
-                    batch_start_version = response.transactions[0].version
-                    batch_end_version = response.transactions[-1].version
-
-                    print(
-                        json.dumps(
-                            {
-                                "message": "[Parser] Response received",
-                                "starting_version": response.transactions[0].version,
-                            }
-                        )
-                    )
-
-                    # TODO: Transaction version validation
-
-                    # If ending version is in the current batch, truncate the transactions in this batcch
-                    if ending_version != None and batch_end_version >= ending_version:
-                        batch_end_version = ending_version
-
-                    self.process_transactions(
-                        response.transactions[
-                            : batch_end_version - batch_start_version + 1
-                        ],
-                        batch_start_version,
-                        batch_end_version,
-                    )
-
-                    # Stop processing if reached ending version
-                    # TODO: Maybe move this to indexer worker
-                    if ending_version == batch_end_version:
-                        print(
-                            json.dumps(
-                                {
-                                    "message": "Reached ending version",
-                                    "ending_version": ending_version,
-                                }
-                            )
-                        )
-                        return
-
-                    if batch_end_version % 1000 == 0:
-                        print(
-                            json.dumps(
-                                {
-                                    "message": "Successfully processed transaction",
-                                    "last_processed_version": batch_end_version,
-                                }
-                            )
-                        )
-
-                    # Update last_processed_version for error logging
-                    last_processed_version = batch_end_version
-            except grpc.RpcError as e:
-                print(
-                    json.dumps(
-                        {
-                            "message": "[Parser] Error processing transaction",
-                            "last_success_transaction_version": last_processed_version,
-                            "error": str(e),
-                        }
-                    )
-                )
-                # TODO: Add retry logic.
-                sys.exit(1)
 
     def update_last_processed_version(self, last_processed_version) -> None:
         with Session() as session, session.begin():
@@ -237,24 +75,3 @@ class TransactionsProcessor(ABC):
                 + ", but received chain ID is: "
                 + str(chain_id)
             )
-
-
-# TODO: Move DB schema initialization to the worker
-@event.listens_for(Base.metadata, "before_create")
-def create_schemas(target, connection, **kw):
-    schemas = set()
-    for table in target.tables.values():
-        if table.schema is not None:
-            schemas.add(table.schema)
-    for schema in schemas:
-        connection.execute(DDL("CREATE SCHEMA IF NOT EXISTS %s" % schema))
-
-
-@event.listens_for(Base.metadata, "after_drop")
-def drop_schemas(target, connection, **kw):
-    schemas = set()
-    for table in target.tables.values():
-        if table.schema is not None:
-            schemas.add(table.schema)
-    for schema in schemas:
-        connection.execute(DDL("DROP SCHEMA IF EXISTS %s" % schema))

--- a/python/utils/worker.py
+++ b/python/utils/worker.py
@@ -1,0 +1,322 @@
+import argparse
+import grpc
+import json
+
+from utils.models.general_models import NextVersionToProcess
+from aptos.indexer.v1 import raw_data_pb2, raw_data_pb2_grpc
+from aptos.transaction.v1 import transaction_pb2
+from utils.config import Config
+from utils.models.general_models import Base
+from utils.session import Session
+from utils.metrics import PROCESSED_TRANSACTIONS_COUNTER
+from sqlalchemy import DDL, Engine, create_engine
+from sqlalchemy import event
+from typing import List
+from prometheus_client import start_http_server
+import http.server
+import socketserver
+import threading
+import sys
+from abc import ABC, abstractmethod
+from utils.transactions_processor import TransactionsProcessor, ProcessingResult
+from time import perf_counter
+
+
+INDEXER_GRPC_BLOB_STORAGE_SIZE = 1000
+
+
+class IndexerProcessorServer:
+    config: Config
+    num_concurrent_processing_tasks: int
+
+    def __init__(self, processor: TransactionsProcessor):
+        print("[Parser] Kicking off")
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-c", "--config", help="Path to config file", required=True)
+        parser.add_argument(
+            "-p",
+            "--perf",
+            help="Show perf metrics for processing X transactions",
+            required=False,
+        )
+        args = parser.parse_args()
+        self.config = Config.from_yaml_file(args.config)
+        self.perf_transactions = args.perf
+        self.processor = processor
+
+        # TODO: Move this to a config
+        self.num_concurrent_processing_tasks = 10
+
+    class WorkerThread(
+        threading.Thread,
+    ):
+        processing_result: ProcessingResult | None
+        exception: Exception | None
+
+        def __init__(
+            self,
+            processor: TransactionsProcessor,
+            transactions: List[transaction_pb2.Transaction],
+        ):
+            threading.Thread.__init__(self)
+            self.processor = processor
+            self.transactions = transactions
+            self.processing_result = None
+            self.exception = None
+
+        def run(self):
+            start_version = self.transactions[0].version
+            end_version = self.transactions[-1].version
+
+            try:
+                self.processing_result = self.processor.process_transactions(
+                    self.transactions, start_version, end_version
+                )
+
+            except Exception as e:
+                print(
+                    f"[Processor worker] Error processing transactions from {start_version} to {end_version}: {e}"
+                )
+                self.exception = e
+
+    def run(self):
+        # Run DB migrations
+        print("[Parser] Initializing DB tables")
+        self.init_db_tables(self.processor.schema())
+        print("[Parser] DB tables initialized")
+
+        self.start_health_and_monitoring_ports()
+
+        # Get starting version from DB
+        starting_version = self.config.get_starting_version(self.processor.name())
+        if self.perf_transactions:
+            ending_version = starting_version + int(self.perf_transactions) - 1
+        else:
+            ending_version = self.config.ending_version
+
+        # Setup GRPC settings
+        metadata = (
+            ("x-aptos-data-authorization", self.config.grpc_data_stream_api_key),
+            ("x-aptos-request-name", self.processor.name()),
+        )
+        options = [
+            ("grpc.max_receive_message_length", -1),
+            (
+                "grpc.keepalive_time_ms",
+                self.config.indexer_grpc_http2_ping_interval_in_secs * 1000,
+            ),
+            (
+                "grpc.keepalive_timeout_ms",
+                self.config.indexer_grpc_http2_ping_timeout_in_secs * 1000,
+            ),
+        ]
+
+        perf_start_time = perf_counter()
+
+        # Connect to indexer grpc endpoint
+        with grpc.insecure_channel(
+            self.config.grpc_data_stream_endpoint, options=options
+        ) as channel:
+            print(
+                json.dumps(
+                    {
+                        "message": f"Connected to grpc data stream endpoint: {self.config.grpc_data_stream_endpoint}",
+                        "starting_version": starting_version,
+                    }
+                ),
+                flush=True,
+            )
+
+            batch_start_version = starting_version
+            batch_end_version = None
+            prev_processed_start_version = None
+            prev_processed_end_version = None
+
+            # Create GPRC request and get the responses
+            stub = raw_data_pb2_grpc.RawDataStub(channel)
+            request = raw_data_pb2.GetTransactionsRequest(
+                starting_version=batch_start_version
+            )
+            responses = stub.GetTransactions(request, metadata=metadata)
+            responses = iter(responses)
+
+            while True:
+                transaction_batches: List[List[transaction_pb2.Transaction]] = []
+
+                # Get batches of transactions for processing
+                for _ in range(self.num_concurrent_processing_tasks):
+                    response = next(responses)
+                    transactions = response.transactions
+
+                    current_batch_size = len(transactions)
+                    if current_batch_size == 0:
+                        print("[Parser] Received empty batch from GRPC stream")
+                        sys.exit(1)
+
+                    batch_start_version = transactions[0].version
+                    batch_end_version = transactions[-1].version
+
+                    # If ending version is in the current batch, truncate the transactions in this batcch
+                    if ending_version != None and batch_end_version >= ending_version:
+                        batch_end_version = ending_version
+                        transactions = transactions[
+                            : batch_end_version - batch_start_version + 1
+                        ]
+                        current_batch_size = len(transactions)
+
+                    transaction_batches.append(transactions)
+
+                    # If it is a partial batch, then skip polling and head to process it first.
+                    if current_batch_size < INDEXER_GRPC_BLOB_STORAGE_SIZE:
+                        break
+
+                # Process transactions in batches
+                threads: List[IndexerProcessorServer.WorkerThread] = []
+                for transactions in transaction_batches:
+                    thread = IndexerProcessorServer.WorkerThread(
+                        self.processor, transactions
+                    )
+                    threads.append(thread)
+                    thread.start()
+
+                # Wait for processor threads to finish
+                for thread in threads:
+                    thread.join()
+
+                # Update state depending on the results of the batch processing
+                processed_versions: List[ProcessingResult] = []
+                for thread in threads:
+                    exception = thread.exception
+
+                    # TODO: Log errors metric
+                    if thread.exception:
+                        print(
+                            json.dumps(
+                                {
+                                    "message": "[Parser] Error processing transaction batch",
+                                    "error": str(exception),
+                                }
+                            )
+                        )
+                        sys.exit(1)
+
+                    if thread.processing_result:
+                        processed_versions.append(thread.processing_result)
+
+                # Make sure there are no gaps and advance states
+                processed_versions.sort(key=lambda x: x.start_version)
+
+                for version in processed_versions:
+                    if prev_processed_start_version == None:
+                        if version.start_version != starting_version:
+                            print(
+                                json.dumps(
+                                    {
+                                        "message": "[Parser] Detected gap in processed transactions",
+                                        "error": f"Gap between transactions {starting_version} and {version.start_version}",
+                                    }
+                                )
+                            )
+                        prev_processed_start_version = version.start_version
+                        prev_processed_end_version = version.end_version
+                    else:
+                        assert prev_processed_end_version
+                        if prev_processed_end_version + 1 != version.start_version:
+                            print(
+                                json.dumps(
+                                    {
+                                        "message": "[Parser] Detected gap in processed transactions",
+                                        "error": f"Gap between transactions {prev_processed_end_version} and {version.start_version}",
+                                    }
+                                )
+                            )
+                            sys.exit(1)
+                        else:
+                            prev_processed_start_version = version.start_version
+                            prev_processed_end_version = version.end_version
+
+                batch_start = processed_versions[0].start_version
+                batch_end = processed_versions[-1].end_version
+
+                batch_start_version = batch_end + 1
+
+                # TODO: Update latest processed version metric
+                self.processor.update_last_processed_version(batch_end)
+
+                print(
+                    json.dumps(
+                        {
+                            "message": f"[Parser] Processed transactions {batch_start} to {batch_end}"
+                        }
+                    ),
+                    flush=True,
+                )
+
+                # Stop processing if reached ending version
+                if batch_end == ending_version:
+                    print(
+                        json.dumps(
+                            {
+                                "message": f"[Parser] Reached ending version {ending_version}. Exiting..."
+                            }
+                        ),
+                        flush=True,
+                    )
+                    break
+
+        perf_stop_time = perf_counter()
+        print(
+            f"Elapsed TPS: {int(self.perf_transactions) / (perf_stop_time - perf_start_time)}"
+        )
+
+    def init_db_tables(self, schema_name: str) -> None:
+        engine = create_engine(self.config.db_connection_uri)
+        engine = engine.execution_options(
+            schema_translate_map={"per_schema": schema_name}
+        )
+        Session.configure(bind=engine)
+        Base.metadata.create_all(engine, checkfirst=True)
+
+    def start_health_and_monitoring_ports(self) -> None:
+        # Start the Prometheus client; this is a non-blocking call.
+        start_http_server(self.config.health_port)
+
+        # Start the health server.
+        def start_health_server() -> None:
+            # The kubelet uses liveness probes to know when to restart a container. In cases where the
+            # container is crashing or unresponsive, the kubelet receives timeout or error responses, and then
+            # restarts the container. It polls every 10 seconds by default.
+            class Handler(http.server.SimpleHTTPRequestHandler):
+                def do_GET(self):
+                    self.send_response(http.HTTPStatus.OK)
+                    self.end_headers()
+                    self.wfile.write(b"OK")
+
+            server_address = ("", self.config.health_port)
+            httpd = socketserver.TCPServer(server_address, Handler)
+            httpd.serve_forever()
+
+        t = threading.Thread(target=start_health_server, daemon=True)
+        # TODO: Handles the exit signal and gracefully shutdown the server.
+        t.start()
+
+
+@event.listens_for(Base.metadata, "before_create")
+def create_schemas(target, connection, **kw):
+    schemas = set()
+    for table in target.tables.values():
+        if table.schema is not None:
+            schemas.add(table.schema)
+    for schema in schemas:
+        connection.execute(DDL("CREATE SCHEMA IF NOT EXISTS %s" % schema))
+
+
+@event.listens_for(Base.metadata, "after_drop")
+def drop_schemas(target, connection, **kw):
+    schemas = set()
+    for table in target.tables.values():
+        if table.schema is not None:
+            schemas.add(table.schema)
+    for schema in schemas:
+        connection.execute(DDL("DROP SCHEMA IF EXISTS %s" % schema))


### PR DESCRIPTION
* Move a lot of code from TransactionsProcessor to IndexerProcessorServer
* Add multithreading (doing it the same way that Rust does it) 
* I'll optimize db writes later

## Testing 
1. Locally ` poetry run python -m processors.nft_marketplace_v2.processor -c config.yaml`
2. Deployed the nft marketplace v2 processor, and now it's running faster than Rust processors
