### PR TITLE
[NFT Metadata Crawler] Add collection support for processor

### DIFF
--- a/rust/processor/src/processors/nft_metadata_processor.rs
+++ b/rust/processor/src/processors/nft_metadata_processor.rs
@@ -90,6 +90,7 @@ impl ProcessorTrait for NFTMetadataProcessor {
         let client = Client::new(config).await?;
         let topic = client.topic(&self.pubsub_topic_name.clone());
         let publisher = topic.new_publisher(None);
+        let ordering_key = get_current_timestamp();
 
         // Publish CurrentTokenDataV2 and CurrentCollectionV2 from transactions
         let (token_datas, collections) =
@@ -109,7 +110,7 @@ impl ProcessorTrait for NFTMetadataProcessor {
                     db_chain_id.expect("db_chain_id must not be null"),
                 )
                 .into(),
-                ordering_key: get_current_timestamp(),
+                ordering_key: ordering_key.clone(),
                 ..Default::default()
             })
         }
@@ -125,7 +126,7 @@ impl ProcessorTrait for NFTMetadataProcessor {
                     db_chain_id.expect("db_chain_id must not be null"),
                 )
                 .into(),
-                ordering_key: get_current_timestamp(),
+                ordering_key: ordering_key.clone(),
                 ..Default::default()
             })
         }
@@ -274,6 +275,7 @@ fn parse_v2_token(
     (current_token_datas_v2, current_collections_v2)
 }
 
