### PR TITLE
Fix dockerfile for rust/processor

### DIFF
--- a/rust/.dockerignore
+++ b/rust/.dockerignore
@@ -1,0 +1,7 @@
+target
+Dockerfile
+.dockerignore
+.git
+.gitignore
+examples
+framework

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,12 +1,33 @@
-### Indexer GRPC Image ###
+### Indexer Processor Image ###
 
-FROM rust as rust-base
+# Stage 1: Build the binary
+
+FROM rust as builder
 
 WORKDIR /app
 
+COPY --link . /app
+
+RUN cargo build --locked --release -p processor
+RUN cp target/release/processor /usr/local/bin
+
+# add build info
+ARG GIT_TAG
+ENV GIT_TAG ${GIT_TAG}
+ARG GIT_BRANCH
+ENV GIT_BRANCH ${GIT_BRANCH}
+ARG GIT_SHA
+ENV GIT_SHA ${GIT_SHA}
+
+# Stage 2: Create the final image
+
+FROM debian:bullseye-slim
+
+COPY --from=builder /usr/local/bin/processor /usr/local/bin
+
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \   
-    apt-get update && apt-get install --no-install-recommends -y \    
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install --no-install-recommends -y \
         libssl1.1 \
         ca-certificates \
         net-tools \
@@ -15,16 +36,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         netcat \
         libpq-dev \
         curl
-# Create the release build for processor.
-
-COPY --link . /app
-
-RUN scripts/build.sh
-
-# The health check port
-EXPOSE 8080
-# The gRPC port
-EXPOSE 50051
 
 ENV RUST_LOG_FORMAT=json
 
@@ -35,3 +46,8 @@ ARG GIT_BRANCH
 ENV GIT_BRANCH ${GIT_BRANCH}
 ARG GIT_SHA
 ENV GIT_SHA ${GIT_SHA}
+
+# The health check port
+EXPOSE 8084
+
+ENTRYPOINT ["/usr/local/bin/processor"]

--- a/rust/scripts/build.sh
+++ b/rust/scripts/build.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-cargo build --locked --release -p processor
-cp target/release/processor /usr/local/bin


### PR DESCRIPTION
## Summary
The previous setup had a few issues:
- Needlessly brought in more context than was necessary because there was no .dockerignore.
- Didn't use two stages, so the image is bigger than necessary.
- Didn't expose the correct health check port by default.

This PR fixes all that.

The image is now only 176 mb instead of a couple of gbs.

## Test Plan
```
docker build . -t indexer-processor
```
```
docker run -it --network host --mount type=bind,source=/tmp/config.yaml,target=/config.yaml indexer-processor:latest -c /config.yaml
```