### PR TITLE
[rust] hack to speed up processors again

### DIFF
--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -39,7 +39,8 @@ use tracing::{error, info};
 pub type PgPool = diesel::r2d2::Pool<ConnectionManager<PgConnection>>;
 pub type PgPoolConnection = PooledConnection<ConnectionManager<PgConnection>>;
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
-const BLOB_STORAGE_SIZE: usize = 1000;
+// const BLOB_STORAGE_SIZE: usize = 1000;
+const MIN_BLOB_SIZE: usize = 10;
 /// GRPC request metadata key for the token ID.
 const GRPC_AUTH_TOKEN_HEADER: &str = "x-aptos-data-authorization";
 /// GRPC request metadata key for the request name. This is used to identify the
@@ -290,8 +291,8 @@ impl Worker {
                     panic!();
                 }
                 transactions_batches.push(transactions);
-                // If it is a partial batch, then skip polling and head to process it first.
-                if current_batch_size < BLOB_STORAGE_SIZE {
+                // If it is a small batch, we assume we're at the head and break out of the loop.
+                if current_batch_size < MIN_BLOB_SIZE {
                     break;
                 }
             }


### PR DESCRIPTION
We added chunking to grpc data service which causes our processors to be very slow. The right thing to do is to rework this logic completely by adding a thread to exclusively fetch from grpc. This is a quick hack to get processors back to speed. 