### PR TITLE
Clean up ANS

### DIFF
--- a/rust/processor/migrations/2023-08-22-232603_add_ans_view/down.sql
+++ b/rust/processor/migrations/2023-08-22-232603_add_ans_view/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW IF EXISTS current_ans_lookup_v2;

--- a/rust/processor/migrations/2023-08-22-232603_add_ans_view/down.sql
+++ b/rust/processor/migrations/2023-08-22-232603_add_ans_view/down.sql
@@ -1,2 +1,2 @@
 -- This file should undo anything in `up.sql`
-DROP VIEW IF EXISTS current_ans_lookup_v2;
+DROP VIEW IF EXISTS current_aptos_names;

--- a/rust/processor/migrations/2023-08-22-232603_add_ans_view/up.sql
+++ b/rust/processor/migrations/2023-08-22-232603_add_ans_view/up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE VIEW current_ans_lookup_v2 AS
+SELECT
+	current_ans_lookup.domain,
+	current_ans_lookup.subdomain,
+	current_ans_lookup.registered_address,
+	current_ans_lookup.expiration_timestamp,
+	current_ans_lookup.is_deleted,
+	COALESCE(NOT current_ans_primary_name.is_deleted, false) AS is_primary
+FROM current_ans_lookup
+LEFT JOIN current_ans_primary_name
+ON current_ans_lookup.token_name = current_ans_primary_name.token_name;

--- a/rust/processor/migrations/2023-08-22-232603_add_ans_view/up.sql
+++ b/rust/processor/migrations/2023-08-22-232603_add_ans_view/up.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW current_ans_lookup_v2 AS
+CREATE OR REPLACE VIEW current_aptos_names AS
 SELECT
 	current_ans_lookup.domain,
 	current_ans_lookup.subdomain,
@@ -8,4 +8,5 @@ SELECT
 	COALESCE(NOT current_ans_primary_name.is_deleted, false) AS is_primary
 FROM current_ans_lookup
 LEFT JOIN current_ans_primary_name
-ON current_ans_lookup.token_name = current_ans_primary_name.token_name;
+ON current_ans_lookup.token_name = current_ans_primary_name.token_name
+WHERE current_ans_lookup.expiration_timestamp > current_timestamp;

--- a/rust/processor/src/processors/ans_processor.rs
+++ b/rust/processor/src/processors/ans_processor.rs
@@ -164,16 +164,7 @@ fn insert_ans_lookups(
             diesel::insert_into(schema::ans_lookup::table)
                 .values(&items_to_insert[start_ind..end_ind])
                 .on_conflict((transaction_version, write_set_change_index))
-                .do_update()
-                .set((
-                    registered_address.eq(excluded(registered_address)),
-                    domain.eq(excluded(domain)),
-                    subdomain.eq(excluded(subdomain)),
-                    expiration_timestamp.eq(excluded(expiration_timestamp)),
-                    token_name.eq(excluded(token_name)),
-                    is_deleted.eq(excluded(is_deleted)),
-                    inserted_at.eq(excluded(inserted_at)),
-                )),
+                .do_nothing(),
             None,
         )?;
     }
@@ -223,15 +214,7 @@ fn insert_ans_primary_names(
             diesel::insert_into(schema::ans_primary_name::table)
                 .values(&items_to_insert[start_ind..end_ind])
                 .on_conflict((transaction_version, write_set_change_index))
-                .do_update()
-                .set((
-                    registered_address.eq(excluded(registered_address)),
-                    domain.eq(excluded(domain)),
-                    subdomain.eq(excluded(subdomain)),
-                    token_name.eq(excluded(token_name)),
-                    is_deleted.eq(excluded(is_deleted)),
-                    inserted_at.eq(excluded(inserted_at)),
-                )),
+                .do_nothing(),
             None,
         )?;
     }


### PR DESCRIPTION
Update non-`current_` ANS tables to use `do_nothing` on conflict 

## Testing 
Run the processor in testnet locally 
![Screenshot 2023-08-22 at 4 28 46 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/13a7710a-2019-4caf-acb7-044b93f706a3)
