### PR TITLE
[Rust] clean up reconnect logic

### DIFF
--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -168,29 +168,7 @@ impl Worker {
             "[Parser] Connecting and making request to GRPC endpoint",
         );
 
-        let indexer_grpc_data_service_address = self.indexer_grpc_data_service_address.clone();
-        let indexer_grpc_http2_ping_interval = self.indexer_grpc_http2_ping_interval;
-        let indexer_grpc_http2_ping_timeout = self.indexer_grpc_http2_ping_timeout;
-        let mut resp_stream = get_stream(
-            indexer_grpc_data_service_address,
-            indexer_grpc_http2_ping_interval,
-            indexer_grpc_http2_ping_timeout,
-            starting_version,
-            self.ending_version,
-            self.auth_token.clone(),
-            self.processor_name.clone(),
-        )
-        .await;
-
         let concurrent_tasks = self.number_concurrent_processing_tasks;
-        info!(
-            processor_name = processor_name,
-            stream_address = self.indexer_grpc_data_service_address.clone(),
-            starting_version = starting_version,
-            ending_version = self.ending_version,
-            concurrent_tasks = concurrent_tasks,
-            "[Parser] Successfully connected to GRPC endpoint. Now instantiating processor",
-        );
 
         // Instantiates correct processor based on config
         let processor_enum = Processor::from_string(&processor_name);
