### PR TITLE
Switch to diesel-async

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -250,6 +250,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "bb8"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b4b0f25f18bcdc3ac72bdb486ed0acf7e185221fd4dc985bc15db5800b0ba2"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
 name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d#d31fab9d81748e2594be5cd5cdf845786a30562d"
@@ -492,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
+checksum = "53c8a2cb22327206568569e5a45bb5a2c946455efdd76e24d15b7e82171af95e"
 dependencies = [
  "bigdecimal",
  "bitflags 2.3.3",
@@ -505,16 +518,41 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "pq-sys",
- "r2d2",
  "serde_json",
 ]
 
 [[package]]
-name = "diesel_derives"
-version = "2.1.0"
+name = "diesel-async"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
+checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "diesel_async_migrations"
+version = "0.11.0"
+source = "git+https://github.com/niroco/diesel_async_migrations?rev=11f331b73c5cfcc894380074f748d8fda710ac12#11f331b73c5cfcc894380074f748d8fda710ac12"
+dependencies = [
+ "diesel",
+ "diesel-async",
+ "macros",
+ "scoped-futures",
+ "tracing",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
 dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
@@ -559,6 +597,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -622,6 +661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +693,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "flate2"
@@ -1011,6 +1062,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "home"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,7 +1130,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1321,6 +1381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "macros"
+version = "0.1.0"
+source = "git+https://github.com/niroco/diesel_async_migrations?rev=11f331b73c5cfcc894380074f748d8fda710ac12#11f331b73c5cfcc894380074f748d8fda710ac12"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1409,16 @@ name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -1610,6 +1689,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,19 +1784,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
+dependencies = [
+ "base64 0.21.2",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2 0.10.8",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "pq-sys"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0052426df997c0cbd30789eb44ca097e3541717a7b8fa36b1c464ee7edebd"
-dependencies = [
- "vcpkg",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1724,6 +1841,8 @@ dependencies = [
  "chrono",
  "clap",
  "diesel",
+ "diesel-async",
+ "diesel_async_migrations",
  "diesel_migrations",
  "enum_dispatch",
  "field_count",
@@ -1741,7 +1860,7 @@ dependencies = [
  "serde",
  "serde_json",
  "server-framework",
- "sha2",
+ "sha2 0.9.9",
  "sha3",
  "strum",
  "tokio",
@@ -1820,17 +1939,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r2d2"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
-dependencies = [
- "log",
- "parking_lot",
- "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -2099,12 +2207,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
+name = "scoped-futures"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
 dependencies = [
- "parking_lot",
+ "cfg-if",
+ "pin-utils",
 ]
 
 [[package]]
@@ -2275,6 +2384,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,6 +2468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +2488,17 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "strsim"
@@ -2380,6 +2527,12 @@ dependencies = [
  "rustversion",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2521,7 +2674,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys",
 ]
@@ -2555,6 +2708,32 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2 0.5.4",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -3101,6 +3280,16 @@ name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,18 +28,20 @@ anyhow = "1.0.62"
 async-trait = "0.1.53"
 backtrace = "0.3.58"
 base64 = "0.13.0"
+bb8 = "0.8.1"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 bigdecimal = { version = "0.3.0", features = ["serde"] }
 chrono = { version = "0.4.19", features = ["clock", "serde"] }
 clap = { version = "4.3.5", features = ["derive", "unstable-styles"] }
-diesel = { version = "2.1.0", features = [
+diesel = { version = "2.1.1", features = [
     "chrono",
-    "postgres",
-    "r2d2",
+    "postgres_backend",
     "numeric",
     "serde_json",
 ] }
+diesel-async = { version = "0.4", features = ["postgres", "bb8", "tokio"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
+diesel_async_migrations = { git = "https://github.com/niroco/diesel_async_migrations", rev = "11f331b73c5cfcc894380074f748d8fda710ac12" }
 enum_dispatch = "0.3.12"
 field_count = "0.1.1"
 futures = "0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.

--- a/rust/processor/Cargo.toml
+++ b/rust/processor/Cargo.toml
@@ -23,6 +23,8 @@ bigdecimal = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 diesel = { workspace = true }
+diesel-async = { workspace = true }
+diesel_async_migrations = { workspace = true }
 diesel_migrations = { workspace = true }
 enum_dispatch = { workspace = true }
 field_count = { workspace = true }

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
@@ -63,7 +63,7 @@ pub struct FungibleAssetActivity {
 }
 
 impl FungibleAssetActivity {
-    pub fn get_v2_from_event(
+    pub async fn get_v2_from_event(
         event: &Event,
         txn_version: i64,
         block_height: i64,
@@ -71,7 +71,7 @@ impl FungibleAssetActivity {
         event_index: i64,
         entry_function_id_str: &Option<String>,
         fungible_asset_metadata: &FungibleAssetAggregatedDataMapping,
-        conn: &mut PgPoolConnection,
+        conn: &mut PgPoolConnection<'_>,
     ) -> anyhow::Result<Option<Self>> {
         let event_type = event.type_str.clone();
         if let Some(fa_event) =
@@ -90,7 +90,9 @@ impl FungibleAssetActivity {
                     conn,
                     &asset_type,
                     fungible_asset_metadata,
-                ) {
+                )
+                .await
+                {
                     return Ok(None);
                 }
 

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -65,13 +65,13 @@ pub struct CurrentFungibleAssetBalance {
 
 impl FungibleAssetBalance {
     /// Basically just need to index FA Store, but we'll need to look up FA metadata
-    pub fn get_v2_from_write_resource(
+    pub async fn get_v2_from_write_resource(
         write_resource: &WriteResource,
         write_set_change_index: i64,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
         fungible_asset_metadata: &FungibleAssetAggregatedDataMapping,
-        conn: &mut PgPoolConnection,
+        conn: &mut PgPoolConnection<'_>,
     ) -> anyhow::Result<Option<(Self, CurrentFungibleAssetBalance)>> {
         if let Some(inner) = &FungibleAssetStore::from_write_resource(write_resource, txn_version)?
         {
@@ -86,7 +86,9 @@ impl FungibleAssetBalance {
                     conn,
                     &asset_type,
                     fungible_asset_metadata,
-                ) {
+                )
+                .await
+                {
                     return Ok(None);
                 }
                 let is_primary = Self::is_primary(&owner_address, &asset_type, &storage_id);

--- a/rust/processor/src/models/ledger_info.rs
+++ b/rust/processor/src/models/ledger_info.rs
@@ -3,7 +3,8 @@
 
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{schema::ledger_infos, utils::database::PgPoolConnection};
-use diesel::{OptionalExtension, QueryDsl, RunQueryDsl};
+use diesel::{OptionalExtension, QueryDsl};
+use diesel_async::RunQueryDsl;
 
 #[derive(Debug, Identifiable, Insertable, Queryable)]
 #[diesel(table_name = ledger_infos)]
@@ -13,10 +14,11 @@ pub struct LedgerInfo {
 }
 
 impl LedgerInfo {
-    pub fn get(conn: &mut PgPoolConnection) -> diesel::QueryResult<Option<Self>> {
+    pub async fn get(conn: &mut PgPoolConnection<'_>) -> diesel::QueryResult<Option<Self>> {
         ledger_infos::table
             .select(ledger_infos::all_columns)
             .first::<Self>(conn)
+            .await
             .optional()
     }
 }

--- a/rust/processor/src/models/processor_status.rs
+++ b/rust/processor/src/models/processor_status.rs
@@ -3,7 +3,8 @@
 
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{schema::processor_status, utils::database::PgPoolConnection};
-use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
+use diesel_async::RunQueryDsl;
 
 #[derive(AsChangeset, Debug, Insertable)]
 #[diesel(table_name = processor_status)]
@@ -23,13 +24,14 @@ pub struct ProcessorStatusQuery {
 }
 
 impl ProcessorStatusQuery {
-    pub fn get_by_processor(
+    pub async fn get_by_processor(
         processor_name: &str,
-        conn: &mut PgPoolConnection,
+        conn: &mut PgPoolConnection<'_>,
     ) -> diesel::QueryResult<Option<Self>> {
         processor_status::table
             .filter(processor_status::processor.eq(processor_name))
             .first::<Self>(conn)
+            .await
             .optional()
     }
 }

--- a/rust/processor/src/models/token_models/tokens.rs
+++ b/rust/processor/src/models/token_models/tokens.rs
@@ -68,10 +68,10 @@ impl Token {
     ///
     /// We also will compute current versions of the token tables which are at a higher granularity than the transactional tables (only
     /// state at the last transaction will be tracked, hence using hashmap to dedupe)
-    pub fn from_transaction(
+    pub async fn from_transaction(
         transaction: &Transaction,
         table_handle_to_owner: &TableHandleToOwner,
-        conn: &mut PgPoolConnection,
+        conn: &mut PgPoolConnection<'_>,
     ) -> (
         Vec<Self>,
         Vec<TokenOwnership>,
@@ -138,6 +138,7 @@ impl Token {
                                 table_handle_to_owner,
                                 conn,
                             )
+                            .await
                             .unwrap(),
                         ),
                         WriteSetChangeEnum::DeleteTableItem(delete_table_item) => (

--- a/rust/processor/src/models/token_v2_models/v2_collections.rs
+++ b/rust/processor/src/models/token_v2_models/v2_collections.rs
@@ -22,6 +22,7 @@ use anyhow::Context;
 use aptos_indexer_protos::transaction::v1::{WriteResource, WriteTableItem};
 use bigdecimal::{BigDecimal, Zero};
 use diesel::{prelude::*, sql_query, sql_types::Text};
+use diesel_async::RunQueryDsl;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -178,13 +179,13 @@ impl CollectionV2 {
         }
     }
 
-    pub fn get_v1_from_write_table_item(
+    pub async fn get_v1_from_write_table_item(
         table_item: &WriteTableItem,
         txn_version: i64,
         write_set_change_index: i64,
         txn_timestamp: chrono::NaiveDateTime,
         table_handle_to_owner: &TableHandleToOwner,
-        conn: &mut PgPoolConnection,
+        conn: &mut PgPoolConnection<'_>,
     ) -> anyhow::Result<Option<(Self, CurrentCollectionV2)>> {
         let table_item_data = table_item.data.as_ref().unwrap();
 
@@ -204,14 +205,17 @@ impl CollectionV2 {
             let mut creator_address = match maybe_creator_address {
                 Some(ca) => ca,
                 None => {
-                    match Self::get_collection_creator_for_v1(conn, &table_handle).context(format!(
-                        "Failed to get collection creator for table handle {}, txn version {}",
-                        table_handle, txn_version
-                    )) {
+                    match Self::get_collection_creator_for_v1(conn, &table_handle)
+                        .await
+                        .context(format!(
+                            "Failed to get collection creator for table handle {}, txn version {}",
+                            table_handle, txn_version
+                        )) {
                         Ok(ca) => ca,
                         Err(_) => {
                             // Try our best by getting from the older collection data
-                            match CollectionData::get_collection_creator(conn, &table_handle) {
+                            match CollectionData::get_collection_creator(conn, &table_handle).await
+                            {
                                 Ok(creator) => creator,
                                 Err(_) => {
                                     tracing::error!(
@@ -276,14 +280,14 @@ impl CollectionV2 {
     /// If collection data is not in resources of the same transaction, then try looking for it in the database. Since collection owner
     /// cannot change, we can just look in the current_collection_datas table.
     /// Retrying a few times since this collection could've been written in a separate thread.
-    fn get_collection_creator_for_v1(
-        conn: &mut PgPoolConnection,
+    async fn get_collection_creator_for_v1(
+        conn: &mut PgPoolConnection<'_>,
         table_handle: &str,
     ) -> anyhow::Result<String> {
         let mut retried = 0;
         while retried < QUERY_RETRIES {
             retried += 1;
-            match Self::get_by_table_handle(conn, table_handle) {
+            match Self::get_by_table_handle(conn, table_handle).await {
                 Ok(creator) => return Ok(creator),
                 Err(_) => {
                     std::thread::sleep(std::time::Duration::from_millis(QUERY_RETRY_DELAY_MS));
@@ -294,15 +298,16 @@ impl CollectionV2 {
     }
 
     /// TODO: Change this to a KV store
-    fn get_by_table_handle(
-        conn: &mut PgPoolConnection,
+    async fn get_by_table_handle(
+        conn: &mut PgPoolConnection<'_>,
         table_handle: &str,
     ) -> anyhow::Result<String> {
         let mut res: Vec<Option<CreatorFromCollectionTableV1>> = sql_query(
             "SELECT creator_address FROM current_collections_v2 WHERE table_handle_v1 = $1",
         )
         .bind::<Text, _>(table_handle)
-        .get_results(conn)?;
+        .get_results(conn)
+        .await?;
         Ok(res
             .pop()
             .context("collection result empty")?

--- a/rust/processor/src/models/token_v2_models/v2_token_activities.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_activities.rs
@@ -68,14 +68,14 @@ impl TokenActivityV2 {
     /// or by looking up the postgres table.
     /// TODO: Create artificial events for mint and burn. There are no mint and burn events so we'll have to
     /// add all the deposits/withdrawals and if it's positive/negative it's a mint/burn.
-    pub fn get_ft_v2_from_parsed_event(
+    pub async fn get_ft_v2_from_parsed_event(
         event: &Event,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
         event_index: i64,
         entry_function_id_str: &Option<String>,
         token_v2_metadata: &TokenV2AggregatedDataMapping,
-        conn: &mut PgPoolConnection,
+        conn: &mut PgPoolConnection<'_>,
     ) -> anyhow::Result<Option<Self>> {
         let event_type = event.type_str.clone();
         if let Some(fa_event) =
@@ -92,6 +92,7 @@ impl TokenActivityV2 {
                 let token_data_id = fungible_asset.metadata.get_reference_address();
                 // Exit early if it's not a token
                 if !TokenDataV2::is_address_fungible_token(conn, &token_data_id, token_v2_metadata)
+                    .await
                 {
                     return Ok(None);
                 }

--- a/rust/processor/src/models/token_v2_models/v2_token_datas.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_datas.rs
@@ -18,6 +18,7 @@ use anyhow::Context;
 use aptos_indexer_protos::transaction::v1::{WriteResource, WriteTableItem};
 use bigdecimal::{BigDecimal, Zero};
 use diesel::{prelude::*, sql_query, sql_types::Text};
+use diesel_async::RunQueryDsl;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -235,8 +236,8 @@ impl TokenDataV2 {
     /// A fungible asset can also be a token. We will make a best effort guess at whether this is a fungible token.
     /// 1. If metadata is present with a token object, then is a token
     /// 2. If metadata is not present, we will do a lookup in the db.
-    pub fn is_address_fungible_token(
-        conn: &mut PgPoolConnection,
+    pub async fn is_address_fungible_token(
+        conn: &mut PgPoolConnection<'_>,
         address: &str,
         token_v2_metadata: &TokenV2AggregatedDataMapping,
     ) -> bool {
@@ -244,7 +245,7 @@ impl TokenDataV2 {
             metadata.token.is_some()
         } else {
             // Look up in the db
-            Self::query_is_address_token(conn, address)
+            Self::query_is_address_token(conn, address).await
         }
     }
 
@@ -252,11 +253,11 @@ impl TokenDataV2 {
     /// and if we can't find after 3 times, we'll assume that it's not a token.
     /// TODO: An improvement is to combine this with is_address_coin. To do this well we need
     /// a k-v store
-    fn query_is_address_token(conn: &mut PgPoolConnection, address: &str) -> bool {
+    async fn query_is_address_token(conn: &mut PgPoolConnection<'_>, address: &str) -> bool {
         let mut retried = 0;
         while retried < QUERY_RETRIES {
             retried += 1;
-            match Self::get_by_token_data_id(conn, address) {
+            match Self::get_by_token_data_id(conn, address).await {
                 Ok(_) => return true,
                 Err(_) => {
                     std::thread::sleep(std::time::Duration::from_millis(QUERY_RETRY_DELAY_MS));
@@ -267,11 +268,15 @@ impl TokenDataV2 {
     }
 
     /// TODO: Change this to a KV store
-    fn get_by_token_data_id(conn: &mut PgPoolConnection, address: &str) -> anyhow::Result<String> {
+    async fn get_by_token_data_id(
+        conn: &mut PgPoolConnection<'_>,
+        address: &str,
+    ) -> anyhow::Result<String> {
         let mut res: Vec<Option<TokenDataIdFromTable>> =
             sql_query("SELECT token_data_id FROM current_token_datas_v2 WHERE token_data_id = $1")
                 .bind::<Text, _>(address)
-                .get_results(conn)?;
+                .get_results(conn)
+                .await?;
         Ok(res
             .pop()
             .context("token data result empty")?


### PR DESCRIPTION
## Summary
There are two main reasons to do this:
- Better perf since we don't block waiting for I/O to happen (esp if I can get pipelining to work).
- Breaking the dep on libpq.

As you can see, at least without pipelining, this PR has no real effect on perf, but in neither direction, it's just the same.

Update: I think I got pipelining to work (at least, it should be working as per the docs), but the impact was negligible. Probably our workload just doesn't benefit from it, not too sure: https://github.com/aptos-labs/aptos-indexer-processors/pull/147.

## Test Plan
### Performance testing
Using this config:
```
health_check_port: 8084
server_config:
  processor_config:
    type: default_processor
  postgres_connection_string: postgresql://postgres:@localhost:5432/default_processor
  indexer_grpc_data_service_address: https://grpc.testnet.aptoslabs.com
  auth_token: <token>
```

Note: Prior to these results I ran this once all the way up to txn 2.5 million to warm up the cache upstream (just in case).

Experiment results. What txn we got up to after 3 minutes (last_success_version in the DB):

Built from main
1. Run 1: 2261999
1. Run 2: 2162999
1. Run 3: 2091999
1. Average: 2172332

Built from this branch
1. Run 1: 2250999
1. Run 2: 2231999
1. Run 3: 2030999
1. Average: 2171332
  
I alternated runs, so I did run 1 for each, then run 2 for each, then run 3 for each.

I ran tests with degraded networking: 100ms latency on downlink and uplink, 1% packet loss, and 50mbps bandwidth down / 10mbps up. There was no noticeable difference between the two builds (we weren't I/O bound in the end).

I used this command. I made sure the binary was built first:
```
timeout 180 target/release/processor -c processor/parser.yaml
```