### PR TITLE
Fix schema and clean up code

### DIFF
--- a/rust/processor/migrations/2023-08-12-190707_add_ans_is_primary/down.sql
+++ b/rust/processor/migrations/2023-08-12-190707_add_ans_is_primary/down.sql
@@ -1,6 +1,10 @@
-ALTER TABLE current_ans_lookup
-DROP COLUMN IF EXISTS is_deleted;
-
+ALTER TABLE current_ans_lookup DROP COLUMN IF EXISTS is_deleted;
+DROP INDEX IF EXISTS capn_tn_index;
+DROP INDEX IF EXISTS capn_insat_index;
+DROP INDEX IF EXISTS apn_tn_index;
+DROP INDEX IF EXISTS apn_insat_index;
+DROP INDEX IF EXISTS al_tn_index;
+DROP INDEX IF EXISTS al_insat_index;
 DROP TABLE IF EXISTS current_ans_primary_name;
 DROP TABLE IF EXISTS ans_primary_name;
 DROP TABLE IF EXISTS ans_lookup;

--- a/rust/processor/migrations/2023-08-12-190707_add_ans_is_primary/up.sql
+++ b/rust/processor/migrations/2023-08-12-190707_add_ans_is_primary/up.sql
@@ -1,47 +1,49 @@
 ALTER TABLE current_ans_lookup
 ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