@@ -245,10 +223,13 @@ impl Worker {
 
         let ending_version = self.ending_version;
         let indexer_grpc_data_service_address = self.indexer_grpc_data_service_address.clone();
+        let indexer_grpc_http2_ping_interval = self.indexer_grpc_http2_ping_interval;
+        let indexer_grpc_http2_ping_timeout = self.indexer_grpc_http2_ping_timeout;
         // Create a transaction fetcher thread that will continuously fetch transactions from the GRPC stream
         // and write into a channel
         // The each item will be (chain_id, batch of transactions)
         let (tx, mut receiver) = tokio::sync::mpsc::channel::<(u64, Vec<Transaction>)>(BUFFER_SIZE);
+        let request_ending_version = self.ending_version;
         let auth_token = self.auth_token.clone();
         tokio::spawn(async move {
             info!(
@@ -257,138 +238,19 @@ impl Worker {
                 batch_start_version = batch_start_version,
                 "[Parser] Starting fetcher thread"
             );
-            // Gets a batch of transactions from the stream. Batch size is set in the grpc server.
-            // The number of batches depends on our config
-            // There could be several special scenarios:
-            // 1. If we lose the connection, we will stop fetching and let the consumer panic.
-            // 2. If we specified an end version and we hit that, we will stop fetching.
-            let mut last_insertion_time = std::time::Instant::now();
-            let mut next_version_to_fetch = batch_start_version;
-            let mut last_reconnection_time: Option<std::time::Instant> = None;
-            let mut reconnection_retries = 0;
-            loop {
-                let is_success = match resp_stream.next().await {
-                    Some(Ok(r)) => {
-                        reconnection_retries = 0;
-                        let start_version = r.transactions.as_slice().first().unwrap().version;
-                        let end_version = r.transactions.as_slice().last().unwrap().version;
-                        next_version_to_fetch = end_version + 1;
-
-                        TRANSMITTED_BYTES_COUNT
-                            .with_label_values(&[processor_name])
-                            .inc_by(r.encoded_len() as u64);
-                        let chain_id = r.chain_id.expect("[Parser] Chain Id doesn't exist.");
-                        match tx.send((chain_id, r.transactions)).await {
-                            Ok(()) => {},
-                            Err(e) => {
-                                error!(
-                                    processor_name = processor_name,
-                                    stream_address = indexer_grpc_data_service_address.clone(),
-                                    error = ?e,
-                                    "[Parser] Error sending datastream response to channel."
-                                );
-                                panic!("[Parser] Error sending datastream response to channel.")
-                            },
-                        }
-                        info!(
-                            processor_name = processor_name,
-                            start_version = start_version,
-                            end_version = end_version,
-                            channel_size = BUFFER_SIZE - tx.capacity(),
-                            channel_recv_latency_in_secs =
-                                last_insertion_time.elapsed().as_secs_f64(),
-                            "[Parser] Received chunk of transactions."
-                        );
-                        last_insertion_time = std::time::Instant::now();
-                        true
-                    },
-                    Some(Err(rpc_error)) => {
-                        tracing::warn!(
-                            processor_name = processor_name,
-                            stream_address = indexer_grpc_data_service_address.clone(),
-                            error = ?rpc_error,
-                            "[Parser] Error receiving datastream response."
-                        );
-                        false
-                    },
-                    None => {
-                        tracing::warn!(
-                            processor_name = processor_name,
-                            stream_address = indexer_grpc_data_service_address.clone(),
-                            "[Parser] Stream ended."
-                        );
-                        false
-                    },
-                };
-                // Check if we're at the end of the stream
-                let is_end = if let Some(ending_version) = ending_version {
-                    next_version_to_fetch > ending_version
-                } else {
-                    false
-                };
-                if is_end {
-                    info!(
-                        processor_name = processor_name,
-                        stream_address = indexer_grpc_data_service_address.clone(),
-                        ending_version = ending_version,
-                        next_version_to_fetch = next_version_to_fetch,
-                        "[Parser] Reached ending version.",
-                    );
-                    // Wait for the fetched transactions to finish processing before closing the channel
-                    loop {
-                        let channel_capacity = tx.capacity();
-                        info!(
-                            processor_name = processor_name,
-                            channel_size = BUFFER_SIZE - channel_capacity,
-                            "[Parser] Waiting for channel to be empty"
-                        );
-                        if channel_capacity == BUFFER_SIZE {
-                            break;
-                        }
-                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                    }
-                    info!("[Parser] The stream is ended.");
-                } else {
-                    // The rest is to see if we need to reconnect
-                    if is_success {
-                        continue;
-                    }
-                    if let Some(lrt) = last_reconnection_time {
-                        let elapsed: u64 = lrt.elapsed().as_secs();
-                        if reconnection_retries >= RECONNECTION_MAX_RETRIES
-                            && elapsed < MIN_SEC_BETWEEN_GRPC_RECONNECTS
-                        {
-                            error!(
-                                processor_name = processor_name,
-                                stream_address = indexer_grpc_data_service_address.clone(),
-                                seconds_since_last_retry = elapsed,
-                                "[Parser] Recently reconnected. Will not retry.",
-                            );
-                            panic!("[Parser] Recently reconnected. Will not retry.")
-                        }
-                    }
-                    reconnection_retries += 1;
-                    last_reconnection_time = Some(std::time::Instant::now());
-                    tracing::warn!(
-                        processor_name = processor_name,
-                        stream_address = indexer_grpc_data_service_address.clone(),
-                        starting_version = next_version_to_fetch,
-                        ending_version = ending_version,
-                        reconnection_retries = reconnection_retries,
-                        "[Parser] Reconnecting to GRPC."
-                    );
-                    resp_stream = get_stream(
-                        indexer_grpc_data_service_address.clone(),
-                        indexer_grpc_http2_ping_interval,
-                        indexer_grpc_http2_ping_timeout,
-                        next_version_to_fetch,
-                        ending_version,
-                        auth_token.clone(),
-                        processor_name.to_string(),
-                    )
-                    .await;
-                }
-            }
+            create_fetcher_loop(
+                tx,
+                indexer_grpc_data_service_address,
+                indexer_grpc_http2_ping_interval,
+                indexer_grpc_http2_ping_timeout,
+                starting_version,
+                request_ending_version,
+                auth_token,
+                processor_name.to_string(),
+                concurrent_tasks,
+                batch_start_version,
+            )
+            .await
         });
 
         // This is the consumer side of the channel. These are the major states:
@@ -719,4 +581,169 @@ pub async fn get_stream(
         .await
         .expect("[Parser] Failed to get grpc response. Is the server running?")
         .into_inner()
+}
+
+/// Gets a batch of transactions from the stream. Batch size is set in the grpc server.
+/// The number of batches depends on our config
+/// There could be several special scenarios:
+/// 1. If we lose the connection, we will try reconnecting X times within Y seconds before crashing.
+/// 2. If we specified an end version and we hit that, we will stop fetching, but we will make sure that
+/// all existing transactions are processed
+pub async fn create_fetcher_loop(
+    tx: tokio::sync::mpsc::Sender<(u64, Vec<Transaction>)>,
+    indexer_grpc_data_service_address: String,
+    indexer_grpc_http2_ping_interval: Duration,
+    indexer_grpc_http2_ping_timeout: Duration,
+    starting_version: u64,
+    request_ending_version: Option<u64>,
+    auth_token: String,
+    processor_name: String,
+    concurrent_tasks: usize,
+    batch_start_version: u64,
+) {
+    let mut last_insertion_time = std::time::Instant::now();
+    let mut next_version_to_fetch = batch_start_version;
+    let mut last_reconnection_time: Option<std::time::Instant> = None;
+    let mut reconnection_retries = 0;
+    let mut resp_stream = get_stream(
+        indexer_grpc_data_service_address.clone(),
+        indexer_grpc_http2_ping_interval,
+        indexer_grpc_http2_ping_timeout,
+        starting_version,
+        request_ending_version,
+        auth_token.clone(),
+        processor_name.to_string(),
+    )
+    .await;
+    info!(
+        processor_name = processor_name,
+        stream_address = indexer_grpc_data_service_address.clone(),
+        starting_version = starting_version,
+        ending_version = request_ending_version,
+        concurrent_tasks = concurrent_tasks,
+        "[Parser] Successfully connected to GRPC endpoint",
+    );
+
+    loop {
+        let is_success = match resp_stream.next().await {
+            Some(Ok(r)) => {
+                reconnection_retries = 0;
+                let start_version = r.transactions.as_slice().first().unwrap().version;
+                let end_version = r.transactions.as_slice().last().unwrap().version;
+                next_version_to_fetch = end_version + 1;
+
+                TRANSMITTED_BYTES_COUNT
+                    .with_label_values(&[&processor_name])
+                    .inc_by(r.encoded_len() as u64);
+                let chain_id = r.chain_id.expect("[Parser] Chain Id doesn't exist.");
+                match tx.send((chain_id, r.transactions)).await {
+                    Ok(()) => {},
+                    Err(e) => {
+                        error!(
+                            processor_name = processor_name,
+                            stream_address = indexer_grpc_data_service_address.clone(),
+                            error = ?e,
+                            "[Parser] Error sending datastream response to channel."
+                        );
+                        panic!("[Parser] Error sending datastream response to channel.")
+                    },
+                }
+                info!(
+                    processor_name = processor_name,
+                    start_version = start_version,
+                    end_version = end_version,
+                    channel_size = BUFFER_SIZE - tx.capacity(),
+                    channel_recv_latency_in_secs = last_insertion_time.elapsed().as_secs_f64(),
+                    "[Parser] Received chunk of transactions."
+                );
+                last_insertion_time = std::time::Instant::now();
+                true
+            },
+            Some(Err(rpc_error)) => {
+                tracing::warn!(
+                    processor_name = processor_name,
+                    stream_address = indexer_grpc_data_service_address.clone(),
+                    error = ?rpc_error,
+                    "[Parser] Error receiving datastream response."
+                );
+                false
+            },
+            None => {
+                tracing::warn!(
+                    processor_name = processor_name,
+                    stream_address = indexer_grpc_data_service_address.clone(),
+                    "[Parser] Stream ended."
+                );
+                false
+            },
+        };
+        // Check if we're at the end of the stream
+        let is_end = if let Some(ending_version) = request_ending_version {
+            next_version_to_fetch > ending_version
+        } else {
+            false
+        };
+        if is_end {
+            info!(
+                processor_name = processor_name,
+                stream_address = indexer_grpc_data_service_address.clone(),
+                ending_version = request_ending_version,
+                next_version_to_fetch = next_version_to_fetch,
+                "[Parser] Reached ending version.",
+            );
+            // Wait for the fetched transactions to finish processing before closing the channel
+            loop {
+                let channel_capacity = tx.capacity();
+                info!(
+                    processor_name = processor_name,
+                    channel_size = BUFFER_SIZE - channel_capacity,
+                    "[Parser] Waiting for channel to be empty"
+                );
+                if channel_capacity == BUFFER_SIZE {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+            info!("[Parser] The stream is ended.");
+        } else {
+            // The rest is to see if we need to reconnect
+            if is_success {
+                continue;
+            }
+            if let Some(lrt) = last_reconnection_time {
+                let elapsed: u64 = lrt.elapsed().as_secs();
+                if reconnection_retries >= RECONNECTION_MAX_RETRIES
+                    && elapsed < MIN_SEC_BETWEEN_GRPC_RECONNECTS
+                {
+                    error!(
+                        processor_name = processor_name,
+                        stream_address = indexer_grpc_data_service_address.clone(),
+                        seconds_since_last_retry = elapsed,
+                        "[Parser] Recently reconnected. Will not retry.",
+                    );
+                    panic!("[Parser] Recently reconnected. Will not retry.")
+                }
+            }
+            reconnection_retries += 1;
+            last_reconnection_time = Some(std::time::Instant::now());
+            tracing::warn!(
+                processor_name = processor_name,
+                stream_address = indexer_grpc_data_service_address.clone(),
+                starting_version = next_version_to_fetch,
+                ending_version = request_ending_version,
+                reconnection_retries = reconnection_retries,
+                "[Parser] Reconnecting to GRPC."
+            );
+            resp_stream = get_stream(
+                indexer_grpc_data_service_address.clone(),
+                indexer_grpc_http2_ping_interval,
+                indexer_grpc_http2_ping_timeout,
+                next_version_to_fetch,
+                request_ending_version,
+                auth_token.clone(),
+                processor_name.to_string(),
+            )
+            .await;
+        }
+    }
 }


### PR DESCRIPTION
* Remove the nested loops
* Add a retry field so that if the upstream server is rebuilding we won't panic. This will potentially create more short lived connections which is something we should watch out for.
* Reduce the reconnect time to 15 seconds from 60. 

Test: I still see restarts in kube. Hopefully no more. 

<img width="1437" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/6784c8b8-3ff3-4af9-9c27-71fb8ee81d22">
