### PR TITLE
Fix nested runtimes issue with Rust processors

### DIFF
--- a/rust/post-processor/src/main.rs
+++ b/rust/post-processor/src/main.rs
@@ -59,5 +59,6 @@ impl RunnableConfig for PostProcessorConfig {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = ServerArgs::parse();
-    args.run::<PostProcessorConfig>().await
+    args.run::<PostProcessorConfig>(tokio::runtime::Handle::current())
+        .await
 }

--- a/rust/processor/src/main.rs
+++ b/rust/processor/src/main.rs
@@ -9,5 +9,6 @@ use server_framework::ServerArgs;
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     let args = ServerArgs::parse();
-    args.run::<IndexerGrpcProcessorConfig>().await
+    args.run::<IndexerGrpcProcessorConfig>(tokio::runtime::Handle::current())
+        .await
 }


### PR DESCRIPTION
## Description
Currently we create a runtime from within the context of a runtime. This is a big no no with tokio and can cause a variety of issues, particularly when using this code from another place: https://stackoverflow.com/q/62536566/3846032.

To address this, instead of creating a runtime in `run_server_with_config`, I require that the caller passes in a handle.

## Test Plan
I ran the formatter, linter, tests, and succesfully ran a processor against a txn stream.