### PR TITLE
[Rust] Events v2

### DIFF
--- a/rust/processor/migrations/2023-09-01-231248_events_v2/down.sql
+++ b/rust/processor/migrations/2023-09-01-231248_events_v2/down.sql
@@ -1,0 +1,8 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE events DROP CONSTRAINT events_pkey;
+ALTER TABLE events
+ADD CONSTRAINT events_pkey PRIMARY KEY (
+    account_address,
+    creation_number,
+    sequence_number
+  );

--- a/rust/processor/migrations/2023-09-01-231248_events_v2/up.sql
+++ b/rust/processor/migrations/2023-09-01-231248_events_v2/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE events DROP CONSTRAINT events_pkey;
+ALTER TABLE events DROP CONSTRAINT IF EXISTS fk_transaction_versions;
+ALTER TABLE events
+ADD CONSTRAINT events_pkey PRIMARY KEY (transaction_version, event_index);

--- a/rust/processor/src/models/default_models/block_metadata_transactions.rs
+++ b/rust/processor/src/models/default_models/block_metadata_transactions.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::transactions::{Transaction, TransactionQuery};
+use super::transactions::Transaction;
 use crate::{
     schema::block_metadata_transactions,
     utils::util::{parse_timestamp, standardize_address},
@@ -33,26 +33,6 @@ pub struct BlockMetadataTransaction {
     pub proposer: String,
     pub failed_proposer_indices: serde_json::Value,
     pub timestamp: chrono::NaiveDateTime,
-}
-
-/// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
-#[derive(
-    Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Queryable, Serialize,
-)]
-#[diesel(belongs_to(TransactionQuery, foreign_key = version))]
-#[diesel(primary_key(version))]
-#[diesel(table_name = block_metadata_transactions)]
-pub struct BlockMetadataTransactionQuery {
-    pub version: i64,
-    pub block_height: i64,
-    pub id: String,
-    pub round: i64,
-    pub epoch: i64,
-    pub previous_block_votes_bitvec: serde_json::Value,
-    pub proposer: String,
-    pub failed_proposer_indices: serde_json::Value,
-    pub timestamp: chrono::NaiveDateTime,
-    pub inserted_at: chrono::NaiveDateTime,
 }
 
 impl BlockMetadataTransaction {

--- a/rust/processor/src/models/default_models/user_transactions.rs
+++ b/rust/processor/src/models/default_models/user_transactions.rs
@@ -7,10 +7,7 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::{
-    signatures::Signature,
-    transactions::{Transaction, TransactionQuery},
-};
+use super::{signatures::Signature, transactions::Transaction};
 use crate::{
     schema::user_transactions,
     utils::util::{
@@ -43,26 +40,6 @@ pub struct UserTransaction {
     pub gas_unit_price: BigDecimal,
     pub timestamp: chrono::NaiveDateTime,
     pub entry_function_id_str: String,
-    pub epoch: i64,
-}
-
-/// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
-#[derive(Associations, Clone, Deserialize, Debug, Identifiable, Queryable, Serialize)]
-#[diesel(belongs_to(TransactionQuery, foreign_key = version))]
-#[diesel(primary_key(version))]
-#[diesel(table_name = user_transactions)]
-pub struct UserTransactionQuery {
-    pub version: i64,
-    pub block_height: i64,
-    pub parent_signature_type: String,
-    pub sender: String,
-    pub sequence_number: i64,
-    pub max_gas_amount: BigDecimal,
-    pub expiration_timestamp_secs: chrono::NaiveDateTime,
-    pub gas_unit_price: BigDecimal,
-    pub timestamp: chrono::NaiveDateTime,
-    pub entry_function_id_str: String,
-    pub inserted_at: chrono::NaiveDateTime,
     pub epoch: i64,
 }
 

--- a/rust/processor/src/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/models/default_models/write_set_changes.rs
@@ -6,7 +6,7 @@ use super::{
     move_modules::MoveModule,
     move_resources::MoveResource,
     move_tables::{CurrentTableItem, TableItem, TableMetadata},
-    transactions::{Transaction, TransactionQuery},
+    transactions::Transaction,
 };
 use crate::{schema::write_set_changes, utils::util::standardize_address};
 use aptos_indexer_protos::transaction::v1::{
@@ -27,21 +27,6 @@ pub struct WriteSetChange {
     transaction_block_height: i64,
     pub type_: String,
     pub address: String,
-}
-
-/// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
-#[derive(Associations, Debug, Deserialize, Identifiable, Queryable, Serialize)]
-#[diesel(belongs_to(TransactionQuery, foreign_key = transaction_version))]
-#[diesel(primary_key(transaction_version, index))]
-#[diesel(table_name = write_set_changes)]
-pub struct WriteSetChangeQuery {
-    pub transaction_version: i64,
-    pub index: i64,
-    pub hash: String,
-    transaction_block_height: i64,
-    pub type_: String,
-    pub address: String,
-    pub inserted_at: chrono::NaiveDateTime,
 }
 
 impl WriteSetChange {

--- a/rust/processor/src/processors/default_processor.rs
+++ b/rust/processor/src/processors/default_processor.rs
@@ -279,7 +279,7 @@ fn insert_events(
             conn,
             diesel::insert_into(schema::events::table)
                 .values(&items_to_insert[start_ind..end_ind])
-                .on_conflict((account_address, creation_number, sequence_number))
+                .on_conflict((transaction_version, event_index))
                 .do_nothing(),
             None,
         )?;

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -594,7 +594,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    events (account_address, creation_number, sequence_number) {
+    events (transaction_version, event_index) {
         sequence_number -> Int8,
         creation_number -> Int8,
         #[max_length = 66]
@@ -605,7 +605,7 @@ diesel::table! {
         type_ -> Text,
         data -> Jsonb,
         inserted_at -> Timestamp,
-        event_index -> Nullable<Int8>,
+        event_index -> Int8,
     }
 }
 


### PR DESCRIPTION
* Change primary key of events table for v2 (should be just on transaction_version and event index)
* Remove unused query structs

## Testing
I validated that (transaction_version, event_index) is a valid PK (no duplicates) 
events table works
<img width="1111" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/88efc6fa-f800-4921-9069-a799f56ca501">

v2 event works as well
<img width="1118" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/9b80e686-d2d8-4ea5-8f75-19c3bf769693">
