### PR TITLE
Make it possible to run migrations separately in the Rust processors

### DIFF
--- a/rust/post-processor/src/main.rs
+++ b/rust/post-processor/src/main.rs
@@ -59,5 +59,6 @@ impl RunnableConfig for PostProcessorConfig {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = ServerArgs::parse();
-    args.run::<PostProcessorConfig>().await
+    args.run::<PostProcessorConfig>(tokio::runtime::Handle::current())
+        .await
 }

--- a/rust/processor/src/config.rs
+++ b/rust/processor/src/config.rs
@@ -21,9 +21,6 @@ pub struct IndexerGrpcProcessorConfig {
     pub starting_version: Option<u64>,
     pub ending_version: Option<u64>,
     pub number_concurrent_processing_tasks: Option<usize>,
-    /// If set, skip running migrations.
-    #[serde(default)]
-    pub skip_migrations: bool,
 }
 
 #[async_trait::async_trait]
@@ -38,7 +35,6 @@ impl RunnableConfig for IndexerGrpcProcessorConfig {
             self.starting_version,
             self.ending_version,
             self.number_concurrent_processing_tasks,
-            self.skip_migrations,
         )
         .await
         .context("Failed to build worker")?;

--- a/rust/processor/src/config.rs
+++ b/rust/processor/src/config.rs
@@ -21,6 +21,9 @@ pub struct IndexerGrpcProcessorConfig {
     pub starting_version: Option<u64>,
     pub ending_version: Option<u64>,
     pub number_concurrent_processing_tasks: Option<usize>,
+    /// If set, skip running migrations.
+    #[serde(default)]
+    pub skip_migrations: bool,
 }
 
 #[async_trait::async_trait]
@@ -35,6 +38,7 @@ impl RunnableConfig for IndexerGrpcProcessorConfig {
             self.starting_version,
             self.ending_version,
             self.number_concurrent_processing_tasks,
+            self.skip_migrations,
         )
         .await
         .context("Failed to build worker")?;

--- a/rust/processor/src/main.rs
+++ b/rust/processor/src/main.rs
@@ -9,5 +9,6 @@ use server_framework::ServerArgs;
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     let args = ServerArgs::parse();
-    args.run::<IndexerGrpcProcessorConfig>().await
+    args.run::<IndexerGrpcProcessorConfig>(tokio::runtime::Handle::current())
+        .await
 }

--- a/rust/processor/src/utils/database.rs
+++ b/rust/processor/src/utils/database.rs
@@ -10,11 +10,14 @@ use diesel::{
     r2d2::{ConnectionManager, PoolError, PooledConnection},
     QueryResult, RunQueryDsl,
 };
+use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use std::{cmp::min, sync::Arc};
 
 pub type PgPool = diesel::r2d2::Pool<ConnectionManager<PgConnection>>;
 pub type PgDbPool = Arc<PgPool>;
 pub type PgPoolConnection = PooledConnection<ConnectionManager<PgConnection>>;
+
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 #[derive(QueryId)]
 /// Using this will append a where clause at the end of the string upsert function, e.g.
@@ -87,6 +90,11 @@ where
         tracing::warn!("Error running query: {:?}\n{:?}", e, debug_string);
     }
     res
+}
+
+pub fn run_pending_migrations(conn: &mut PgConnection) {
+    conn.run_pending_migrations(MIGRATIONS)
+        .expect("[Parser] Migrations failed!");
 }
 
 /// Section below is required to modify the query.

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -433,13 +433,15 @@ impl Worker {
                 info!(
                     processor_name = processor_name,
                     chain_id = grpc_chain_id,
-                    "[Parser] Adding chain id to db, continue to index.."
+                    "[Parser] Adding chain id to db, continue to index..."
                 );
                 execute_with_better_error(
                     &mut conn,
-                    diesel::insert_into(ledger_infos::table).values(LedgerInfo {
-                        chain_id: grpc_chain_id,
-                    }),
+                    diesel::insert_into(ledger_infos::table)
+                        .values(LedgerInfo {
+                            chain_id: grpc_chain_id,
+                        })
+                        .on_conflict_do_nothing(),
                     None,
                 )
                 .context("[Parser] Error updating chain_id!")

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -65,7 +65,6 @@ pub struct Worker {
     pub starting_version: Option<u64>,
     pub ending_version: Option<u64>,
     pub number_concurrent_processing_tasks: usize,
-    pub skip_migrations: bool,
 }
 
 impl Worker {
@@ -78,7 +77,6 @@ impl Worker {
         starting_version: Option<u64>,
         ending_version: Option<u64>,
         number_concurrent_processing_tasks: Option<usize>,
-        skip_migrations: bool,
     ) -> Result<Self> {
         let processor_name = processor_config.name();
         info!(processor_name = processor_name, "[Parser] Kicking off");
@@ -104,7 +102,6 @@ impl Worker {
             ending_version,
             auth_token,
             number_concurrent_processing_tasks,
-            skip_migrations,
         })
     }
 
@@ -116,17 +113,15 @@ impl Worker {
     /// 4. We will keep track of the last processed version and monitoring things like TPS
     pub async fn run(&mut self) {
         let processor_name = self.processor_config.name();
-        if !self.skip_migrations {
-            info!(
-                processor_name = processor_name,
-                "[Parser] Running migrations"
-            );
-            self.run_migrations();
-            info!(
-                processor_name = processor_name,
-                "[Parser] Finished migrations"
-            );
-        }
+        info!(
+            processor_name = processor_name,
+            "[Parser] Running migrations"
+        );
+        self.run_migrations();
+        info!(
+            processor_name = processor_name,
+            "[Parser] Finished migrations"
+        );
 
         let starting_version_from_db = self
             .get_start_version()


### PR DESCRIPTION
From the CLI I need to be able to run migrations only once due to this problem: https://aptos-org.slack.com/archives/C04PRP1K1FZ/p1695747178956299. This makes it possible.

This is a backwards compatible change re existing configs, they should all work fine as they are now.

I also fix issues with concurrent chain ID updates.