### PR TITLE
[Rust] Storage refund

### DIFF
--- a/hasura-api/metadata-json/unified.json
+++ b/hasura-api/metadata-json/unified.json
@@ -1,5 +1,5 @@
 {
-  "resource_version": 326,
+  "resource_version": 268,
   "metadata": {
     "version": 3,
     "sources": [
@@ -634,6 +634,7 @@
                     "is_gas_fee",
                     "is_transaction_success",
                     "owner_address",
+                    "storage_refund_amount",
                     "transaction_timestamp",
                     "transaction_version"
                   ],
@@ -1733,6 +1734,7 @@
                     "is_transaction_success",
                     "owner_address",
                     "storage_id",
+                    "storage_refund_amount",
                     "token_standard",
                     "transaction_timestamp",
                     "transaction_version",

--- a/hasura-api/metadata-json/unified.json
+++ b/hasura-api/metadata-json/unified.json
@@ -308,7 +308,7 @@
                     },
                     "insertion_order": null,
                     "remote_table": {
-                      "name": "delegated_staking_activities",
+                      "name": "fungible_asset_activities",
                       "schema": "public"
                     }
                   }

--- a/rust/processor/migrations/2023-09-07-175640_storage_refund/down.sql
+++ b/rust/processor/migrations/2023-09-07-175640_storage_refund/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE coin_activities DROP COLUMN IF EXISTS storage_refund_amount;
+ALTER TABLE fungible_asset_activities DROP COLUMN IF EXISTS storage_refund_amount;

--- a/rust/processor/migrations/2023-09-07-175640_storage_refund/up.sql
+++ b/rust/processor/migrations/2023-09-07-175640_storage_refund/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE coin_activities
+ADD COLUMN IF NOT EXISTS storage_refund_amount NUMERIC NOT NULL DEFAULT 0;
+ALTER TABLE fungible_asset_activities
+ADD COLUMN IF NOT EXISTS storage_refund_amount NUMERIC NOT NULL DEFAULT 0;