-
+-- Tracks current primary name, deleted means that address no longer has a primary name
 CREATE TABLE IF NOT EXISTS current_ans_primary_name (
-    registered_address VARCHAR(66),
-    domain VARCHAR(64) NOT NULL,
-    -- if subdomain is null set to empty string
-    subdomain VARCHAR(64) NOT NULL,
-    token_name VARCHAR(140) NOT NULL,
-    is_primary BOOLEAN NOT NULL,
+    registered_address VARCHAR(66) UNIQUE PRIMARY KEY NOT NULL,
+    domain VARCHAR(64),
+    subdomain VARCHAR(64),
+    token_name VARCHAR(140),
+    is_deleted BOOLEAN NOT NULL,
     last_transaction_version BIGINT NOT NULL,
-    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    -- Constraints
-    -- We need domain and subdomain name in the PK to support soft deletes of primary name
-    PRIMARY KEY (registered_address, domain, subdomain)
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
-
+CREATE INDEX IF NOT EXISTS capn_tn_index on current_ans_primary_name (token_name);
+CREATE INDEX IF NOT EXISTS capn_insat_index on current_ans_primary_name (inserted_at);
+-- Tracks primary name, deleted means that address no longer has a primary name
 CREATE TABLE IF NOT EXISTS ans_primary_name (
     transaction_version BIGINT NOT NULL,
-    wsc_index BIGINT NOT NULL,
-    domain VARCHAR(64) NOT NULL,
-    -- if subdomain is null set to empty string
-    subdomain VARCHAR(64) NOT NULL,
-    registered_address VARCHAR(66),
-    token_name VARCHAR(140) NOT NULL,
-    is_primary BOOLEAN NOT NULL,
+    write_set_change_index BIGINT NOT NULL,
+    registered_address VARCHAR(66) NOT NULL,
+    domain VARCHAR(64),
+    subdomain VARCHAR(64),
+    token_name VARCHAR(140),
+    is_deleted BOOLEAN NOT NULL,
     inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
     -- Constraints 
-    -- Need registered_address, domain, subdomain in PK because multiple updates can happen in the same wsc
-    PRIMARY KEY (transaction_version, wsc_index, domain, subdomain)
+    PRIMARY KEY (
+        transaction_version,
+        write_set_change_index
+    )
 );
-
+CREATE INDEX IF NOT EXISTS apn_tn_index on ans_primary_name (token_name);
+CREATE INDEX IF NOT EXISTS apn_insat_index on ans_primary_name (inserted_at);
+-- Tracks full history of the ans records table
 CREATE TABLE IF NOT EXISTS ans_lookup (
     transaction_version BIGINT NOT NULL,
-    wsc_index BIGINT NOT NULL,
+    write_set_change_index BIGINT NOT NULL,
     domain VARCHAR(64) NOT NULL,
     -- if subdomain is null set to empty string
     subdomain VARCHAR(64) NOT NULL,
     registered_address VARCHAR(66),
     expiration_timestamp TIMESTAMP,
     token_name VARCHAR(140) NOT NULL,
-    is_primary BOOLEAN NOT NULL,
     is_deleted BOOLEAN NOT NULL,
     inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
     -- Constraints 
-    PRIMARY KEY (transaction_version, wsc_index)
+    PRIMARY KEY (transaction_version, write_set_change_index)
 );
+CREATE INDEX IF NOT EXISTS al_tn_index on ans_lookup (token_name);
+CREATE INDEX IF NOT EXISTS al_insat_index on ans_lookup (inserted_at);

--- a/rust/processor/src/models/ans_models/ans_lookup.rs
+++ b/rust/processor/src/models/ans_models/ans_lookup.rs
@@ -5,34 +5,22 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
+use super::ans_utils::AnsTableItem;
 use crate::{
     schema::{ans_lookup, ans_primary_name, current_ans_lookup, current_ans_primary_name},
-    utils::{
-        database::PgPoolConnection,
-        util::{
-            bigdecimal_to_u64, deserialize_from_string, parse_timestamp_secs, standardize_address,
-        },
-    },
+    utils::util::{get_name_from_unnested_move_type, standardize_address},
 };
 use aptos_indexer_protos::transaction::v1::{DeleteTableItem, WriteTableItem};
-use bigdecimal::BigDecimal;
 use diesel::prelude::*;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
-pub const QUERY_RETRIES: u32 = 5;
-pub const QUERY_RETRY_DELAY_MS: u64 = 500;
-
-pub type Address = String;
 pub type Domain = String;
 pub type Subdomain = String;
 // PK of current_ans_lookup, i.e. domain and subdomain name
 pub type CurrentAnsLookupPK = (Domain, Subdomain);
-// PK of current_ans_primary_names, i.e. address, domain, and subdomain name
-pub type CurrentAnsPrimaryNamePK = (Address, Domain, Subdomain);
-// PK of ans_lookup, i.e. transaction version, domain, and subdomain
-pub type AnsLookupPK = (i64, Domain, Subdomain);
+// PK of current_ans_primary_name, i.e. registered_address
+pub type CurrentAnsPrimaryNamePK = String;
 
 #[derive(Clone, Default, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(domain, subdomain))]
@@ -48,19 +36,13 @@ pub struct CurrentAnsLookup {
     pub is_deleted: bool,
 }
 
-impl CurrentAnsLookup {
-    pub fn pk(&self) -> CurrentAnsLookupPK {
-        (self.domain.clone(), self.subdomain.clone())
-    }
-}
-
 #[derive(Clone, Default, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
-#[diesel(primary_key(transaction_version, wsc_index))]
+#[diesel(primary_key(transaction_version, write_set_change_index))]
 #[diesel(table_name = ans_lookup)]
 #[diesel(treat_none_as_null = true)]
 pub struct AnsLookup {
     pub transaction_version: i64,
-    pub wsc_index: i64,
+    pub write_set_change_index: i64,
     pub domain: String,
     pub subdomain: String,
     pub registered_address: Option<String>,
@@ -75,425 +57,213 @@ pub struct AnsLookup {
 #[diesel(treat_none_as_null = true)]
 pub struct CurrentAnsPrimaryName {
     pub registered_address: String,
-    pub domain: String,
-    pub subdomain: String,
-    pub token_name: String,
-    pub is_primary: bool,
+    pub domain: Option<String>,
+    pub subdomain: Option<String>,
+    pub token_name: Option<String>,
+    pub is_deleted: bool,
     pub last_transaction_version: i64,
-}
-
-impl CurrentAnsPrimaryName {
-    pub fn pk(&self) -> CurrentAnsPrimaryNamePK {
-        (
-            self.registered_address.clone(),
-            self.domain.clone(),
-            self.subdomain.clone(),
-        )
-    }
-}
-
-/// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
-#[derive(Debug, Identifiable, Queryable)]
-#[diesel(primary_key(registered_address, domain, subdomain))]
-#[diesel(table_name = current_ans_primary_name)]
-pub struct CurrentAnsPrimaryNameDataQuery {
-    pub registered_address: String,
-    pub domain: String,
-    pub subdomain: String,
-    pub token_name: String,
-    pub is_primary: bool,
-    pub last_transaction_version: i64,
-    pub inserted_at: chrono::NaiveDateTime,
-}
-
-impl CurrentAnsPrimaryNameDataQuery {
-    pub fn get_name_record_by_primary_address(
-        conn: &mut PgPoolConnection,
-        registered_address: &str,
-    ) -> diesel::QueryResult<Self> {
-        current_ans_primary_name::table
-            .filter(current_ans_primary_name::registered_address.eq(registered_address))
-            .first::<Self>(conn)
-    }
 }
 
 #[derive(Clone, Default, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
-#[diesel(primary_key(transaction_version, wsc_index, domain, subdomain))]
+#[diesel(primary_key(transaction_version, write_set_change_index, domain, subdomain))]
 #[diesel(table_name = ans_primary_name)]
 #[diesel(treat_none_as_null = true)]
 pub struct AnsPrimaryName {
     pub transaction_version: i64,
-    pub wsc_index: i64,
-    pub domain: String,
-    pub subdomain: String,
+    pub write_set_change_index: i64,
     pub registered_address: String,
-    pub token_name: String,
-    pub is_primary: bool,
+    pub domain: Option<String>,
+    pub subdomain: Option<String>,
+    pub token_name: Option<String>,
+    pub is_deleted: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct OptionalString {
-    vec: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct NameRecordKeyV1 {
-    domain_name: String,
-    subdomain_name: OptionalString,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct NameRecordV1 {
-    #[serde(deserialize_with = "deserialize_from_string")]
-    expiration_time_sec: BigDecimal,
-    #[serde(deserialize_with = "deserialize_from_string")]
-    property_version: BigDecimal,
-    target_address: OptionalString,
-}
-
-impl OptionalString {
-    fn get_string(&self) -> Option<String> {
-        if self.vec.is_empty() {
-            None
-        } else {
-            Some(self.vec[0].clone())
+impl CurrentAnsLookup {
+    // Parse name record from write table item.
+    // The table key has the domain and subdomain.
+    // The table value data has the metadata (expiration, property version, target address).
+    pub fn parse_name_record_from_write_table_item_v1(
+        write_table_item: &WriteTableItem,
+        ans_name_records_table_handle: &Option<String>,
+        txn_version: i64,
+        write_set_change_index: i64,
+    ) -> anyhow::Result<Option<(Self, AnsLookup)>> {
+        let table_handle = write_table_item.handle.as_ref();
+        if table_handle != ans_name_records_table_handle.clone().unwrap_or_default() {
+            return Ok(None);
         }
-    }
-}
+        if let Some(data) = write_table_item.data.as_ref() {
+            // Get the name only, e.g. 0x1::domain::Name. This will return Name
+            let key_type_name = get_name_from_unnested_move_type(data.key_type.as_ref());
 
-impl NameRecordKeyV1 {
-    pub fn get_domain(&self) -> String {
-        self.domain_name.clone()
-    }
-
-    pub fn get_subdomain(&self) -> String {
-        self.subdomain_name.get_string().unwrap_or_default()
-    }
-
-    pub fn get_token_name(&self) -> String {
-        let domain = self.get_domain();
-        let subdomain = self.get_subdomain();
-        let mut token_name = format!("{}.apt", &domain);
-        if !subdomain.is_empty() {
-            token_name = format!("{}.{}", &subdomain, token_name);
+            if let Some(AnsTableItem::NameRecordKeyV1(name_record_key)) =
+                &AnsTableItem::from_table_item(key_type_name, &data.key, txn_version)?
+            {
+                let value_type_name = get_name_from_unnested_move_type(data.value_type.as_ref());
+                if let Some(AnsTableItem::NameRecordV1(name_record)) =
+                    &AnsTableItem::from_table_item(value_type_name, &data.value, txn_version)?
+                {
+                    return Ok(Some((
+                        Self {
+                            domain: name_record_key.get_domain_trunc(),
+                            subdomain: name_record_key.get_subdomain_trunc(),
+                            registered_address: name_record.get_target_address(),
+                            expiration_timestamp: name_record.get_expiration_time(),
+                            token_name: name_record_key.get_token_name(),
+                            last_transaction_version: txn_version,
+                            is_deleted: false,
+                        },
+                        AnsLookup {
+                            transaction_version: txn_version,
+                            write_set_change_index,
+                            domain: name_record_key.get_domain_trunc(),
+                            subdomain: name_record_key.get_subdomain_trunc(),
+                            registered_address: name_record.get_target_address(),
+                            expiration_timestamp: name_record.get_expiration_time(),
+                            token_name: name_record_key.get_token_name(),
+                            is_deleted: false,
+                        },
+                    )));
+                }
+            }
         }
-        token_name
-    }
-}
-
-impl NameRecordV1 {
-    pub fn get_expiration_time(&self) -> chrono::NaiveDateTime {
-        parse_timestamp_secs(bigdecimal_to_u64(&self.expiration_time_sec), 0)
+        Ok(None)
     }
 
-    pub fn get_property_version(&self) -> u64 {
-        bigdecimal_to_u64(&self.property_version)
-    }
-
-    pub fn get_target_address(&self) -> Option<String> {
-        let target_address = self.target_address.get_string().unwrap_or_default();
-        if !target_address.is_empty() {
-            Some(standardize_address(&target_address))
-        } else {
-            None
+    // Parse name record from delete table item.
+    // This change results in marking the domain name record as deleted and setting
+    // the rest of the fields to default values.
+    pub fn parse_name_record_from_delete_table_item_v1(
+        delete_table_item: &DeleteTableItem,
+        ans_name_records_table_handle: &Option<String>,
+        txn_version: i64,
+        write_set_change_index: i64,
+    ) -> anyhow::Result<Option<(Self, AnsLookup)>> {
+        let table_handle = delete_table_item.handle.as_ref();
+        if table_handle != ans_name_records_table_handle.clone().unwrap_or_default() {
+            return Ok(None);
         }
-    }
-}
+        if let Some(data) = delete_table_item.data.as_ref() {
+            let key_type_name = get_name_from_unnested_move_type(data.key_type.as_ref());
 
-// Parse the primary name reverse record from write table item.
-// The table key is the target address the primary name points to.
-// The table value data has the domain and subdomain of the primary name.
-// We also need to lookup which domain the address previoulsy pointed to,
-// so we can mark it as non-primary.
-pub fn parse_primary_name_record_from_write_table_item_v1(
-    write_table_item: &WriteTableItem,
-    txn_version: i64,
-    wsc_index: i64,
-    lookup_ans_primary_names: &HashMap<Address, CurrentAnsPrimaryName>,
-    conn: &mut PgPoolConnection,
-) -> anyhow::Result<(
-    CurrentAnsPrimaryName,         // New current primary name record
-    AnsPrimaryName,                // New primary name record
-    Option<CurrentAnsPrimaryName>, // Old current primary name record
-    Option<AnsPrimaryName>,        // Old primary name record
-)> {
-    let mut old_current_primary_name_record: Option<CurrentAnsPrimaryName> = None;
-    let mut old_primary_name_record: Option<AnsPrimaryName> = None;
-
-    let table_item_data = write_table_item.data.as_ref().unwrap();
-    let key: &str = serde_json::from_str(&table_item_data.key).unwrap_or_else(|e| {
-        tracing::error!(
-            transaction_version = txn_version,
-            data = table_item_data.key,
-            e = ?e,
-            "Failed to parse address from ANS reverse lookup table item",
-        );
-        panic!();
-    });
-    let registered_address = standardize_address(key);
-    let value = &table_item_data.value;
-    let primary_name_record: NameRecordKeyV1 = serde_json::from_str(value).unwrap_or_else(|e| {
-        tracing::error!(
-            transaction_version = txn_version,
-            data = value,
-            e = ?e,
-            "Failed to parse NameRecordKeyV1 from ANS reverse lookup table item",
-        );
-        panic!();
-    });
-
-    // Need to lookup old primary name record to update the row's is_primary = false
-    if let Some(lookup_primary_name_record) = match lookup_name_record_by_primary_address(
-        lookup_ans_primary_names,
-        &registered_address,
-        conn,
-    ) {
-        Some(ans_record) => Some(ans_record),
-        None => {
-            tracing::error!(
-                transaction_version = txn_version,
-                lookup_key = &registered_address,
-                "Failed to get ans record for registered address. You probably should backfill db."
-            );
-            None
-        },
-    } {
-        // Update the old primary name record with is_primary = false
-        old_current_primary_name_record = Some(CurrentAnsPrimaryName {
-            registered_address: registered_address.clone(),
-            domain: lookup_primary_name_record.domain.clone(),
-            subdomain: lookup_primary_name_record.subdomain.clone(),
-            token_name: lookup_primary_name_record.token_name.clone(),
-            is_primary: false,
-            last_transaction_version: txn_version,
-        });
-        old_primary_name_record = Some(AnsPrimaryName {
-            transaction_version: txn_version,
-            wsc_index,
-            registered_address: registered_address.clone(),
-            domain: lookup_primary_name_record.domain.clone(),
-            subdomain: lookup_primary_name_record.subdomain.clone(),
-            token_name: lookup_primary_name_record.token_name.clone(),
-            is_primary: false,
-        });
-    }
-
-    Ok((
-        CurrentAnsPrimaryName {
-            registered_address: registered_address.clone(),
-            domain: primary_name_record.get_domain().clone(),
-            subdomain: primary_name_record.get_subdomain().clone(),
-            token_name: primary_name_record.get_token_name(),
-            is_primary: true,
-            last_transaction_version: txn_version,
-        },
-        AnsPrimaryName {
-            transaction_version: txn_version,
-            wsc_index,
-            registered_address: registered_address.clone(),
-            domain: primary_name_record.get_domain().clone(),
-            subdomain: primary_name_record.get_subdomain().clone(),
-            token_name: primary_name_record.get_token_name(),
-            is_primary: true,
-        },
-        old_current_primary_name_record,
-        old_primary_name_record,
-    ))
-}
-
-// Parse primary name from delete table item
-// We need to lookup which domain the address points to so we can mark it as non-primary.
-pub fn parse_primary_name_record_from_delete_table_item_v1(
-    delete_table_item: &DeleteTableItem,
-    txn_version: i64,
-    wsc_index: i64,
-    lookup_ans_primary_names: &HashMap<Address, CurrentAnsPrimaryName>,
-    conn: &mut PgPoolConnection,
-) -> anyhow::Result<Option<(CurrentAnsPrimaryName, AnsPrimaryName)>> {
-    let table_item_data = delete_table_item.data.as_ref().unwrap();
-    let key = serde_json::from_str(&table_item_data.key).unwrap_or_else(|e| {
-        tracing::error!(
-            transaction_version = txn_version,
-            e = ?e,
-            "Failed to parse address from ANS reverse lookup table item",
-        );
-        panic!();
-    });
-    let registered_address = standardize_address(key);
-
-    // Need to lookup old primary name record to update the row's is_primary = false
-    if let Some(mut lookup_primary_name_record) = match lookup_name_record_by_primary_address(
-        lookup_ans_primary_names,
-        &registered_address,
-        conn,
-    ) {
-        Some(ans_record) => Some(ans_record),
-        None => {
-            tracing::error!(
-                transaction_version = txn_version,
-                lookup_key = &registered_address,
-                "Failed to get ans record for registered address. You probably should backfill db."
-            );
-            None
-        },
-    } {
-        // Update the old primary name record with is_primary = false
-        lookup_primary_name_record.is_primary = false;
-        lookup_primary_name_record.last_transaction_version = txn_version;
-        return Ok(Some((
-            CurrentAnsPrimaryName {
-                registered_address: registered_address.clone(),
-                domain: lookup_primary_name_record.domain.clone(),
-                subdomain: lookup_primary_name_record.subdomain.clone(),
-                token_name: lookup_primary_name_record.token_name.clone(),
-                is_primary: false,
-                last_transaction_version: txn_version,
-            },
-            AnsPrimaryName {
-                transaction_version: txn_version,
-                wsc_index,
-                registered_address: registered_address.clone(),
-                domain: lookup_primary_name_record.domain.clone(),
-                subdomain: lookup_primary_name_record.subdomain.clone(),
-                token_name: lookup_primary_name_record.token_name.clone(),
-                is_primary: false,
-            },
-        )));
-    }
-
-    Ok(None)
-}
-
-// Parse name record from write table item.
-// The table key has the domain and subdomain.
-// The table value data has the metadata (expiration, property version, target address).
-pub fn parse_name_record_from_write_table_item_v1(
-    write_table_item: &WriteTableItem,
-    txn_version: i64,
-    wsc_index: i64,
-) -> anyhow::Result<(CurrentAnsLookup, AnsLookup)> {
-    let table_item_data = write_table_item.data.as_ref().unwrap();
-    let name_record_key: NameRecordKeyV1 = serde_json::from_str(&table_item_data.key)
-        .unwrap_or_else(|e| {
-            tracing::error!(
-                transaction_version = txn_version,
-                e = ?e,
-                "Failed to parse NameRecordKeyV1 from ANS name record write table item",
-            );
-            panic!();
-        });
-    let name_record: NameRecordV1 =
-        serde_json::from_str(&table_item_data.value).unwrap_or_else(|e| {
-            tracing::error!(
-                transaction_version = txn_version,
-                e = ?e,
-                "Failed to parse NameRecordV1 from ANS name record write table item",
-            );
-            panic!();
-        });
-    Ok((
-        CurrentAnsLookup {
-            domain: name_record_key.get_domain(),
-            subdomain: name_record_key.get_subdomain(),
-            registered_address: name_record.get_target_address(),
-            last_transaction_version: txn_version,
-            expiration_timestamp: name_record.get_expiration_time(),
-            token_name: name_record_key.get_token_name(),
-            is_deleted: false,
-        },
-        AnsLookup {
-            transaction_version: txn_version,
-            wsc_index,
-            domain: name_record_key.get_domain(),
-            subdomain: name_record_key.get_subdomain(),
-            registered_address: name_record.get_target_address(),
-            expiration_timestamp: name_record.get_expiration_time(),
-            token_name: name_record_key.get_token_name(),
-            is_deleted: false,
-        },
-    ))
-}
-
-// Parse name record from delete table item.
-// This change results in marking the domain name record as deleted and setting
-// the rest of the fields to default values.
-pub fn parse_name_record_from_delete_table_item_v1(
-    delete_table_item: &DeleteTableItem,
-    txn_version: i64,
-    wsc_index: i64,
-) -> anyhow::Result<(CurrentAnsLookup, AnsLookup)> {
-    let table_item_data = delete_table_item.data.as_ref().unwrap();
-    let name_record_key: NameRecordKeyV1 = serde_json::from_str(&table_item_data.key)
-        .unwrap_or_else(|e| {
-            tracing::error!(
-                transaction_version = txn_version,
-                e = ?e,
-                "Failed to parse NameRecordKeyV1 from ANS name record delete table item",
-            );
-            panic!();
-        });
-    Ok((
-        CurrentAnsLookup {
-            domain: name_record_key.get_domain().clone(),
-            subdomain: name_record_key.get_subdomain().clone(),
-            registered_address: None,
-            last_transaction_version: txn_version,
-            // Default to zero
-            expiration_timestamp: chrono::NaiveDateTime::from_timestamp_opt(0, 0)
-                .unwrap_or_default(),
-            token_name: name_record_key.get_token_name(),
-            is_deleted: true,
-        },
-        AnsLookup {
-            transaction_version: txn_version,
-            wsc_index,
-            domain: name_record_key.get_domain(),
-            subdomain: name_record_key.get_subdomain(),
-            registered_address: None,
-            // Default to zero
-            expiration_timestamp: chrono::NaiveDateTime::from_timestamp_opt(0, 0)
-                .unwrap_or_default(),
-            token_name: name_record_key.get_token_name(),
-            is_deleted: true,
-        },
-    ))
-}
-
-fn lookup_name_record_by_primary_address(
-    lookup_ans_primary_names: &HashMap<Address, CurrentAnsPrimaryName>,
-    registered_address: &str,
-    conn: &mut PgPoolConnection,
-) -> Option<CurrentAnsPrimaryName> {
-    // Check if the current primary name record is in the current batch
-    let maybe_primary_name_record = lookup_ans_primary_names.get(&registered_address.to_string());
-
-    if let Some(primary_record) = maybe_primary_name_record {
-        return Some(primary_record.clone());
-    }
-
-    // If the primary name record is not in the current batch, then it was committed in a different
-    // transaction batch and we should lookup in DB.
-    let mut retried = 0;
-    while retried < QUERY_RETRIES {
-        retried += 1;
-        match CurrentAnsPrimaryNameDataQuery::get_name_record_by_primary_address(
-            conn,
-            registered_address,
-        ) {
-            Ok(ans_record) => {
-                return Some(CurrentAnsPrimaryName {
-                    registered_address: ans_record.registered_address,
-                    domain: ans_record.domain,
-                    subdomain: ans_record.subdomain,
-                    token_name: ans_record.token_name,
-                    is_primary: ans_record.is_primary,
-                    last_transaction_version: ans_record.last_transaction_version,
-                });
-            },
-            Err(_) => {
-                std::thread::sleep(std::time::Duration::from_millis(QUERY_RETRY_DELAY_MS));
-            },
+            if let Some(AnsTableItem::NameRecordKeyV1(name_record_key)) =
+                &AnsTableItem::from_table_item(key_type_name, &data.key, txn_version)?
+            {
+                return Ok(Some((
+                    Self {
+                        domain: name_record_key.get_domain_trunc(),
+                        subdomain: name_record_key.get_subdomain_trunc(),
+                        registered_address: None,
+                        expiration_timestamp: chrono::NaiveDateTime::default(),
+                        token_name: name_record_key.get_token_name(),
+                        last_transaction_version: txn_version,
+                        is_deleted: true,
+                    },
+                    AnsLookup {
+                        transaction_version: txn_version,
+                        write_set_change_index,
+                        domain: name_record_key.get_domain_trunc(),
+                        subdomain: name_record_key.get_subdomain_trunc(),
+                        registered_address: None,
+                        expiration_timestamp: chrono::NaiveDateTime::default(),
+                        token_name: name_record_key.get_token_name(),
+                        is_deleted: true,
+                    },
+                )));
+            }
         }
+        Ok(None)
     }
-    None
+}
+
+impl CurrentAnsPrimaryName {
+    // Parse the primary name reverse record from write table item.
+    // The table key is the target address the primary name points to.
+    // The table value data has the domain and subdomain of the primary name.
+    pub fn parse_primary_name_record_from_write_table_item_v1(
+        write_table_item: &WriteTableItem,
+        ans_primary_names_table_handle: &Option<String>,
+        txn_version: i64,
+        write_set_change_index: i64,
+    ) -> anyhow::Result<Option<(Self, AnsPrimaryName)>> {
+        let table_handle = write_table_item.handle.as_str();
+        if table_handle != ans_primary_names_table_handle.clone().unwrap_or_default() {
+            return Ok(None);
+        }
+        if let Some(data) = write_table_item.data.as_ref() {
+            // Return early if key is not address type. This should not be possible but just a precaution
+            // in case we input the wrong table handle
+            if data.key_type != "address" {
+                return Ok(None);
+            }
+            let registered_address = standardize_address(data.key.as_ref());
+            let value_type_name = get_name_from_unnested_move_type(data.value_type.as_ref());
+            if let Some(AnsTableItem::NameRecordKeyV1(name_record_key)) =
+                &AnsTableItem::from_table_item(value_type_name, &data.value, txn_version)?
+            {
+                return Ok(Some((
+                    Self {
+                        registered_address: registered_address.clone(),
+                        domain: Some(name_record_key.get_domain_trunc()),
+                        subdomain: Some(name_record_key.get_subdomain_trunc()),
+                        token_name: Some(name_record_key.get_token_name()),
+                        last_transaction_version: txn_version,
+                        is_deleted: false,
+                    },
+                    AnsPrimaryName {
+                        transaction_version: txn_version,
+                        write_set_change_index,
+                        registered_address,
+                        domain: Some(name_record_key.get_domain_trunc()),
+                        subdomain: Some(name_record_key.get_subdomain_trunc()),
+                        token_name: Some(name_record_key.get_token_name()),
+                        is_deleted: false,
+                    },
+                )));
+            }
+        }
+        Ok(None)
+    }
+
+    // Parse primary name from delete table item
+    // We need to lookup which domain the address points to so we can mark it as non-primary.
+    pub fn parse_primary_name_record_from_delete_table_item_v1(
+        delete_table_item: &DeleteTableItem,
+        ans_primary_names_table_handle: &Option<String>,
+        txn_version: i64,
+        write_set_change_index: i64,
+    ) -> anyhow::Result<Option<(Self, AnsPrimaryName)>> {
+        let table_handle = delete_table_item.handle.as_str();
+        if table_handle != ans_primary_names_table_handle.clone().unwrap_or_default() {
+            return Ok(None);
+        }
+        if let Some(data) = delete_table_item.data.as_ref() {
+            // Return early if key is not address type. This should not be possible but just a precaution
+            // in case we input the wrong table handle
+            if data.key_type != "address" {
+                return Ok(None);
+            }
+            let registered_address = standardize_address(data.key.as_ref());
+            return Ok(Some((
+                Self {
+                    registered_address: registered_address.clone(),
+                    domain: None,
+                    subdomain: None,
+                    token_name: None,
+                    last_transaction_version: txn_version,
+                    is_deleted: false,
+                },
+                AnsPrimaryName {
+                    transaction_version: txn_version,
+                    write_set_change_index,
+                    registered_address,
+                    domain: None,
+                    subdomain: None,
+                    token_name: None,
+                    is_deleted: false,
+                },
+            )));
+        }
+        Ok(None)
+    }
 }

--- a/rust/processor/src/models/ans_models/ans_utils.rs
+++ b/rust/processor/src/models/ans_models/ans_utils.rs
@@ -1,0 +1,116 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+
+use crate::utils::util::{
+    bigdecimal_to_u64, deserialize_from_string, parse_timestamp_secs, standardize_address,
+    truncate_str,
+};
+use anyhow::Context;
+use bigdecimal::BigDecimal;
+use serde::{Deserialize, Serialize};
+
+pub const DOMAIN_LENGTH: usize = 64;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NameRecordKeyV1 {
+    domain_name: String,
+    subdomain_name: OptionalString,
+}
+
+impl NameRecordKeyV1 {
+    pub fn get_domain_trunc(&self) -> String {
+        truncate_str(self.domain_name.as_str(), DOMAIN_LENGTH)
+    }
+
+    pub fn get_subdomain_trunc(&self) -> String {
+        truncate_str(
+            self.subdomain_name
+                .get_string()
+                .unwrap_or_default()
+                .as_str(),
+            DOMAIN_LENGTH,
+        )
+    }
+
+    pub fn get_token_name(&self) -> String {
+        let domain = self.get_domain_trunc();
+        let subdomain = self.get_subdomain_trunc();
+        let mut token_name = format!("{}.apt", &domain);
+        if !subdomain.is_empty() {
+            token_name = format!("{}.{}", &subdomain, token_name);
+        }
+        token_name
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NameRecordV1 {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    expiration_time_sec: BigDecimal,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    property_version: BigDecimal,
+    target_address: OptionalString,
+}
+
+impl NameRecordV1 {
+    pub fn get_expiration_time(&self) -> chrono::NaiveDateTime {
+        parse_timestamp_secs(bigdecimal_to_u64(&self.expiration_time_sec), 0)
+    }
+
+    pub fn get_property_version(&self) -> u64 {
+        bigdecimal_to_u64(&self.property_version)
+    }
+
+    pub fn get_target_address(&self) -> Option<String> {
+        self.target_address
+            .get_string()
+            .map(|addr| standardize_address(&addr))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct OptionalString {
+    vec: Vec<String>,
+}
+
+impl OptionalString {
+    fn get_string(&self) -> Option<String> {
+        if self.vec.is_empty() {
+            None
+        } else {
+            Some(self.vec[0].clone())
+        }
+    }
+}
+
+pub enum AnsTableItem {
+    NameRecordKeyV1(NameRecordKeyV1),
+    NameRecordV1(NameRecordV1),
+}
+
+impl AnsTableItem {
+    /// Matches based on the type name (last part of a full qualified type) instead of the fully qualified type
+    /// because we already know what the table handle is
+    pub fn from_table_item(
+        data_type_name: &str,
+        data: &str,
+        txn_version: i64,
+    ) -> anyhow::Result<Option<Self>> {
+        match data_type_name {
+            "NameRecordKeyV1" => {
+                serde_json::from_str(data).map(|inner| Some(Self::NameRecordKeyV1(inner)))
+            },
+            "NameRecordV1" => {
+                serde_json::from_str(data).map(|inner| Some(Self::NameRecordV1(inner)))
+            },
+            _ => Ok(None),
+        }
+        .context(format!(
+            "version {} failed! failed to parse type {}, data {:?}",
+            txn_version, data_type_name, data
+        ))
+    }
+}

--- a/rust/processor/src/models/ans_models/mod.rs
+++ b/rust/processor/src/models/ans_models/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod ans_lookup;
+pub mod ans_utils;

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -10,9 +10,9 @@ diesel::table! {
 }
 
 diesel::table! {
-    ans_lookup (transaction_version, wsc_index) {
+    ans_lookup (transaction_version, write_set_change_index) {
         transaction_version -> Int8,
-        wsc_index -> Int8,
+        write_set_change_index -> Int8,
         #[max_length = 64]
         domain -> Varchar,
         #[max_length = 64]
@@ -22,44 +22,24 @@ diesel::table! {
         expiration_timestamp -> Nullable<Timestamp>,
         #[max_length = 140]
         token_name -> Varchar,
-        is_primary -> Bool,
         is_deleted -> Bool,
         inserted_at -> Timestamp,
     }
 }
 
 diesel::table! {
-    ans_lookups (transaction_version, wsc_index) {
+    ans_primary_name (transaction_version, write_set_change_index) {
         transaction_version -> Int8,
-        wsc_index -> Int8,
-        #[max_length = 64]
-        domain -> Varchar,
-        #[max_length = 64]
-        subdomain -> Varchar,
+        write_set_change_index -> Int8,
         #[max_length = 66]
-        registered_address -> Nullable<Varchar>,
-        expiration_timestamp -> Nullable<Timestamp>,
+        registered_address -> Varchar,
+        #[max_length = 64]
+        domain -> Nullable<Varchar>,
+        #[max_length = 64]
+        subdomain -> Nullable<Varchar>,
         #[max_length = 140]
-        token_name -> Varchar,
-        is_primary -> Bool,
+        token_name -> Nullable<Varchar>,
         is_deleted -> Bool,
-        inserted_at -> Timestamp,
-    }
-}
-
-diesel::table! {
-    ans_primary_name (transaction_version, wsc_index, domain, subdomain) {
-        transaction_version -> Int8,
-        wsc_index -> Int8,
-        #[max_length = 64]
-        domain -> Varchar,
-        #[max_length = 64]
-        subdomain -> Varchar,
-        #[max_length = 66]
-        registered_address -> Nullable<Varchar>,
-        #[max_length = 140]
-        token_name -> Varchar,
-        is_primary -> Bool,
         inserted_at -> Timestamp,
     }
 }
@@ -223,22 +203,21 @@ diesel::table! {
         inserted_at -> Timestamp,
         #[max_length = 140]
         token_name -> Varchar,
-        is_primary -> Bool,
         is_deleted -> Bool,
     }
 }
 
 diesel::table! {
-    current_ans_primary_name (registered_address, domain, subdomain) {
+    current_ans_primary_name (registered_address) {
         #[max_length = 66]
         registered_address -> Varchar,
         #[max_length = 64]
-        domain -> Varchar,
+        domain -> Nullable<Varchar>,
         #[max_length = 64]
-        subdomain -> Varchar,
+        subdomain -> Nullable<Varchar>,
         #[max_length = 140]
-        token_name -> Varchar,
-        is_primary -> Bool,
+        token_name -> Nullable<Varchar>,
+        is_deleted -> Bool,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
     }
@@ -1094,7 +1073,6 @@ diesel::table! {
 diesel::allow_tables_to_appear_in_same_query!(
     account_transactions,
     ans_lookup,
-    ans_lookups,
     ans_primary_name,
     block_metadata_transactions,
     coin_activities,

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -398,6 +398,13 @@ pub fn time_diff_since_pb_timestamp_in_secs(timestamp: &Timestamp) -> f64 {
     current_timestamp - transaction_time
 }
 
+/// Get name from unwrapped move type
+/// E.g. 0x1::domain::Name will return Name
+pub fn get_name_from_unnested_move_type(move_type: &str) -> &str {
+    let t: Vec<&str> = move_type.split("::").collect();
+    t.last().unwrap()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Question: Should we rename the configs to v1? e.g. ans_primary_names_table_handle -> ans_v1_primary_names_table_handle

Main changes

* Logic can be simplified
  * No need for lookup if primary names table is keyed on address

* Fix typos
  * remove is_primary from ans_lookup tables
  * is_primary -> is_deleted in primary name tables

* Code structure
  * Extract non critical code to ans_utils
  * Moved the table handle checking logic in the functions themselves. It'll allow easier extensibility into v2 and it keeps the main processor flow decluttered. 