### PR TITLE
Partial voting review

### DIFF
--- a/rust/processor/migrations/2023-08-14-235438_add_current_delegated_voter_table/down.sql
+++ b/rust/processor/migrations/2023-08-14-235438_add_current_delegated_voter_table/down.sql
@@ -1,6 +1,7 @@
 -- This file should undo anything in `up.sql`
 DROP INDEX IF EXISTS cdv_da_index;
 DROP INDEX IF EXISTS cdv_v_index;
+DROP INDEX IF EXISTS cdv_th_index;
 DROP INDEX IF EXISTS cdv_pv_index;
 DROP INDEX IF EXISTS cdv_insat_index;
 DROP TABLE IF EXISTS current_delegated_voter;

--- a/rust/processor/migrations/2023-08-14-235438_add_current_delegated_voter_table/down.sql
+++ b/rust/processor/migrations/2023-08-14-235438_add_current_delegated_voter_table/down.sql
@@ -1,7 +1,6 @@
 -- This file should undo anything in `up.sql`
-DROP TABLE IF EXISTS current_delegated_voter;
-DROP INDEX IF EXISTS cdv_dpa_idx;
 DROP INDEX IF EXISTS cdv_da_index;
-DROP INDEX IF EXISTS cdv_th_index;
 DROP INDEX IF EXISTS cdv_v_index;
 DROP INDEX IF EXISTS cdv_pv_index;
+DROP INDEX IF EXISTS cdv_insat_index;
+DROP TABLE IF EXISTS current_delegated_voter;

--- a/rust/processor/migrations/2023-08-14-235438_add_current_delegated_voter_table/up.sql
+++ b/rust/processor/migrations/2023-08-14-235438_add_current_delegated_voter_table/up.sql
@@ -8,10 +8,10 @@ CREATE TABLE IF NOT EXISTS current_delegated_voter (
   pending_voter VARCHAR(66),
   last_transaction_version BIGINT NOT NULL,
   last_transaction_timestamp TIMESTAMP NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
   PRIMARY KEY (delegation_pool_address, delegator_address)
 );
-CREATE INDEX IF NOT EXISTS cdv_dpa_idx ON current_delegated_voter (delegation_pool_address);
 CREATE INDEX IF NOT EXISTS cdv_da_index ON current_delegated_voter (delegator_address);
-CREATE INDEX IF NOT EXISTS cdv_th_index ON current_delegated_voter (table_handle);
 CREATE INDEX IF NOT EXISTS cdv_v_index ON current_delegated_voter (voter);
 CREATE INDEX IF NOT EXISTS cdv_pv_index ON current_delegated_voter (pending_voter);
+CREATE INDEX IF NOT EXISTS cdv_insat_index ON current_delegated_voter (inserted_at);