--- a/rust/processor/src/models/coin_models/coin_activities.rs
+++ b/rust/processor/src/models/coin_models/coin_activities.rs
@@ -14,24 +14,28 @@ use super::{
 use crate::{
     models::{
         default_models::signatures::Signature,
-        fungible_asset_models::v2_fungible_asset_activities::{
-            CoinType, CurrentCoinBalancePK, EventToCoinType, BURN_GAS_EVENT_CREATION_NUM,
-            BURN_GAS_EVENT_INDEX, GAS_FEE_EVENT,
+        fungible_asset_models::{
+            v2_fungible_asset_activities::{
+                CoinType, CurrentCoinBalancePK, EventToCoinType, BURN_GAS_EVENT_CREATION_NUM,
+                BURN_GAS_EVENT_INDEX, GAS_FEE_EVENT,
+            },
+            v2_fungible_asset_utils::FeeStatement,
         },
     },
     processors::coin_processor::APTOS_COIN_TYPE_STR,
     schema::coin_activities,
-    utils::util::{get_entry_function_from_user_request, standardize_address},
+    utils::util::{get_entry_function_from_user_request, standardize_address, u64_to_bigdecimal},
 };
 use aptos_indexer_protos::transaction::v1::{
     transaction::TxnData, write_set_change::Change as WriteSetChangeEnum, Event as EventPB,
     Transaction as TransactionPB, TransactionInfo, UserTransactionRequest,
 };
-use bigdecimal::BigDecimal;
+use bigdecimal::{BigDecimal, Zero};
 use chrono::NaiveDateTime;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
 #[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(
     transaction_version,
@@ -56,6 +60,7 @@ pub struct CoinActivity {
     pub transaction_timestamp: chrono::NaiveDateTime,
     pub event_index: Option<i64>,
     pub gas_fee_payer_address: Option<String>,
+    pub storage_refund_amount: BigDecimal,
 }
 
 impl CoinActivity {
@@ -115,6 +120,11 @@ impl CoinActivity {
         // Handling gas first
         let mut entry_function_id_str = None;
         if let Some(user_request) = maybe_user_request {
+            let fee_statement = events.iter().find_map(|event| {
+                let event_type = event.type_str.as_str();
+                FeeStatement::from_event(event_type, &event.data, txn_version)
+            });
+
             entry_function_id_str = get_entry_function_from_user_request(user_request);
             coin_activities.push(Self::get_gas_event(
                 transaction_info,
@@ -123,6 +133,7 @@ impl CoinActivity {
                 txn_version,
                 txn_timestamp,
                 block_height,
+                fee_statement,
             ));
         }
 
@@ -249,6 +260,7 @@ impl CoinActivity {
             transaction_timestamp,
             event_index: Some(event_index),
             gas_fee_payer_address: None,
+            storage_refund_amount: BigDecimal::zero(),
         }
     }
 
@@ -259,6 +271,7 @@ impl CoinActivity {
         transaction_version: i64,
         transaction_timestamp: chrono::NaiveDateTime,
         block_height: i64,
+        fee_statement: Option<FeeStatement>,
     ) -> Self {
         let aptos_coin_burned =
             BigDecimal::from(txn_info.gas_used * user_transaction_request.gas_unit_price);
@@ -293,6 +306,9 @@ impl CoinActivity {
             transaction_timestamp,
             event_index: Some(BURN_GAS_EVENT_INDEX),
             gas_fee_payer_address,
+            storage_refund_amount: fee_statement
+                .map(|fs| u64_to_bigdecimal(fs.storage_fee_refund_octas))
+                .unwrap_or(BigDecimal::zero()),
         }
     }
 }

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_utils.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_utils.rs
@@ -25,6 +25,30 @@ const FUNGIBLE_ASSET_SYMBOL: usize = 10;
 /// Tracks all fungible asset related data in a hashmap for quick access (keyed on address of the object core)
 pub type FungibleAssetAggregatedDataMapping = HashMap<CurrentObjectPK, FungibleAssetAggregatedData>;
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FeeStatement {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub storage_fee_refund_octas: u64,
+}
+
+impl FeeStatement {
+    pub fn from_event(data_type: &str, data: &str, txn_version: i64) -> Option<Self> {
+        if data_type == "0x1::transaction_fee::FeeStatement" {
+            let fee_statement: FeeStatement = serde_json::from_str(data).unwrap_or_else(|_| {
+                tracing::error!(
+                    transaction_version = txn_version,
+                    data = data,
+                    "failed to parse event for fee statement"
+                );
+                panic!();
+            });
+            Some(fee_statement)
+        } else {
+            None
+        }
+    }
+}
+
 /// This contains objects used by fungible assets
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FungibleAssetAggregatedData {

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -10,7 +10,7 @@ use crate::{
                 CurrentFungibleAssetBalance, CurrentFungibleAssetMapping, FungibleAssetBalance,
             },
             v2_fungible_asset_utils::{
-                FungibleAssetAggregatedData, FungibleAssetAggregatedDataMapping,
+                FeeStatement, FungibleAssetAggregatedData, FungibleAssetAggregatedDataMapping,
                 FungibleAssetMetadata, FungibleAssetStore,
             },
             v2_fungible_metadata::{FungibleAssetMetadataMapping, FungibleAssetMetadataModel},
@@ -408,6 +408,11 @@ fn parse_v2_coin(
         for (index, event) in events.iter().enumerate() {
             // The artificial gas event, only need for v1
             if let Some(req) = user_request {
+                let fee_statement = events.iter().find_map(|event| {
+                    let event_type = event.type_str.as_str();
+                    FeeStatement::from_event(event_type, &event.data, txn_version)
+                });
+
                 let gas_event = FungibleAssetActivity::get_gas_event(
                     transaction_info,
                     req,
@@ -415,6 +420,7 @@ fn parse_v2_coin(
                     txn_version,
                     txn_timestamp,
                     block_height,
+                    fee_statement,
                 );
                 fungible_asset_activities.push(gas_event);
             }

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -85,6 +85,7 @@ diesel::table! {
         event_index -> Nullable<Int8>,
         #[max_length = 66]
         gas_fee_payer_address -> Nullable<Varchar>,
+        storage_refund_amount -> Numeric,
     }
 }
 
@@ -634,6 +635,7 @@ diesel::table! {
         token_standard -> Varchar,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
+        storage_refund_amount -> Numeric,
     }
 }
 


### PR DESCRIPTION
Add new field to coin and fungible asset activities to indicate storage refund. 

## Backfill
It's not in testnet or mainnet just yet, so using ledger for now
Testnet: 667675894
Mainnet: 255894550

## Test
<img width="1112" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/a776c833-ba3a-45d5-b8c6-aecd5c81f443">
<img width="1115" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/d60135ba-9c38-4e49-83f7-4f4f904119eb">