+/// Get current system timestamp in milliseconds for ordering key
 fn get_current_timestamp() -> String {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/rust/processor/src/processors/nft_metadata_processor.rs
+++ b/rust/processor/src/processors/nft_metadata_processor.rs
@@ -3,12 +3,18 @@
 
 use super::processor_trait::{ProcessingResult, ProcessorTrait};
 use crate::{
-    models::token_v2_models::{
-        v2_token_datas::{CurrentTokenDataV2, CurrentTokenDataV2PK, TokenDataV2},
-        v2_token_utils::{ObjectWithMetadata, TokenV2AggregatedData, TokenV2AggregatedDataMapping},
+    models::{
+        token_models::tokens::{TableHandleToOwner, TableMetadataForToken},
+        token_v2_models::{
+            v2_collections::{CollectionV2, CurrentCollectionV2, CurrentCollectionV2PK},
+            v2_token_datas::{CurrentTokenDataV2, CurrentTokenDataV2PK, TokenDataV2},
+            v2_token_utils::{
+                ObjectWithMetadata, TokenV2AggregatedData, TokenV2AggregatedDataMapping,
+            },
+        },
     },
     utils::{
-        database::PgDbPool,
+        database::{PgDbPool, PgPoolConnection},
         util::{parse_timestamp, standardize_address},
     },
 };
@@ -72,16 +78,28 @@ impl ProcessorTrait for NFTMetadataProcessor {
         end_version: u64,
         db_chain_id: Option<u64>,
     ) -> anyhow::Result<ProcessingResult> {
+        let mut conn = self.get_conn();
+
+        // First get all token related table metadata from the batch of transactions. This is in case
+        // an earlier transaction has metadata (in resources) that's missing from a later transaction.
+        let table_handle_to_owner =
+            TableMetadataForToken::get_table_handle_to_owner_from_transactions(&transactions);
+
         // Initialize pubsub client
         let config = ClientConfig::default().with_auth().await?;
         let client = Client::new(config).await?;
         let topic = client.topic(&self.pubsub_topic_name.clone());
         let publisher = topic.new_publisher(None);
 
-        // Publish all parsed CurrentTokenDataV2 to Pubsub
-        let pubsub_messages: Vec<PubsubMessage> = parse_v2_token(&transactions)
-            .iter()
-            .map(|token_data| PubsubMessage {
+        // Publish CurrentTokenDataV2 and CurrentCollectionV2 from transactions
+        let (token_datas, collections) =
+            parse_v2_token(&transactions, &table_handle_to_owner, &mut conn);
+        let mut pubsub_messages: Vec<PubsubMessage> =
+            Vec::with_capacity(token_datas.len() + collections.len());
+
+        // Publish all parsed token and collection data to Pubsub
+        for token_data in token_datas {
+            pubsub_messages.push(PubsubMessage {
                 data: format!(
                     "{},{},{},{},{},false",
                     token_data.token_data_id,
@@ -91,14 +109,26 @@ impl ProcessorTrait for NFTMetadataProcessor {
                     db_chain_id.expect("db_chain_id must not be null"),
                 )
                 .into(),
-                ordering_key: SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis()
-                    .to_string(),
+                ordering_key: get_current_timestamp(),
                 ..Default::default()
             })
-            .collect();
+        }
+
+        for collection in collections {
+            pubsub_messages.push(PubsubMessage {
+                data: format!(
+                    "{},{},{},{},{},false",
+                    collection.collection_id,
+                    collection.uri,
+                    collection.last_transaction_version,
+                    collection.last_transaction_timestamp,
+                    db_chain_id.expect("db_chain_id must not be null"),
+                )
+                .into(),
+                ordering_key: get_current_timestamp(),
+                ..Default::default()
+            })
+        }
 
         info!(
             start_version = start_version,
@@ -131,8 +161,14 @@ impl ProcessorTrait for NFTMetadataProcessor {
 }
 
 /// Copied from token_processor;
-fn parse_v2_token(transactions: &[Transaction]) -> Vec<CurrentTokenDataV2> {
+fn parse_v2_token(
+    transactions: &[Transaction],
+    table_handle_to_owner: &TableHandleToOwner,
+    conn: &mut PgPoolConnection,
+) -> (Vec<CurrentTokenDataV2>, Vec<CurrentCollectionV2>) {
     let mut current_token_datas_v2: HashMap<CurrentTokenDataV2PK, CurrentTokenDataV2> =
+        HashMap::new();
+    let mut current_collections_v2: HashMap<CurrentCollectionV2PK, CurrentCollectionV2> =
         HashMap::new();
 
     for txn in transactions {
@@ -181,6 +217,20 @@ fn parse_v2_token(transactions: &[Transaction]) -> Vec<CurrentTokenDataV2> {
                         current_token_datas_v2
                             .insert(current_token_data.token_data_id.clone(), current_token_data);
                     }
+                    if let Some((_, current_collection)) =
+                        CollectionV2::get_v1_from_write_table_item(
+                            table_item,
+                            txn_version,
+                            wsc_index,
+                            txn_timestamp,
+                            table_handle_to_owner,
+                            conn,
+                        )
+                        .unwrap()
+                    {
+                        current_collections_v2
+                            .insert(current_collection.collection_id.clone(), current_collection);
+                    }
                 },
                 Change::WriteResource(resource) => {
                     if let Some((_, current_token_data)) = TokenDataV2::get_v2_from_write_resource(
@@ -195,6 +245,18 @@ fn parse_v2_token(transactions: &[Transaction]) -> Vec<CurrentTokenDataV2> {
                         current_token_datas_v2
                             .insert(current_token_data.token_data_id.clone(), current_token_data);
                     }
+                    if let Some((_, current_collection)) = CollectionV2::get_v2_from_write_resource(
+                        resource,
+                        txn_version,
+                        wsc_index,
+                        txn_timestamp,
+                        &token_v2_metadata_helper,
+                    )
+                    .unwrap()
+                    {
+                        current_collections_v2
+                            .insert(current_collection.collection_id.clone(), current_collection);
+                    }
                 },
 
                 _ => {},
@@ -202,10 +264,20 @@ fn parse_v2_token(transactions: &[Transaction]) -> Vec<CurrentTokenDataV2> {
         }
     }
 
-    let mut current_token_datas_v2 = current_token_datas_v2
+    let current_token_datas_v2 = current_token_datas_v2
         .into_values()
         .collect::<Vec<CurrentTokenDataV2>>();
-    current_token_datas_v2.sort_by(|a, b| a.token_data_id.cmp(&b.token_data_id));
+    let current_collections_v2 = current_collections_v2
+        .into_values()
+        .collect::<Vec<CurrentCollectionV2>>();
 
-    current_token_datas_v2
+    (current_token_datas_v2, current_collections_v2)
+}
+
+fn get_current_timestamp() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .to_string()
 }


### PR DESCRIPTION
Collections also have assets that can be added to the CDN. This adds `CurrentCollectionV2` to also be indexed in the NFT Metadata Processor. 

<img width="1023" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/37165464/594397eb-44cc-42a9-84e6-95e04021c2ab">
