### PR TITLE
Install pnpm in GH workflow, fix tagging in release-processor-images.mjs

### DIFF
--- a/.github/workflows/copy-processor-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-processor-images-to-dockerhub.yaml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   copy-processor-images:
     # Run on a machine with more local storage for large docker images
-    runs-on: medium-perf-docker-with-local-ssd
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
 

--- a/.github/workflows/copy-processor-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-processor-images-to-dockerhub.yaml
@@ -10,13 +10,11 @@ on:
       version_tag:
         required: false
         type: string
-        description: the version tag to use for the image tag.
+        description: After we copy the image from GAR to DockerHub, we will add this tag to the image. For example v1.0.4.
       GIT_SHA:
         required: true
         type: string
-        description: the git sha to use for the image tag.
-
-
+        description: The git SHA you want to copy from GAR to DockerHub. For example de766ae36a1c74212d370aae75bf234320612bbc.
 
 permissions:
   contents: read
@@ -44,14 +42,18 @@ jobs:
         with:
           node-version-file: .node-version
 
-      - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # pin https://github.com/pnpm/action-setup/releases/tag/v2.4.0
         with:
           run_install: false
           package_json_file: scripts/package.json
+
+      - run: pnpm install --frozen-lockfile
+        working-directory: scripts
 
       - name: Release Images
         env:
           FORCE_COLOR: 3 # Force color output as per https://github.com/google/zx#using-github-actions
           GIT_SHA: ${{ inputs.GIT_SHA }}
           GCP_DOCKER_ARTIFACT_PROCESSOR_REPO_US: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO_US }}
-        run: ./scripts/release-processor-images.mjs --language=${{ inputs.processor_language }} --version-tag=${{ inputs.version_tag }} --wait-for-image-seconds=3600
+        run: pnpm release-processor-images --language=${{ inputs.processor_language }} --version-tag=${{ inputs.version_tag }} --wait-for-image-seconds=3600
+        working-directory: scripts

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,5 @@
+# Scripts
+To run any of the JS scripts you must first install the deps:
+```
+pnpm install
+```

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,9 +1,12 @@
 {
   "name": "scripts",
+  "description": "Scripts for aptos-indexer-processors",
   "version": "1.0.0",
-  "description": "",
+  "packageManager": "pnpm@8.6.2",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+      "release-processor-images": "./release-processor-images.mjs"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/scripts/release-processor-images.mjs
+++ b/scripts/release-processor-images.mjs
@@ -26,17 +26,10 @@
 // GIT_SHA=${{ github.sha }} GCP_DOCKER_ARTIFACT_PROCESSOR_REPO_US="${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}" ./docker/release-processor-images.mjs --language=rust --wait-for-image-seconds=1800
 
 
-import { execSync } from "node:child_process";
 import { dirname } from "node:path";
 import { chdir } from "node:process";
 import { promisify } from "node:util";
 const sleep = promisify(setTimeout);
-
-// Change workdir to the location of the script.
-chdir(dirname(process.argv[1]));
-
-// Install deps.
-execSync("pnpm install --frozen-lockfile", { stdio: "inherit" });
 
 // Change workdir to the root of the repo.
 chdir(dirname(process.argv[1]) + "/..");
@@ -62,6 +55,9 @@ for (const arg of OPTIONAL_ARGS) {
   parsedArgs[arg] = argValue;
 }
 
+// Default 10 seconds.
+parsedArgs.WAIT_FOR_IMAGE_SECONDS = parseInt(parsedArgs.WAIT_FOR_IMAGE_SECONDS ?? 10, 10);
+
 let crane;
 
 if (process.env.CI === "true") {
@@ -86,35 +82,34 @@ if (process.env.CI === "true") {
   crane = "crane";
 }
 
-
 function getImage(language) {
     const sourceImage = `indexer-client-examples/${language}`;
     const targetImage = `indexer-processor-${language}`;
-
     return {sourceImage, targetImage};
 }
 
 const GCP_ARTIFACT_PROCESSOR_REPO_US = parsedArgs.GCP_DOCKER_ARTIFACT_PROCESSOR_REPO_US;
 const DOCKERHUB = "docker.io/aptoslabs";
-const {sourceImage, targetImage} = getImage(parsedArgs.LANGUAGE);
-console.log(targetImage);
-// default 10 seconds
-parsedArgs.WAIT_FOR_IMAGE_SECONDS = parseInt(parsedArgs.WAIT_FOR_IMAGE_SECONDS ?? 10, 10);
 
+const {sourceImage, targetImage} = getImage(parsedArgs.LANGUAGE);
+console.info(chalk.yellow(`INFO: Target image: ${targetImage}`));
 
 const imageSource = `${GCP_ARTIFACT_PROCESSOR_REPO_US}/${sourceImage}:${parsedArgs.GIT_SHA}`;
 const imageGitShaTarget = `${DOCKERHUB}/${targetImage}:${parsedArgs.GIT_SHA}`;
-const imageLatestTarget = `${DOCKERHUB}/${targetImage}:latest`;
-console.info(chalk.green(`INFO: copying ${imageSource} to ${imageGitShaTarget}`));
-await waitForImageToBecomeAvailable(imageSource, parsedArgs.WAIT_FOR_IMAGE_SECONDS);
-await $`${crane} copy ${imageSource} ${imageGitShaTarget}`;
-await $`${crane} tag ${imageSource} ${imageLatestTarget}`;
-if(parsedArgs.VERSION_TAG !== null) {
-    const imageVersionTagTarget = `${DOCKERHUB}/${targetImage}:${parsedArgs.VERSION_TAG}`;
-    console.info(chalk.green(`INFO: copying ${imageSource} to ${imageVersionTagTarget}`));
-    await $`${crane} tag ${imageSource} ${imageVersionTagTarget}`;
-}
 
+console.info(chalk.green(`INFO: Waiting for ${imageSource} to become available in the source repo`));
+await waitForImageToBecomeAvailable(imageSource, parsedArgs.WAIT_FOR_IMAGE_SECONDS);
+
+console.info(chalk.green(`INFO: Copying ${imageSource} to ${imageGitShaTarget}`));
+await $`${crane} copy ${imageSource} ${imageGitShaTarget}`;
+
+console.info(chalk.green(`INFO: Tagging image as latest`));
+await $`${crane} tag ${imageGitShaTarget} latest`;
+
+if(parsedArgs.VERSION_TAG !== null) {
+    console.info(chalk.green(`INFO: Tagging image as ${parsedArgs.VERSION_TAG}`));
+    await $`${crane} tag ${imageGitShaTarget} ${parsedArgs.VERSION_TAG}`;
+}
 
 async function waitForImageToBecomeAvailable(imageToWaitFor, waitForImageSeconds) {
   const WAIT_TIME_IN_BETWEEN_ATTEMPTS = 10000; // 10 seconds in ms


### PR DESCRIPTION
## Summary
I think installing the pnpm deps from inside the script is a bit irregular. I instead make the script something you just run via a script entry in package.json. I think everyone knows you should run `pnpm install` before running a JS script.

Beyond that, the script was broken, for example the way we were invoking `crane tag` was incorrect. I fix that in this PR.

## Test Plan
```
gh workflow run 'Release Processor Images' --ref banool/release-processor-images -f GIT_SHA=de766ae36a1c74212d370aae75bf234320612bbc -f version_tag=v1.0.4
```