### PR TITLE
[Rust] Handle case of missing gas when events is empty

### DIFF
--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -404,26 +404,26 @@ fn parse_v2_coin(
             }
         }
 
+        // The artificial gas event, only need for v1
+        if let Some(req) = user_request {
+            let fee_statement = events.iter().find_map(|event| {
+                let event_type = event.type_str.as_str();
+                FeeStatement::from_event(event_type, &event.data, txn_version)
+            });
+            let gas_event = FungibleAssetActivity::get_gas_event(
+                transaction_info,
+                req,
+                &entry_function_id_str,
+                txn_version,
+                txn_timestamp,
+                block_height,
+                fee_statement,
+            );
+            fungible_asset_activities.push(gas_event);
+        }
+
         // Loop to handle events and collect additional metadata from events for v2
         for (index, event) in events.iter().enumerate() {
-            // The artificial gas event, only need for v1
-            if let Some(req) = user_request {
-                let fee_statement = events.iter().find_map(|event| {
-                    let event_type = event.type_str.as_str();
-                    FeeStatement::from_event(event_type, &event.data, txn_version)
-                });
-
-                let gas_event = FungibleAssetActivity::get_gas_event(
-                    transaction_info,
-                    req,
-                    &entry_function_id_str,
-                    txn_version,
-                    txn_timestamp,
-                    block_height,
-                    fee_statement,
-                );
-                fungible_asset_activities.push(gas_event);
-            }
             if let Some(v1_activity) = FungibleAssetActivity::get_v1_from_event(
                 event,
                 txn_version,

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -711,6 +711,7 @@ pub async fn create_fetcher_loop(
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
             info!("[Parser] The stream is ended.");
+            break;
         } else {
             // The rest is to see if we need to reconnect
             if is_success {


### PR DESCRIPTION
* Fix bug where events is 0, we missed gas event for fungible_asset_processor. 
* Also added break when ending_version is specified

## Backfill
Easiest to just backfill from 0. 

## Testing
<img width="993" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/aa8919bd-3fee-4732-8e02-c4d283889d90">