--- a/rust/processor/migrations/2023-08-14-235438_add_current_delegated_voter_table/up.sql
+++ b/rust/processor/migrations/2023-08-14-235438_add_current_delegated_voter_table/up.sql
@@ -3,7 +3,7 @@
 CREATE TABLE IF NOT EXISTS current_delegated_voter (
   delegation_pool_address VARCHAR(66) NOT NULL,
   delegator_address VARCHAR(66) NOT NULL,
-  table_handle VARCHAR(66) NOT NULL,
+  table_handle VARCHAR(66),
   voter VARCHAR(66),
   pending_voter VARCHAR(66),
   last_transaction_version BIGINT NOT NULL,
@@ -13,5 +13,6 @@ CREATE TABLE IF NOT EXISTS current_delegated_voter (
 );
 CREATE INDEX IF NOT EXISTS cdv_da_index ON current_delegated_voter (delegator_address);
 CREATE INDEX IF NOT EXISTS cdv_v_index ON current_delegated_voter (voter);
+CREATE INDEX IF NOT EXISTS cdv_th_index ON current_delegated_voter (table_handle);
 CREATE INDEX IF NOT EXISTS cdv_pv_index ON current_delegated_voter (pending_voter);
 CREATE INDEX IF NOT EXISTS cdv_insat_index ON current_delegated_voter (inserted_at);

--- a/rust/processor/src/models/stake_models/current_delegated_voter.rs
+++ b/rust/processor/src/models/stake_models/current_delegated_voter.rs
@@ -5,22 +5,15 @@
 #![allow(clippy::extra_unused_lifetimes)]
 
 use super::{
-    delegator_balances::ShareToStakingPoolMapping,
-    delegator_pools::DelegatorPool,
-    stake_utils::{DelgationVoteGovernanceRecordsResource, VoteDelegationTableItem},
+    delegator_balances::{CurrentDelegatorBalance, ShareToStakingPoolMapping},
+    stake_utils::VoteDelegationTableItem,
 };
 use crate::{
     models::token_models::collection_datas::{QUERY_RETRIES, QUERY_RETRY_DELAY_MS},
     schema::current_delegated_voter,
-    utils::{
-        database::PgPoolConnection,
-        util::{parse_timestamp, standardize_address},
-    },
+    utils::{database::PgPoolConnection, util::standardize_address},
 };
-use aptos_indexer_protos::transaction::v1::{
-    transaction::TxnData, write_set_change::Change as WriteSetChange, Transaction as TransactionPB,
-    WriteResource, WriteTableItem,
-};
+use aptos_indexer_protos::transaction::v1::WriteTableItem;
 use diesel::{prelude::*, ExpressionMethods};
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
@@ -30,22 +23,23 @@ use std::collections::HashMap;
 #[diesel(primary_key(delegator_address, delegation_pool_address))]
 #[diesel(table_name = current_delegated_voter)]
 pub struct CurrentDelegatedVoterQuery {
-    pub delegator_address: String,
     pub delegation_pool_address: String,
-    pub table_handle: String,
+    pub delegator_address: String,
+    pub table_handle: Option<String>, // vote_delegation table handle
     pub voter: Option<String>,
     pub pending_voter: Option<String>,
     pub last_transaction_version: i64,
     pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub inserted_at: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, Eq, FieldCount, Identifiable, Insertable, PartialEq, Serialize)]
 #[diesel(primary_key(delegator_address, delegation_pool_address))]
 #[diesel(table_name = current_delegated_voter)]
 pub struct CurrentDelegatedVoter {
-    pub delegator_address: String,
     pub delegation_pool_address: String,
-    pub table_handle: String, // vote_delegation table handle
+    pub delegator_address: String,
+    pub table_handle: Option<String>, // vote_delegation table handle
     pub voter: Option<String>,
     pub pending_voter: Option<String>, // voter to be in the next lockup period
     pub last_transaction_version: i64,
@@ -53,222 +47,117 @@ pub struct CurrentDelegatedVoter {
 }
 
 // (delegation_pool_address, delegator_address)
-pub type CurrentDelegatedVoterPK = (String, String);
-
-pub type CurrentDelegatedVoterMap = HashMap<CurrentDelegatedVoterPK, CurrentDelegatedVoter>;
+type CurrentDelegatedVoterPK = (String, String);
+type CurrentDelegatedVoterMap = HashMap<CurrentDelegatedVoterPK, CurrentDelegatedVoter>;
 // table handle to delegation pool address mapping
-pub type VoteDelegationTableHandleToDelegationPoolAddress = HashMap<String, String>;
-// (optional voter, optional pending voter, table handle)
-pub type PKtoVoteDelegation =
-    HashMap<CurrentDelegatedVoterPK, (Option<String>, Option<String>, String)>;
+type VoteDelegationTableHandleToPool = HashMap<String, String>;
 
 impl CurrentDelegatedVoter {
-    pub fn from_transaction(
-        transaction: &TransactionPB,
+    pub fn pk(&self) -> CurrentDelegatedVoterPK {
+        (
+            self.delegation_pool_address.clone(),
+            self.delegator_address.clone(),
+        )
+    }
+
+    /// There are 3 pieces of information we need in order to get the delegated voters
+    /// 1. We need the mapping between pool address and table handle of the governance record. This will help us
+    /// figure out what the pool address it is
+    /// 2. We need to parse the governance record itself
+    /// 3. All active shares prior to governance contract need to be tracked as well, the default voters are the delegators themselves
+    pub fn from_write_table_item(
+        write_table_item: &WriteTableItem,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        vote_delegation_handle_to_pool_address: &VoteDelegationTableHandleToPool,
         conn: &mut PgPoolConnection,
-    ) -> anyhow::Result<CurrentDelegatedVoterMap> {
-        let mut current_delegated_voter_map: CurrentDelegatedVoterMap = HashMap::new();
-        let mut vote_delegation_handle_to_pool_address: VoteDelegationTableHandleToDelegationPoolAddress = HashMap::new();
-        let mut pk_to_vote_delegation: PKtoVoteDelegation = HashMap::new();
-        let mut active_pool_to_staking_pool: ShareToStakingPoolMapping = HashMap::new();
+    ) -> anyhow::Result<Option<Self>> {
+        let table_item_data = write_table_item.data.as_ref().unwrap();
+        let table_handle = standardize_address(&write_table_item.handle);
+        if let Some(VoteDelegationTableItem::VoteDelegationMap(inner)) =
+            VoteDelegationTableItem::from_table_item_type(
+                table_item_data.value_type.as_str(),
+                &table_item_data.value,
+                txn_version,
+            )?
+        {
+            let delegator_address = inner.get_delegator_address();
+            let voter = inner.value.get_voter();
+            let pending_voter = inner.value.get_pending_voter();
 
-        let txn_version = transaction.version as i64;
-        let txn_timestamp = parse_timestamp(transaction.timestamp.as_ref().unwrap(), txn_version);
-        let txn_data = transaction
-            .txn_data
-            .as_ref()
-            .expect("Txn Data doesn't exit!");
-
-        if let TxnData::User(_) = txn_data {
-            let transaction_info = transaction
-                .info
-                .as_ref()
-                .expect("Transaction info doesn't exist!");
-
-            // this write resource indexing is to get GovernanceRecords WR with the mapping of pool address to table handle
-            for wsc in &transaction_info.changes {
-                if let WriteSetChange::WriteResource(write_resource) = wsc.change.as_ref().unwrap()
-                {
-                    if let Some(DelgationVoteGovernanceRecordsResource::GovernanceRecords(inner)) =
-                        DelgationVoteGovernanceRecordsResource::from_write_resource(
-                            write_resource,
-                            txn_version,
-                        )?
-                    {
-                        let delegation_pool_address =
-                            standardize_address(&write_resource.address.to_string());
-                        let vote_delegation_handle =
-                            inner.vote_delegation.buckets.inner.get_handle();
-
-                        vote_delegation_handle_to_pool_address
-                            .insert(vote_delegation_handle, delegation_pool_address.clone());
-                    }
-                }
-            }
-
-            // this write table item indexing is to get delegator address, table handle, and voter & pending voter
-            for wsc in &transaction_info.changes {
-                if let WriteSetChange::WriteTableItem(write_table_item) =
-                    wsc.change.as_ref().unwrap()
-                {
-                    let table_item_data = write_table_item.data.as_ref().unwrap();
-                    let table_handle = &write_table_item.handle;
-                    if let Some(VoteDelegationTableItem::VoteDelegationMap(inner)) =
-                        VoteDelegationTableItem::from_table_item_type(
-                            table_item_data.value_type.as_str(),
-                            &table_item_data.value,
-                            txn_version,
-                        )?
-                    {
-                        let delegator_address = standardize_address(&inner.key);
-                        let voter = &inner.value.get_voter();
-                        let pending_voter = &inner.value.get_pending_voter();
-                        if let Some(maybe_delegation_pool_address) =
-                            vote_delegation_handle_to_pool_address.get(table_handle)
-                        {
-                            let current_delegated_voter = CurrentDelegatedVoter {
-                                delegator_address: delegator_address.clone(),
-                                delegation_pool_address: maybe_delegation_pool_address.clone(),
-                                voter: Some(voter.clone()),
-                                pending_voter: Some(pending_voter.clone()),
-                                last_transaction_timestamp: txn_timestamp,
-                                last_transaction_version: txn_version,
-                                table_handle: table_handle.clone(),
-                            };
-                            current_delegated_voter_map.insert(
-                                (
-                                    maybe_delegation_pool_address.clone(),
-                                    delegator_address.clone(),
-                                ),
-                                current_delegated_voter,
+            let pool_address = match vote_delegation_handle_to_pool_address.get(&table_handle) {
+                Some(pool_address) => pool_address.clone(),
+                None => {
+                    // look up from db
+                    Self::get_delegation_pool_address_by_table_handle(conn, &table_handle)
+                        .unwrap_or_else(|_| {
+                            tracing::error!(
+                                transaction_version = txn_version,
+                                lookup_key = &table_handle,
+                                "Missing pool address for table handle. You probably should backfill db.",
                             );
-                            pk_to_vote_delegation.insert(
-                                (
-                                    maybe_delegation_pool_address.clone(),
-                                    delegator_address.clone(),
-                                ),
-                                (
-                                    Some(voter.to_string()),
-                                    Some(pending_voter.to_string()),
-                                    table_handle.clone(),
-                                ),
-                            );
-                        } else {
-                            match Self::get_delegation_pool_address_by_table_handle(
-                                conn,
-                                table_handle,
-                            ) {
-                                Ok(delegation_pool_address_from_query_result) => {
-                                    let current_delegated_voter = CurrentDelegatedVoter {
-                                        delegator_address: delegator_address.clone(),
-                                        delegation_pool_address:
-                                            delegation_pool_address_from_query_result.clone(),
-                                        voter: Some(voter.clone()),
-                                        pending_voter: Some(pending_voter.clone()),
-                                        last_transaction_timestamp: txn_timestamp,
-                                        last_transaction_version: txn_version,
-                                        table_handle: table_handle.clone(),
-                                    };
-                                    current_delegated_voter_map.insert(
-                                        (
-                                            delegation_pool_address_from_query_result.clone(),
-                                            delegator_address.clone(),
-                                        ),
-                                        current_delegated_voter,
-                                    );
-                                    vote_delegation_handle_to_pool_address.insert(
-                                        table_handle.clone(),
-                                        delegation_pool_address_from_query_result.clone(),
-                                    );
-                                    pk_to_vote_delegation.insert(
-                                        (
-                                            delegation_pool_address_from_query_result.clone(),
-                                            delegator_address.clone(),
-                                        ),
-                                        (
-                                            Some(voter.to_string()),
-                                            Some(pending_voter.to_string()),
-                                            table_handle.clone(),
-                                        ),
-                                    );
-                                },
-                                Err(_) => {
-                                    tracing::error!(
-                                        transaction_version = txn_version,
-                                        lookup_key = &table_handle,
-                                        "Failed to get delegation pool address from vote delegation write table handle. You probably should backfill db.",
-                                    );
-                                },
-                            }
-                        }
-                    }
-                }
-            }
-
-            // this write resource indexing is to get active pool to DelegatorPoolBalanceMetadata mapping
-            // as a helper for us to get delegation pool address and delegator address from DelegationPool
-            // with the assumption that when delegator can delegate votes, they must have already staked
-            for wsc in &transaction.info.as_ref().unwrap().changes {
-                if let WriteSetChange::WriteResource(write_resource) = wsc.change.as_ref().unwrap()
-                {
-                    if let Some(map) =
-                        Self::get_active_pool_to_staking_pool_mapping(write_resource, txn_version)?
-                    {
-                        active_pool_to_staking_pool.extend(map);
-                    }
-                }
-            }
-
-            // this write table item indexing is to get delegation pool address and delegator address PK
-            // to cover the edge case where partial voting didn't exist in the pre vote delegation era
-            // where we try to get the PK and check against the DB to check for its existence
-            // if already there, don't overwrite, if not, try to get vote delegation info from mapping pk_to_vote_delegation
-            // if not found, return vote delegation fields as none
-            for wsc in &transaction.info.as_ref().unwrap().changes {
-                if let WriteSetChange::WriteTableItem(write_table_item) =
-                    wsc.change.as_ref().unwrap()
-                {
-                    if let Some(pk) = Self::get_pk_from_write_table_item(
-                        write_table_item,
-                        &active_pool_to_staking_pool,
-                    )? {
-                        if let Some((maybe_voter, maybe_pending_voter, table_handle)) =
-                            pk_to_vote_delegation.get(&pk)
-                        {
-                            match Self::get_existance_by_pk(conn, &pk.0, &pk.1) {
-                                Ok(pk_exist) => {
-                                    if pk_exist {
-                                        continue;
-                                    }
-
-                                    let new_current_delegated_voter = CurrentDelegatedVoter {
-                                        delegator_address: pk.1.clone(),
-                                        delegation_pool_address: pk.0.clone(),
-                                        voter: maybe_voter.clone(),
-                                        pending_voter: maybe_pending_voter.clone(),
-                                        last_transaction_timestamp: txn_timestamp,
-                                        last_transaction_version: txn_version,
-                                        table_handle: table_handle.clone(),
-                                    };
-
-                                    current_delegated_voter_map
-                                        .insert(pk, new_current_delegated_voter);
-                                },
-                                Err(_) => {
-                                    tracing::error!(
-                                        transaction_version = txn_version,
-                                        lookup_key = &table_handle,
-                                        "Failed to get row from PK.",
-                                    );
-                                },
-                            }
-                        }
-                    }
-                };
+                            return "".to_string();
+                        })
+                },
+            };
+            if !pool_address.is_empty() {
+                return Ok(Some(CurrentDelegatedVoter {
+                    delegator_address,
+                    delegation_pool_address: pool_address,
+                    voter: Some(voter),
+                    pending_voter: Some(pending_voter),
+                    last_transaction_timestamp: txn_timestamp,
+                    last_transaction_version: txn_version,
+                    table_handle: Some(table_handle),
+                }));
             }
         }
+        Ok(None)
+    }
 
-        Ok(current_delegated_voter_map)
+    /// For delegators that have delegated before the vote delegation contract deployment, we
+    /// need to mark them as default voters, but also be careful that we don't override the
+    /// new data
+    pub fn get_delegators_pre_contract_deployment(
+        write_table_item: &WriteTableItem,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        active_pool_to_staking_pool: &ShareToStakingPoolMapping,
+        previous_delegated_voters: &CurrentDelegatedVoterMap,
+        conn: &mut PgPoolConnection,
+    ) -> anyhow::Result<Option<Self>> {
+        if let Some(active_balance) =
+            CurrentDelegatorBalance::get_active_share_from_write_table_item(
+                write_table_item,
+                txn_version,
+                active_pool_to_staking_pool,
+            )?
+        {
+            let pool_address = active_balance.pool_address.clone();
+            let delegator_address = active_balance.delegator_address.clone();
+
+            let already_exists = match previous_delegated_voters
+                .get(&(pool_address.clone(), delegator_address.clone()))
+            {
+                Some(_) => true,
+                None => {
+                    // look up from db
+                    Self::get_existence_by_pk(conn, &delegator_address, &pool_address)
+                },
+            };
+            if !already_exists {
+                return Ok(Some(CurrentDelegatedVoter {
+                    delegator_address: delegator_address.clone(),
+                    delegation_pool_address: pool_address,
+                    table_handle: None,
+                    voter: Some(delegator_address.clone()),
+                    pending_voter: Some(delegator_address),
+                    last_transaction_version: txn_version,
+                    last_transaction_timestamp: txn_timestamp,
+                }));
+            }
+        }
+        Ok(None)
     }
 
     pub fn get_delegation_pool_address_by_table_handle(
@@ -292,58 +181,26 @@ impl CurrentDelegatedVoter {
         ))
     }
 
-    pub fn get_existance_by_pk(
+    pub fn get_existence_by_pk(
         conn: &mut PgPoolConnection,
-        delegation_pool_address: &str,
         delegator_address: &str,
-    ) -> anyhow::Result<bool> {
+        delegation_pool_address: &str,
+    ) -> bool {
         let mut retried = 0;
         while retried < QUERY_RETRIES {
             retried += 1;
             match CurrentDelegatedVoterQuery::get_by_pk(
                 conn,
-                delegation_pool_address,
                 delegator_address,
+                delegation_pool_address,
             ) {
-                Ok(_) => return Ok(true),
+                Ok(_) => return true,
                 Err(_) => {
                     std::thread::sleep(std::time::Duration::from_millis(QUERY_RETRY_DELAY_MS));
                 },
             }
         }
-        Ok(false)
-    }
-
-    pub fn get_active_pool_to_staking_pool_mapping(
-        write_resource: &WriteResource,
-        txn_version: i64,
-    ) -> anyhow::Result<Option<ShareToStakingPoolMapping>> {
-        if let Some(balance) = DelegatorPool::get_delegated_pool_metadata_from_write_resource(
-            write_resource,
-            txn_version,
-        )? {
-            Ok(Some(HashMap::from([(
-                balance.active_share_table_handle.clone(),
-                balance,
-            )])))
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub fn get_pk_from_write_table_item(
-        write_table_item: &WriteTableItem,
-        active_pool_to_staking_pool: &ShareToStakingPoolMapping,
-    ) -> anyhow::Result<Option<(String, String)>> {
-        let table_handle = standardize_address(&write_table_item.handle.to_string());
-        if let Some(pool_balance) = active_pool_to_staking_pool.get(&table_handle) {
-            let delegation_pool_address = pool_balance.staking_pool_address.clone();
-            let delegator_address = standardize_address(&write_table_item.key.to_string());
-
-            Ok(Some((delegation_pool_address, delegator_address)))
-        } else {
-            Ok(None)
-        }
+        false
     }
 }
 
@@ -359,12 +216,27 @@ impl CurrentDelegatedVoterQuery {
 
     pub fn get_by_pk(
         conn: &mut PgPoolConnection,
-        delegation_pool_address: &str,
         delegator_address: &str,
+        delegation_pool_address: &str,
     ) -> diesel::QueryResult<Self> {
         current_delegated_voter::table
-            .filter(current_delegated_voter::delegation_pool_address.eq(delegation_pool_address))
             .filter(current_delegated_voter::delegator_address.eq(delegator_address))
+            .filter(current_delegated_voter::delegation_pool_address.eq(delegation_pool_address))
             .first::<Self>(conn)
+    }
+}
+
+impl Ord for CurrentDelegatedVoter {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.delegator_address.cmp(&other.delegator_address).then(
+            self.delegation_pool_address
+                .cmp(&other.delegation_pool_address),
+        )
+    }
+}
+
+impl PartialOrd for CurrentDelegatedVoter {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }

--- a/rust/processor/src/models/stake_models/stake_utils.rs
+++ b/rust/processor/src/models/stake_models/stake_utils.rs
@@ -228,9 +228,14 @@ pub enum VoteDelegationTableItem {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct VoteDelegationMap {
-    pub hash: String,
-    pub key: String,
+    key: String,
     pub value: VoteDelegationResource,
+}
+
+impl VoteDelegationMap {
+    pub fn get_delegator_address(&self) -> String {
+        standardize_address(&self.key)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -287,11 +292,11 @@ pub struct VoteDelegationInnerResource {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum DelgationVoteGovernanceRecordsResource {
+pub enum DelegationVoteGovernanceRecordsResource {
     GovernanceRecords(GovernanceRecordsResource),
 }
 
-impl DelgationVoteGovernanceRecordsResource {
+impl DelegationVoteGovernanceRecordsResource {
     pub fn from_resource(
         data_type: &str,
         data: &serde_json::Value,
@@ -300,7 +305,7 @@ impl DelgationVoteGovernanceRecordsResource {
         match data_type {
             x if x == format!("{}::delegation_pool::GovernanceRecords", STAKE_ADDR) => {
                 serde_json::from_value(data.clone()).map(|inner| {
-                    Some(DelgationVoteGovernanceRecordsResource::GovernanceRecords(
+                    Some(DelegationVoteGovernanceRecordsResource::GovernanceRecords(
                         inner,
                     ))
                 })

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -3,6 +3,7 @@
 diesel::table! {
     account_transactions (account_address, transaction_version) {
         transaction_version -> Int8,
+        #[max_length = 66]
         account_address -> Varchar,
         inserted_at -> Timestamp,
     }
@@ -12,10 +13,12 @@ diesel::table! {
     block_metadata_transactions (version) {
         version -> Int8,
         block_height -> Int8,
+        #[max_length = 66]
         id -> Varchar,
         round -> Int8,
         epoch -> Int8,
         previous_block_votes_bitvec -> Jsonb,
+        #[max_length = 66]
         proposer -> Varchar,
         failed_proposer_indices -> Jsonb,
         timestamp -> Timestamp,
@@ -26,20 +29,26 @@ diesel::table! {
 diesel::table! {
     coin_activities (transaction_version, event_account_address, event_creation_number, event_sequence_number) {
         transaction_version -> Int8,
+        #[max_length = 66]
         event_account_address -> Varchar,
         event_creation_number -> Int8,
         event_sequence_number -> Int8,
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 5000]
         coin_type -> Varchar,
         amount -> Numeric,
+        #[max_length = 200]
         activity_type -> Varchar,
         is_gas_fee -> Bool,
         is_transaction_success -> Bool,
+        #[max_length = 1000]
         entry_function_id_str -> Nullable<Varchar>,
         block_height -> Int8,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
         event_index -> Nullable<Int8>,
+        #[max_length = 66]
         gas_fee_payer_address -> Nullable<Varchar>,
     }
 }
@@ -47,8 +56,11 @@ diesel::table! {
 diesel::table! {
     coin_balances (transaction_version, owner_address, coin_type_hash) {
         transaction_version -> Int8,
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 64]
         coin_type_hash -> Varchar,
+        #[max_length = 5000]
         coin_type -> Varchar,
         amount -> Numeric,
         transaction_timestamp -> Timestamp,
@@ -58,15 +70,21 @@ diesel::table! {
 
 diesel::table! {
     coin_infos (coin_type_hash) {
+        #[max_length = 64]
         coin_type_hash -> Varchar,
+        #[max_length = 5000]
         coin_type -> Varchar,
         transaction_version_created -> Int8,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 32]
         name -> Varchar,
+        #[max_length = 10]
         symbol -> Varchar,
         decimals -> Int4,
         transaction_created_timestamp -> Timestamp,
         inserted_at -> Timestamp,
+        #[max_length = 66]
         supply_aggregator_table_handle -> Nullable<Varchar>,
         supply_aggregator_table_key -> Nullable<Text>,
     }
@@ -75,7 +93,9 @@ diesel::table! {
 diesel::table! {
     coin_supply (transaction_version, coin_type_hash) {
         transaction_version -> Int8,
+        #[max_length = 64]
         coin_type_hash -> Varchar,
+        #[max_length = 5000]
         coin_type -> Varchar,
         supply -> Numeric,
         transaction_timestamp -> Timestamp,
@@ -86,11 +106,15 @@ diesel::table! {
 
 diesel::table! {
     collection_datas (collection_data_id_hash, transaction_version) {
+        #[max_length = 64]
         collection_data_id_hash -> Varchar,
         transaction_version -> Int8,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
         description -> Text,
+        #[max_length = 512]
         metadata_uri -> Varchar,
         supply -> Numeric,
         maximum -> Numeric,
@@ -98,6 +122,7 @@ diesel::table! {
         uri_mutable -> Bool,
         description_mutable -> Bool,
         inserted_at -> Timestamp,
+        #[max_length = 66]
         table_handle -> Varchar,
         transaction_timestamp -> Timestamp,
     }
@@ -107,17 +132,23 @@ diesel::table! {
     collections_v2 (transaction_version, write_set_change_index) {
         transaction_version -> Int8,
         write_set_change_index -> Int8,
+        #[max_length = 66]
         collection_id -> Varchar,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
         description -> Text,
+        #[max_length = 512]
         uri -> Varchar,
         current_supply -> Numeric,
         max_supply -> Nullable<Numeric>,
         total_minted_v2 -> Nullable<Numeric>,
         mutable_description -> Nullable<Bool>,
         mutable_uri -> Nullable<Bool>,
+        #[max_length = 66]
         table_handle_v1 -> Nullable<Varchar>,
+        #[max_length = 10]
         token_standard -> Varchar,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
@@ -126,20 +157,27 @@ diesel::table! {
 
 diesel::table! {
     current_ans_lookup (domain, subdomain) {
+        #[max_length = 64]
         domain -> Varchar,
+        #[max_length = 64]
         subdomain -> Varchar,
+        #[max_length = 66]
         registered_address -> Nullable<Varchar>,
         expiration_timestamp -> Timestamp,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        #[max_length = 140]
         token_name -> Varchar,
     }
 }
 
 diesel::table! {
     current_coin_balances (owner_address, coin_type_hash) {
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 64]
         coin_type_hash -> Varchar,
+        #[max_length = 5000]
         coin_type -> Varchar,
         amount -> Numeric,
         last_transaction_version -> Int8,
@@ -150,10 +188,14 @@ diesel::table! {
 
 diesel::table! {
     current_collection_datas (collection_data_id_hash) {
+        #[max_length = 64]
         collection_data_id_hash -> Varchar,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
         description -> Text,
+        #[max_length = 512]
         metadata_uri -> Varchar,
         supply -> Numeric,
         maximum -> Numeric,
@@ -162,6 +204,7 @@ diesel::table! {
         description_mutable -> Bool,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        #[max_length = 66]
         table_handle -> Varchar,
         last_transaction_timestamp -> Timestamp,
     }
@@ -169,17 +212,23 @@ diesel::table! {
 
 diesel::table! {
     current_collections_v2 (collection_id) {
+        #[max_length = 66]
         collection_id -> Varchar,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
         description -> Text,
+        #[max_length = 512]
         uri -> Varchar,
         current_supply -> Numeric,
         max_supply -> Nullable<Numeric>,
         total_minted_v2 -> Nullable<Numeric>,
         mutable_description -> Nullable<Bool>,
         mutable_uri -> Nullable<Bool>,
+        #[max_length = 66]
         table_handle_v1 -> Nullable<Varchar>,
+        #[max_length = 10]
         token_standard -> Varchar,
         last_transaction_version -> Int8,
         last_transaction_timestamp -> Timestamp,
@@ -189,52 +238,70 @@ diesel::table! {
 
 diesel::table! {
     current_delegated_staking_pool_balances (staking_pool_address) {
+        #[max_length = 66]
         staking_pool_address -> Varchar,
         total_coins -> Numeric,
         total_shares -> Numeric,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
         operator_commission_percentage -> Numeric,
+        #[max_length = 66]
         inactive_table_handle -> Varchar,
+        #[max_length = 66]
         active_table_handle -> Varchar,
     }
 }
 
 diesel::table! {
     current_delegated_voter (delegation_pool_address, delegator_address) {
+        #[max_length = 66]
         delegation_pool_address -> Varchar,
+        #[max_length = 66]
         delegator_address -> Varchar,
+        #[max_length = 66]
         table_handle -> Varchar,
+        #[max_length = 66]
         voter -> Nullable<Varchar>,
+        #[max_length = 66]
         pending_voter -> Nullable<Varchar>,
         last_transaction_version -> Int8,
         last_transaction_timestamp -> Timestamp,
+        inserted_at -> Timestamp,
     }
 }
 
 diesel::table! {
     current_delegator_balances (delegator_address, pool_address, pool_type, table_handle) {
+        #[max_length = 66]
         delegator_address -> Varchar,
+        #[max_length = 66]
         pool_address -> Varchar,
+        #[max_length = 100]
         pool_type -> Varchar,
+        #[max_length = 66]
         table_handle -> Varchar,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
         shares -> Numeric,
+        #[max_length = 66]
         parent_table_handle -> Varchar,
     }
 }
 
 diesel::table! {
     current_fungible_asset_balances (storage_id) {
+        #[max_length = 66]
         storage_id -> Varchar,
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 1000]
         asset_type -> Varchar,
         is_primary -> Bool,
         is_frozen -> Bool,
         amount -> Numeric,
         last_transaction_timestamp -> Timestamp,
         last_transaction_version -> Int8,
+        #[max_length = 10]
         token_standard -> Varchar,
         inserted_at -> Timestamp,
     }
@@ -242,8 +309,11 @@ diesel::table! {
 
 diesel::table! {
     current_objects (object_address) {
+        #[max_length = 66]
         object_address -> Varchar,
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 66]
         state_key_hash -> Varchar,
         allow_ungated_transfer -> Bool,
         last_guid_creation_num -> Numeric,
@@ -255,17 +325,22 @@ diesel::table! {
 
 diesel::table! {
     current_staking_pool_voter (staking_pool_address) {
+        #[max_length = 66]
         staking_pool_address -> Varchar,
+        #[max_length = 66]
         voter_address -> Varchar,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        #[max_length = 66]
         operator_address -> Varchar,
     }
 }
 
 diesel::table! {
     current_table_items (table_handle, key_hash) {
+        #[max_length = 66]
         table_handle -> Varchar,
+        #[max_length = 64]
         key_hash -> Varchar,
         key -> Text,
         decoded_key -> Jsonb,
@@ -278,14 +353,20 @@ diesel::table! {
 
 diesel::table! {
     current_token_datas (token_data_id_hash) {
+        #[max_length = 64]
         token_data_id_hash -> Varchar,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
+        #[max_length = 128]
         name -> Varchar,
         maximum -> Numeric,
         supply -> Numeric,
         largest_property_version -> Numeric,
+        #[max_length = 512]
         metadata_uri -> Varchar,
+        #[max_length = 66]
         payee_address -> Varchar,
         royalty_points_numerator -> Numeric,
         royalty_points_denominator -> Numeric,
@@ -297,6 +378,7 @@ diesel::table! {
         default_properties -> Jsonb,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        #[max_length = 64]
         collection_data_id_hash -> Varchar,
         last_transaction_timestamp -> Timestamp,
         description -> Text,
@@ -305,15 +387,20 @@ diesel::table! {
 
 diesel::table! {
     current_token_datas_v2 (token_data_id) {
+        #[max_length = 66]
         token_data_id -> Varchar,
+        #[max_length = 66]
         collection_id -> Varchar,
+        #[max_length = 128]
         token_name -> Varchar,
         maximum -> Nullable<Numeric>,
         supply -> Numeric,
         largest_property_version_v1 -> Nullable<Numeric>,
+        #[max_length = 512]
         token_uri -> Varchar,
         description -> Text,
         token_properties -> Jsonb,
+        #[max_length = 10]
         token_standard -> Varchar,
         is_fungible_v2 -> Nullable<Bool>,
         last_transaction_version -> Int8,
@@ -325,16 +412,22 @@ diesel::table! {
 
 diesel::table! {
     current_token_ownerships (token_data_id_hash, property_version, owner_address) {
+        #[max_length = 64]
         token_data_id_hash -> Varchar,
         property_version -> Numeric,
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
+        #[max_length = 128]
         name -> Varchar,
         amount -> Numeric,
         token_properties -> Jsonb,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        #[max_length = 64]
         collection_data_id_hash -> Varchar,
         table_type -> Text,
         last_transaction_timestamp -> Timestamp,
@@ -343,14 +436,19 @@ diesel::table! {
 
 diesel::table! {
     current_token_ownerships_v2 (token_data_id, property_version_v1, owner_address, storage_id) {
+        #[max_length = 66]
         token_data_id -> Varchar,
         property_version_v1 -> Numeric,
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 66]
         storage_id -> Varchar,
         amount -> Numeric,
+        #[max_length = 66]
         table_type_v1 -> Nullable<Varchar>,
         token_properties_mutated_v1 -> Nullable<Jsonb>,
         is_soulbound_v2 -> Nullable<Bool>,
+        #[max_length = 10]
         token_standard -> Varchar,
         is_fungible_v2 -> Nullable<Bool>,
         last_transaction_version -> Int8,
@@ -362,29 +460,42 @@ diesel::table! {
 
 diesel::table! {
     current_token_pending_claims (token_data_id_hash, property_version, from_address, to_address) {
+        #[max_length = 64]
         token_data_id_hash -> Varchar,
         property_version -> Numeric,
+        #[max_length = 66]
         from_address -> Varchar,
+        #[max_length = 66]
         to_address -> Varchar,
+        #[max_length = 64]
         collection_data_id_hash -> Varchar,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
+        #[max_length = 128]
         name -> Varchar,
         amount -> Numeric,
+        #[max_length = 66]
         table_handle -> Varchar,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
         last_transaction_timestamp -> Timestamp,
+        #[max_length = 66]
         token_data_id -> Varchar,
+        #[max_length = 66]
         collection_id -> Varchar,
     }
 }
 
 diesel::table! {
     current_token_v2_metadata (object_address, resource_type) {
+        #[max_length = 66]
         object_address -> Varchar,
+        #[max_length = 128]
         resource_type -> Varchar,
         data -> Jsonb,
+        #[max_length = 66]
         state_key_hash -> Varchar,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
@@ -395,7 +506,9 @@ diesel::table! {
     delegated_staking_activities (transaction_version, event_index) {
         transaction_version -> Int8,
         event_index -> Int8,
+        #[max_length = 66]
         delegator_address -> Varchar,
+        #[max_length = 66]
         pool_address -> Varchar,
         event_type -> Text,
         amount -> Numeric,
@@ -406,18 +519,22 @@ diesel::table! {
 diesel::table! {
     delegated_staking_pool_balances (transaction_version, staking_pool_address) {
         transaction_version -> Int8,
+        #[max_length = 66]
         staking_pool_address -> Varchar,
         total_coins -> Numeric,
         total_shares -> Numeric,
         inserted_at -> Timestamp,
         operator_commission_percentage -> Numeric,
+        #[max_length = 66]
         inactive_table_handle -> Varchar,
+        #[max_length = 66]
         active_table_handle -> Varchar,
     }
 }
 
 diesel::table! {
     delegated_staking_pools (staking_pool_address) {
+        #[max_length = 66]
         staking_pool_address -> Varchar,
         first_transaction_version -> Int8,
         inserted_at -> Timestamp,
@@ -428,6 +545,7 @@ diesel::table! {
     events (account_address, creation_number, sequence_number) {
         sequence_number -> Int8,
         creation_number -> Int8,
+        #[max_length = 66]
         account_address -> Varchar,
         transaction_version -> Int8,
         transaction_block_height -> Int8,
@@ -443,18 +561,24 @@ diesel::table! {
     fungible_asset_activities (transaction_version, event_index) {
         transaction_version -> Int8,
         event_index -> Int8,
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 66]
         storage_id -> Varchar,
+        #[max_length = 1000]
         asset_type -> Varchar,
         is_frozen -> Nullable<Bool>,
         amount -> Nullable<Numeric>,
         #[sql_name = "type"]
         type_ -> Varchar,
         is_gas_fee -> Bool,
+        #[max_length = 66]
         gas_fee_payer_address -> Nullable<Varchar>,
         is_transaction_success -> Bool,
+        #[max_length = 1000]
         entry_function_id_str -> Nullable<Varchar>,
         block_height -> Int8,
+        #[max_length = 10]
         token_standard -> Varchar,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
@@ -465,13 +589,17 @@ diesel::table! {
     fungible_asset_balances (transaction_version, write_set_change_index) {
         transaction_version -> Int8,
         write_set_change_index -> Int8,
+        #[max_length = 66]
         storage_id -> Varchar,
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 1000]
         asset_type -> Varchar,
         is_primary -> Bool,
         is_frozen -> Bool,
         amount -> Numeric,
         transaction_timestamp -> Timestamp,
+        #[max_length = 10]
         token_standard -> Varchar,
         inserted_at -> Timestamp,
     }
@@ -479,17 +607,25 @@ diesel::table! {
 
 diesel::table! {
     fungible_asset_metadata (asset_type) {
+        #[max_length = 1000]
         asset_type -> Varchar,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 32]
         name -> Varchar,
+        #[max_length = 10]
         symbol -> Varchar,
         decimals -> Int4,
+        #[max_length = 512]
         icon_uri -> Nullable<Varchar>,
+        #[max_length = 512]
         project_uri -> Nullable<Varchar>,
         last_transaction_version -> Int8,
         last_transaction_timestamp -> Timestamp,
+        #[max_length = 66]
         supply_aggregator_table_handle_v1 -> Nullable<Varchar>,
         supply_aggregator_table_key_v1 -> Nullable<Text>,
+        #[max_length = 10]
         token_standard -> Varchar,
         inserted_at -> Timestamp,
     }
@@ -497,6 +633,7 @@ diesel::table! {
 
 diesel::table! {
     indexer_status (db) {
+        #[max_length = 50]
         db -> Varchar,
         is_indexer_up -> Bool,
         inserted_at -> Timestamp,
@@ -515,6 +652,7 @@ diesel::table! {
         write_set_change_index -> Int8,
         transaction_block_height -> Int8,
         name -> Text,
+        #[max_length = 66]
         address -> Varchar,
         bytecode -> Nullable<Bytea>,
         friends -> Nullable<Jsonb>,
@@ -531,6 +669,7 @@ diesel::table! {
         write_set_change_index -> Int8,
         transaction_block_height -> Int8,
         name -> Text,
+        #[max_length = 66]
         address -> Varchar,
         #[sql_name = "type"]
         type_ -> Text,
@@ -539,6 +678,7 @@ diesel::table! {
         data -> Nullable<Jsonb>,
         is_deleted -> Bool,
         inserted_at -> Timestamp,
+        #[max_length = 66]
         state_key_hash -> Varchar,
     }
 }
@@ -546,6 +686,7 @@ diesel::table! {
 diesel::table! {
     nft_points (transaction_version) {
         transaction_version -> Int8,
+        #[max_length = 66]
         owner_address -> Varchar,
         token_name -> Text,
         point_type -> Text,
@@ -559,8 +700,11 @@ diesel::table! {
     objects (transaction_version, write_set_change_index) {
         transaction_version -> Int8,
         write_set_change_index -> Int8,
+        #[max_length = 66]
         object_address -> Varchar,
+        #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 66]
         state_key_hash -> Varchar,
         guid_creation_num -> Numeric,
         allow_ungated_transfer -> Bool,
@@ -571,6 +715,7 @@ diesel::table! {
 
 diesel::table! {
     processor_status (processor) {
+        #[max_length = 50]
         processor -> Varchar,
         last_success_version -> Int8,
         last_updated -> Timestamp,
@@ -581,7 +726,9 @@ diesel::table! {
     proposal_votes (transaction_version, proposal_id, voter_address) {
         transaction_version -> Int8,
         proposal_id -> Int8,
+        #[max_length = 66]
         voter_address -> Varchar,
+        #[max_length = 66]
         staking_pool_address -> Varchar,
         num_votes -> Numeric,
         should_pass -> Bool,
@@ -596,11 +743,14 @@ diesel::table! {
         multi_agent_index -> Int8,
         multi_sig_index -> Int8,
         transaction_block_height -> Int8,
+        #[max_length = 66]
         signer -> Varchar,
         is_sender_primary -> Bool,
         #[sql_name = "type"]
         type_ -> Varchar,
+        #[max_length = 66]
         public_key -> Varchar,
+        #[max_length = 200]
         signature -> Varchar,
         threshold -> Int8,
         public_key_indices -> Jsonb,
@@ -614,6 +764,7 @@ diesel::table! {
         transaction_version -> Int8,
         write_set_change_index -> Int8,
         transaction_block_height -> Int8,
+        #[max_length = 66]
         table_handle -> Varchar,
         decoded_key -> Jsonb,
         decoded_value -> Nullable<Jsonb>,
@@ -624,6 +775,7 @@ diesel::table! {
 
 diesel::table! {
     table_metadatas (handle) {
+        #[max_length = 66]
         handle -> Varchar,
         key_type -> Text,
         value_type -> Text,
@@ -634,17 +786,26 @@ diesel::table! {
 diesel::table! {
     token_activities (transaction_version, event_account_address, event_creation_number, event_sequence_number) {
         transaction_version -> Int8,
+        #[max_length = 66]
         event_account_address -> Varchar,
         event_creation_number -> Int8,
         event_sequence_number -> Int8,
+        #[max_length = 64]
         collection_data_id_hash -> Varchar,
+        #[max_length = 64]
         token_data_id_hash -> Varchar,
         property_version -> Numeric,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
+        #[max_length = 128]
         name -> Varchar,
+        #[max_length = 50]
         transfer_type -> Varchar,
+        #[max_length = 66]
         from_address -> Nullable<Varchar>,
+        #[max_length = 66]
         to_address -> Nullable<Varchar>,
         token_amount -> Numeric,
         coin_type -> Nullable<Text>,
@@ -659,17 +820,23 @@ diesel::table! {
     token_activities_v2 (transaction_version, event_index) {
         transaction_version -> Int8,
         event_index -> Int8,
+        #[max_length = 66]
         event_account_address -> Varchar,
+        #[max_length = 66]
         token_data_id -> Varchar,
         property_version_v1 -> Numeric,
         #[sql_name = "type"]
         type_ -> Varchar,
+        #[max_length = 66]
         from_address -> Nullable<Varchar>,
+        #[max_length = 66]
         to_address -> Nullable<Varchar>,
         token_amount -> Numeric,
         before_value -> Nullable<Text>,
         after_value -> Nullable<Text>,
+        #[max_length = 1000]
         entry_function_id_str -> Nullable<Varchar>,
+        #[max_length = 10]
         token_standard -> Varchar,
         is_fungible_v2 -> Nullable<Bool>,
         transaction_timestamp -> Timestamp,
@@ -679,15 +846,21 @@ diesel::table! {
 
 diesel::table! {
     token_datas (token_data_id_hash, transaction_version) {
+        #[max_length = 64]
         token_data_id_hash -> Varchar,
         transaction_version -> Int8,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
+        #[max_length = 128]
         name -> Varchar,
         maximum -> Numeric,
         supply -> Numeric,
         largest_property_version -> Numeric,
+        #[max_length = 512]
         metadata_uri -> Varchar,
+        #[max_length = 66]
         payee_address -> Varchar,
         royalty_points_numerator -> Numeric,
         royalty_points_denominator -> Numeric,
@@ -698,6 +871,7 @@ diesel::table! {
         royalty_mutable -> Bool,
         default_properties -> Jsonb,
         inserted_at -> Timestamp,
+        #[max_length = 64]
         collection_data_id_hash -> Varchar,
         transaction_timestamp -> Timestamp,
         description -> Text,
@@ -708,15 +882,20 @@ diesel::table! {
     token_datas_v2 (transaction_version, write_set_change_index) {
         transaction_version -> Int8,
         write_set_change_index -> Int8,
+        #[max_length = 66]
         token_data_id -> Varchar,
+        #[max_length = 66]
         collection_id -> Varchar,
+        #[max_length = 128]
         token_name -> Varchar,
         maximum -> Nullable<Numeric>,
         supply -> Numeric,
         largest_property_version_v1 -> Nullable<Numeric>,
+        #[max_length = 512]
         token_uri -> Varchar,
         token_properties -> Jsonb,
         description -> Text,
+        #[max_length = 10]
         token_standard -> Varchar,
         is_fungible_v2 -> Nullable<Bool>,
         transaction_timestamp -> Timestamp,
@@ -727,17 +906,24 @@ diesel::table! {
 
 diesel::table! {
     token_ownerships (token_data_id_hash, property_version, transaction_version, table_handle) {
+        #[max_length = 64]
         token_data_id_hash -> Varchar,
         property_version -> Numeric,
         transaction_version -> Int8,
+        #[max_length = 66]
         table_handle -> Varchar,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
+        #[max_length = 128]
         name -> Varchar,
+        #[max_length = 66]
         owner_address -> Nullable<Varchar>,
         amount -> Numeric,
         table_type -> Nullable<Text>,
         inserted_at -> Timestamp,
+        #[max_length = 64]
         collection_data_id_hash -> Varchar,
         transaction_timestamp -> Timestamp,
     }
@@ -747,14 +933,19 @@ diesel::table! {
     token_ownerships_v2 (transaction_version, write_set_change_index) {
         transaction_version -> Int8,
         write_set_change_index -> Int8,
+        #[max_length = 66]
         token_data_id -> Varchar,
         property_version_v1 -> Numeric,
+        #[max_length = 66]
         owner_address -> Nullable<Varchar>,
+        #[max_length = 66]
         storage_id -> Varchar,
         amount -> Numeric,
+        #[max_length = 66]
         table_type_v1 -> Nullable<Varchar>,
         token_properties_mutated_v1 -> Nullable<Jsonb>,
         is_soulbound_v2 -> Nullable<Bool>,
+        #[max_length = 10]
         token_standard -> Varchar,
         is_fungible_v2 -> Nullable<Bool>,
         transaction_timestamp -> Timestamp,
@@ -765,14 +956,19 @@ diesel::table! {
 
 diesel::table! {
     tokens (token_data_id_hash, property_version, transaction_version) {
+        #[max_length = 64]
         token_data_id_hash -> Varchar,
         property_version -> Numeric,
         transaction_version -> Int8,
+        #[max_length = 66]
         creator_address -> Varchar,
+        #[max_length = 128]
         collection_name -> Varchar,
+        #[max_length = 128]
         name -> Varchar,
         token_properties -> Jsonb,
         inserted_at -> Timestamp,
+        #[max_length = 64]
         collection_data_id_hash -> Varchar,
         transaction_timestamp -> Timestamp,
     }
@@ -782,16 +978,21 @@ diesel::table! {
     transactions (version) {
         version -> Int8,
         block_height -> Int8,
+        #[max_length = 66]
         hash -> Varchar,
         #[sql_name = "type"]
         type_ -> Varchar,
         payload -> Nullable<Jsonb>,
+        #[max_length = 66]
         state_change_hash -> Varchar,
+        #[max_length = 66]
         event_root_hash -> Varchar,
+        #[max_length = 66]
         state_checkpoint_hash -> Nullable<Varchar>,
         gas_used -> Numeric,
         success -> Bool,
         vm_status -> Text,
+        #[max_length = 66]
         accumulator_root_hash -> Varchar,
         num_events -> Int8,
         num_write_set_changes -> Int8,
@@ -804,13 +1005,16 @@ diesel::table! {
     user_transactions (version) {
         version -> Int8,
         block_height -> Int8,
+        #[max_length = 50]
         parent_signature_type -> Varchar,
+        #[max_length = 66]
         sender -> Varchar,
         sequence_number -> Int8,
         max_gas_amount -> Numeric,
         expiration_timestamp_secs -> Timestamp,
         gas_unit_price -> Numeric,
         timestamp -> Timestamp,
+        #[max_length = 1000]
         entry_function_id_str -> Varchar,
         inserted_at -> Timestamp,
         epoch -> Int8,
@@ -821,10 +1025,12 @@ diesel::table! {
     write_set_changes (transaction_version, index) {
         transaction_version -> Int8,
         index -> Int8,
+        #[max_length = 66]
         hash -> Varchar,
         transaction_block_height -> Int8,
         #[sql_name = "type"]
         type_ -> Text,
+        #[max_length = 66]
         address -> Varchar,
         inserted_at -> Timestamp,
     }

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -259,7 +259,7 @@ diesel::table! {
         #[max_length = 66]
         delegator_address -> Varchar,
         #[max_length = 66]
-        table_handle -> Varchar,
+        table_handle -> Nullable<Varchar>,
         #[max_length = 66]
         voter -> Nullable<Varchar>,
         #[max_length = 66]


### PR DESCRIPTION
Comments about the changes: 
* primary key already adds an index
  * in this case it's `PRIMARY KEY (delegation_pool_address, delegator_address)`, which adds an index already on `delegation_poo_address` so we don't need to add it again (basically if pk or index is on `(a, b)`, it creates an index for `a`, then `(a,b)`, you do need to add one for `b` separately if you plan to only query `b`)
* upgrade diesel so that diesel migrations generates the proper schema.rs
* Shouldn't limit to user transactions because some changes might be coming from block metadata changes
* Adopt the PK from @rtso's ANS PR
* Persist mappings across transactions (whenever a look up is needed, we need to also persist mapping thru the full batch)

Tips
* Unindent by assigning variables
* Make sure that models encapsulates as much as possible, leaving the main flow clean
* Minimize number of mapping and logic in general
* Reuse code, e.g. get_active_share_from_write_table_item
* Add doc blocks to functions

Tested w/ testnet
<img width="1039" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/509b76d9-3de3-4bfb-ba60-488de3c06104">
