### PR TITLE
Add post-processor to docker build

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -11,6 +11,8 @@ COPY --link . /app
 RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev lld
 RUN cargo build --locked --release -p processor
 RUN cp target/release/processor /usr/local/bin
+RUN cargo build --locked --release -p post-processor
+RUN cp target/release/post-processor /usr/local/bin
 
 # add build info
 ARG GIT_TAG
@@ -25,6 +27,7 @@ ENV GIT_SHA ${GIT_SHA}
 FROM debian:bullseye-slim
 
 COPY --from=builder /usr/local/bin/processor /usr/local/bin
+COPY --from=builder /usr/local/bin/post-processor /usr/local/bin
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/typescript/aptos-indexer-protos/src/aptos/indexer/v1/raw_data.ts
+++ b/typescript/aptos-indexer-protos/src/aptos/indexer/v1/raw_data.ts
@@ -1,15 +1,13 @@
 /* eslint-disable */
 import {
-  CallOptions,
   ChannelCredentials,
   Client,
-  ClientOptions,
   ClientReadableStream,
   handleServerStreamingCall,
   makeGenericClientConstructor,
   Metadata,
-  UntypedServiceImplementation,
 } from "@grpc/grpc-js";
+import type { CallOptions, ClientOptions, UntypedServiceImplementation } from "@grpc/grpc-js";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Transaction } from "../../transaction/v1/transaction";

--- a/typescript/aptos-indexer-protos/src/aptos/internal/fullnode/v1/fullnode_data.ts
+++ b/typescript/aptos-indexer-protos/src/aptos/internal/fullnode/v1/fullnode_data.ts
@@ -1,15 +1,13 @@
 /* eslint-disable */
 import {
-  CallOptions,
   ChannelCredentials,
   Client,
-  ClientOptions,
   ClientReadableStream,
   handleServerStreamingCall,
   makeGenericClientConstructor,
   Metadata,
-  UntypedServiceImplementation,
 } from "@grpc/grpc-js";
+import type { CallOptions, ClientOptions, UntypedServiceImplementation } from "@grpc/grpc-js";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Transaction } from "../../../transaction/v1/transaction";


### PR DESCRIPTION
Update Dockerfile to include `post-processor` binary in the final docker image. `post-processor` binary will be used to deploy it in cloud run. 