### PR TITLE
Refer to tontine submodule by https not git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "python/processors/aptos-tontine"]
 	path = python/processors/aptos-tontine
-	url = git@github.com:banool/aptos-tontine.git
+	url = https://github.com/banool/aptos-tontine.git


### PR DESCRIPTION
Makes it possible to clone this repo with https. This was causing issues with building crates that depend on this repo.

Referring to the code by https is how we normally prefer to do it anyway for git submodules, I imagine for this reason.

Confirmed that this works by updating a project to rely on this branch instead.