### PR TITLE
[config] Adding a more descriptive error message when the processor name isn't set up correctly

### DIFF
--- a/python/utils/worker.py
+++ b/python/utils/worker.py
@@ -47,7 +47,12 @@ class IndexerProcessorServer:
             case ProcessorName.NFT_MARKETPLACE_V2_PROCESSOR.value:
                 self.processor = NFTMarketplaceV2Processor()
             case _:
-                raise Exception("Invalid processor name")
+                raise Exception(
+                    "Invalid processor name"
+                    "\n[ERROR]: The specified processor name was invalid or not found.\n"
+                    "         - If you are using a custom processor, make sure to add it to the ProcessorName enum in utils/processor_name.py.\n"
+                    "         - Ensure the IndexerProcessorServer constructor in utils/worker.py uses the new enum value.\n"
+                )
 
         self.processor.config = self.config
 


### PR DESCRIPTION
Added a more descriptive error for when the processor name isn't correctly configured:

```python
[Parser] Kicking off
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "~/indexer/python/processors/main.py", line 11, in <module>
    indexer_server = IndexerProcessorServer(
                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "~/indexer/python/utils/worker.py", line 50, in __init__
    raise Exception(
Exception: Invalid processor name
[ERROR]: The specified processor name was invalid or not found.
         - If you are using a custom processor, make sure to add it to the ProcessorName enum in utils/processor_name.py.
         - Ensure the IndexerProcessorServer constructor in utils/worker.py uses the new enum value.
```