### PR TITLE
[Python] Add grpc reconnection logic to python processors

### DIFF
--- a/python/processors/main.py
+++ b/python/processors/main.py
@@ -1,6 +1,7 @@
 import argparse
 from utils.config import Config
 from utils.worker import IndexerProcessorServer
+import asyncio
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -11,4 +12,4 @@ if __name__ == "__main__":
     indexer_server = IndexerProcessorServer(
         config,
     )
-    indexer_server.run()
+    asyncio.run(indexer_server.run())

--- a/python/processors/main.py
+++ b/python/processors/main.py
@@ -1,7 +1,6 @@
 import argparse
 from utils.config import Config
 from utils.worker import IndexerProcessorServer
-import asyncio
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -12,4 +11,4 @@ if __name__ == "__main__":
     indexer_server = IndexerProcessorServer(
         config,
     )
-    asyncio.run(indexer_server.run())
+    indexer_server.run()

--- a/python/utils/worker.py
+++ b/python/utils/worker.py
@@ -10,7 +10,7 @@ from utils.session import Session
 from utils.metrics import PROCESSED_TRANSACTIONS_COUNTER
 from sqlalchemy import DDL, create_engine
 from sqlalchemy import event
-from typing import List
+from typing import Iterator, List, Optional
 from prometheus_client.twisted import MetricsResource
 from twisted.web.server import Site
 from twisted.web.resource import Resource
@@ -18,7 +18,7 @@ from twisted.internet import reactor
 import threading
 import sys
 from utils.transactions_processor import TransactionsProcessor, ProcessingResult
-from time import perf_counter
+from time import perf_counter, sleep
 import traceback
 from utils.processor_name import ProcessorName
 from processors.example_event_processor.processor import ExampleEventProcessor
@@ -26,8 +26,460 @@ from processors.nft_orderbooks.nft_marketplace_processor import NFTMarketplacePr
 from processors.nft_marketplace_v2.processor import NFTMarketplaceV2Processor
 from processors.coin_flip.processor import CoinFlipProcessor
 from processors.aptos_ambassador_token.processor import AptosAmbassadorTokenProcessor
+import asyncio
+import logging
+import queue
+import os
 
 INDEXER_GRPC_BLOB_STORAGE_SIZE = 1000
+INDEXER_GRPC_MIN_SEC_BETWEEN_GRPC_RECONNECTS = 60
+# How large the fetcher queue should be
+FETCHER_QUEUE_SIZE = 50
+# We will try to reconnect to GRPC once every X seconds if we get disconnected, before crashing
+# We define short connection issue as < 10 seconds so adding a bit of a buffer here
+MIN_SEC_BETWEEN_GRPC_RECONNECTS = 15
+# We will try to reconnect to GRPC 5 times in case upstream connection is being updated
+RECONNECTION_MAX_RETRIES = 5
+
+
+def get_grpc_stream(
+    indexer_grpc_data_service_address: str,
+    indexer_grpc_data_stream_api_key: str,
+    indexer_grpc_http2_ping_interval_in_secs: int,
+    indexer_grpc_http2_ping_timeout_in_secs: int,
+    starting_version: int,
+    ending_version: Optional[int],
+    processor_name: str,
+) -> Iterator[raw_data_pb2.TransactionsResponse]:
+    logging.info(
+        json.dumps(
+            {
+                "processor_name": processor_name,
+                "stream_address": indexer_grpc_data_service_address,
+                "message": "[Parser] Setting up rpc channel",
+            }
+        ),
+    )
+
+    metadata = (
+        ("authorization", "Bearer " + indexer_grpc_data_stream_api_key),
+        ("x-aptos-request-name", processor_name),
+    )
+    options = [
+        ("grpc.max_receive_message_length", -1),
+        (
+            "grpc.keepalive_time_ms",
+            indexer_grpc_http2_ping_interval_in_secs * 1000,
+        ),
+        (
+            "grpc.keepalive_timeout_ms",
+            indexer_grpc_http2_ping_timeout_in_secs * 1000,
+        ),
+    ]
+
+    channel = grpc.secure_channel(
+        indexer_grpc_data_service_address,
+        options=options,
+        credentials=grpc.ssl_channel_credentials(),
+    )
+    transactions_count = (
+        ending_version - starting_version + 1 if ending_version else None
+    )
+
+    logging.info(
+        json.dumps(
+            {
+                "processor_name": processor_name,
+                "stream_address": indexer_grpc_data_service_address,
+                "starting_version": starting_version,
+                "ending_version": ending_version,
+                "count": transactions_count,
+                "message": "[Parser] Setting up stream",
+            }
+        ),
+    )
+
+    try:
+        stub = raw_data_pb2_grpc.RawDataStub(channel)
+        request = raw_data_pb2.GetTransactionsRequest(
+            starting_version=starting_version, transactions_count=transactions_count
+        )
+        responses = stub.GetTransactions(request, metadata=metadata)
+        return iter(responses)
+    except Exception as e:
+        logging.exception(
+            json.dumps(
+                {
+                    "message": "[Parser] Failed to get grpc response. Is the server running?",
+                }
+            ),
+        )
+        os._exit(1)
+
+
+# Gets a batch of transactions from the stream. Batch size is set in the grpc server.
+# The number of batches depends on our config
+# There could be several special scenarios:
+# 1. If we lose the connection, we will try reconnecting X times within Y seconds before crashing.
+# 2. If we specified an end version and we hit that, we will stop fetching, but we will make sure that
+# all existing transactions are processed
+def producer(
+    q: queue.Queue,
+    indexer_grpc_data_service_address: str,
+    indexer_grpc_data_stream_api_key: str,
+    indexer_grpc_http2_ping_interval: int,
+    indexer_grpc_http2_ping_timeout: int,
+    starting_version: int,
+    ending_version: Optional[int],
+    processor_name: str,
+    batch_start_version: int,
+):
+    last_insertion_time = perf_counter()
+    next_version_to_fetch = batch_start_version
+    last_reconnection_time = None
+    reconnection_retries = 0
+    response_stream = get_grpc_stream(
+        indexer_grpc_data_service_address,
+        indexer_grpc_data_stream_api_key,
+        indexer_grpc_http2_ping_interval,
+        indexer_grpc_http2_ping_timeout,
+        starting_version,
+        ending_version,
+        processor_name,
+    )
+
+    logging.info(
+        json.dumps(
+            {
+                "processor_name": processor_name,
+                "stream_address": indexer_grpc_data_service_address,
+                "starting_version": starting_version,
+                "ending_version": ending_version,
+                "message": "[Parser] Successfully connected to GRPC endpoint",
+            }
+        ),
+    )
+
+    while True:
+        is_success = False
+        try:
+            response = next(response_stream)
+            reconnection_retries = 0
+            batch_start_version = response.transactions[0].version
+            batch_end_version = response.transactions[-1].version
+            next_version_to_fetch = batch_end_version + 1
+
+            chain_id = response.chain_id
+            assert chain_id is not None, "[Parser] Chain Id doesn't exist"
+            q.put((chain_id, response.transactions))
+
+            logging.info(
+                json.dumps(
+                    {
+                        "processor_name": processor_name,
+                        "start_version": str(batch_start_version),
+                        "end_version": str(batch_end_version),
+                        "channel_size": q.qsize(),
+                        "channel_recv_latency_in_secs": str(
+                            format(perf_counter() - last_insertion_time, ".8f")
+                        ),
+                        "message": "[Parser] Received chunk of transactions",
+                    }
+                ),
+            )
+            last_insertion_time = perf_counter()
+            is_success = True
+        except StopIteration:
+            logging.info(
+                json.dumps(
+                    {
+                        "processor_name": processor_name,
+                        "stream_address": indexer_grpc_data_service_address,
+                        "message": "[Parser] Stream ended",
+                    }
+                ),
+            )
+        except Exception as e:
+            logging.exception(
+                json.dumps(
+                    {
+                        "processor_name": processor_name,
+                        "stream_address": indexer_grpc_data_service_address,
+                        "message": "[Parser] Error receiving datastream response",
+                    },
+                    indent=4,
+                )
+            )
+
+        # Check if we're at the end of the stream
+        reached_ending_version = (
+            next_version_to_fetch > ending_version if ending_version else False
+        )
+        if reached_ending_version:
+            logging.info(
+                json.dumps(
+                    {
+                        "processor_name": processor_name,
+                        "stream_address": indexer_grpc_data_service_address,
+                        "ending_version": ending_version,
+                        "next_version_to_fetch": next_version_to_fetch,
+                        "message": "[Parser] Reached ending version",
+                    }
+                ),
+            )
+            # Wait for the fetched transactions to finish processing before closing the channel
+            while True:
+                logging.info(
+                    json.dumps(
+                        {
+                            "processor_name": processor_name,
+                            "channel_size": q.qsize(),
+                            "message": "[Parser] Waiting for channel to be empty",
+                        }
+                    ),
+                )
+                if q.qsize() == 0:
+                    break
+            logging.info(
+                json.dumps(
+                    {
+                        "message": "[Parser] The stream is ended",
+                    }
+                ),
+            )
+            break
+        else:
+            # The rest is to see if we need to reconnect
+            if is_success:
+                continue
+
+            if last_reconnection_time:
+                elapsed_secs = perf_counter() - last_reconnection_time
+                if (
+                    reconnection_retries >= RECONNECTION_MAX_RETRIES
+                    and elapsed_secs < MIN_SEC_BETWEEN_GRPC_RECONNECTS
+                ):
+                    logging.warn(
+                        json.dumps(
+                            {
+                                "processor_name": processor_name,
+                                "stream_address": indexer_grpc_data_service_address,
+                                "seconds_since_last_retry": str(elapsed_secs),
+                                "message": "[Parser] Recently reconnected. Will not retry.",
+                            }
+                        ),
+                    )
+                    os._exit(1)
+            reconnection_retries += 1
+            last_reconnection_time = perf_counter()
+            logging.info(
+                json.dumps(
+                    {
+                        "processor_name": processor_name,
+                        "stream_address": indexer_grpc_data_service_address,
+                        "starting_version": next_version_to_fetch,
+                        "ending_version": ending_version,
+                        "reconnection_retries": reconnection_retries,
+                        "message": "[Parser] Reconnecting to GRPC.",
+                    }
+                ),
+            )
+            response_stream = get_grpc_stream(
+                indexer_grpc_data_service_address,
+                indexer_grpc_data_stream_api_key,
+                indexer_grpc_http2_ping_interval,
+                indexer_grpc_http2_ping_timeout,
+                next_version_to_fetch,
+                ending_version,
+                processor_name,
+            )
+
+
+# This is the consumer side of the channel. These are the major states:
+# 1. We're backfilling so we should expect many concurrent threads to process transactions
+# 2. We're caught up so we should expect a single thread to process transactions
+# 3. We have received either an empty batch or a batch with a gap. We should panic.
+# 4. We have not received anything in X seconds, we should panic.
+# 5. If it's the wrong chain, panic.
+def consumer(
+    q: queue.Queue,
+    producer_thread: threading.Thread,
+    indexer_grpc_data_stream_endpoint: str,
+    processor: TransactionsProcessor,
+    num_concurrent_processing_tasks: int,
+    starting_version: int,
+    processor_name: str,
+):
+    asyncio.run(
+        consumer_impl(
+            q,
+            producer_thread,
+            indexer_grpc_data_stream_endpoint,
+            processor,
+            num_concurrent_processing_tasks,
+            starting_version,
+            processor_name,
+        )
+    )
+
+
+async def consumer_impl(
+    q: queue.Queue,
+    producer_thread: threading.Thread,
+    indexer_grpc_data_stream_endpoint: str,
+    processor: TransactionsProcessor,
+    num_concurrent_processing_tasks: int,
+    starting_version: int,
+    processor_name: str,
+):
+    chain_id = None
+    batch_start_version = starting_version
+
+    while True:
+        tps_start_time = perf_counter()
+
+        # Check if producer task is done
+        if not producer_thread.is_alive():
+            logging.info(
+                json.dumps(
+                    {
+                        "processor_name": processor_name,
+                        "message": "[Parser] Channel closed; stream ended.",
+                    }
+                ),
+            )
+            os._exit(0)
+
+        # Fetch transaction batches from channel to process
+        transaction_batches = []
+        last_fetched_version = batch_start_version - 1
+        for task_index in range(num_concurrent_processing_tasks):
+            if task_index == 0:
+                # If we're the first task, we should wait until we get data.
+                chain_id, transactions = q.get()
+            else:
+                # If we're not the first task, we should poll to see if we get any data.
+                try:
+                    chain_id, transactions = q.get_nowait()
+                except queue.Empty:
+                    # Channel is empty and send is not dropped which we definitely expect. Wait for a bit and continue polling.
+                    continue
+
+            # TODO: Check chain_id saved in DB
+
+            current_fetched_version = transactions[0].version
+            if last_fetched_version + 1 != current_fetched_version:
+                logging.warn(
+                    json.dumps(
+                        {
+                            "processor_name": processor_name,
+                            "last_fetched_version": last_fetched_version,
+                            "current_fetched_version": current_fetched_version,
+                            "message": "[Parser] Received batch with gap from GRPC stream",
+                        }
+                    )
+                )
+                os._exit(1)
+            last_fetched_version = transactions[-1].version
+            transaction_batches.append(transactions)
+
+        # Process the transactions in parallel
+        # TODO: Add processor metrics
+        async def create_processor_task(transactions):
+            start_version = transactions[0].version
+            end_version = transactions[-1].version
+            processing_result = processor.process_transactions(
+                transactions, start_version, end_version
+            )
+            return processing_result
+
+        processor_threads = []
+        for transactions in transaction_batches:
+            thread = IndexerProcessorServer.WorkerThread(processor, transactions)
+            processor_threads.append(thread)
+            thread.start()
+
+        for thread in processor_threads:
+            thread.join()
+
+        processing_time = perf_counter()
+        task_count = len(processor_threads)
+        processed_versions: List[ProcessingResult] = []
+        for thread in processor_threads:
+            if thread.exception:
+                logging.warn(
+                    json.dumps(
+                        {
+                            "processor_name": processor_name,
+                            "message": "[Parser] Error processing transaction batch",
+                        }
+                    )
+                )
+                os._exit(1)
+
+            processed_versions.append(thread.processing_result)
+
+        logging.info(
+            json.dumps(
+                {
+                    "processor_name": processor_name,
+                    "task_count": task_count,
+                    "processing_duration": str(
+                        format(perf_counter() - processing_time, ".8f")
+                    ),
+                    "message": "[Parser] Finished processing transaction batches",
+                }
+            )
+        )
+
+        # Make sure there are no gaps and advance states
+        prev_start = None
+        prev_end = None
+        for result in processed_versions:
+            if prev_start is None or prev_end is None:
+                prev_start = result.start_version
+                prev_end = result.end_version
+            else:
+                if prev_end + 1 != result.start_version:
+                    logging.warn(
+                        json.dumps(
+                            {
+                                "processor_name": processor_name,
+                                "stream_address": indexer_grpc_data_stream_endpoint,
+                                "processed_versions": processed_versions,
+                                "message": "[Parser] Gaps in processing stream",
+                            }
+                        )
+                    )
+                    os._exit(1)
+                prev_start = result.start_version
+                prev_end = result.end_version
+
+        processed_start_version = processed_versions[0].start_version
+        processed_end_version = processed_versions[-1].end_version
+        batch_start_version = processed_end_version + 1
+
+        processor.update_last_processed_version(processed_end_version)
+        PROCESSED_TRANSACTIONS_COUNTER.inc(
+            processed_end_version - processed_start_version + 1
+        )
+
+        tps_end_time = perf_counter()
+
+        logging.info(
+            json.dumps(
+                {
+                    "processor_name": processor.name(),
+                    "start_version": str(processed_start_version),
+                    "end_version": str(processed_end_version),
+                    "batch_size": str(
+                        processed_end_version - processed_start_version + 1
+                    ),
+                    "tps": f"{(processed_end_version - processed_start_version + 1) / (tps_end_time - tps_start_time)}",
+                    "message": f"[Parser] Processed transactions",
+                }
+            ),
+        )
 
 
 class IndexerProcessorServer:
@@ -35,7 +487,8 @@ class IndexerProcessorServer:
     num_concurrent_processing_tasks: int
 
     def __init__(self, config: Config):
-        print("[Parser] Kicking off")
+        logging.getLogger().setLevel(logging.INFO)
+        logging.info(json.dumps({"message": "[Parser] Kicking off"}))
 
         self.config = config
 
@@ -95,11 +548,26 @@ class IndexerProcessorServer:
             except Exception as e:
                 self.exception = e
 
-    def run(self):
+    async def run(self):
+        processor_name = self.config.processor_name
         # Run DB migrations
-        print("[Parser] Initializing DB tables")
+        logging.info(
+            json.dumps(
+                {
+                    "processor_name": self.processor.name(),
+                    "message": "[Parser] Initializing DB tables",
+                }
+            ),
+        )
         self.init_db_tables(self.processor.schema())
-        print("[Parser] DB tables initialized")
+        logging.info(
+            json.dumps(
+                {
+                    "processor_name": self.processor.name(),
+                    "message": "[Parser] DB tables initialized",
+                }
+            )
+        )
 
         self.start_health_and_monitoring_ports()
 
@@ -107,187 +575,51 @@ class IndexerProcessorServer:
         starting_version = self.config.get_starting_version(self.processor.name())
         ending_version = self.config.ending_version
 
-        # Setup GRPC settings
-        metadata = (
-            ("authorization", "Bearer " + self.config.grpc_data_stream_api_key),
-            ("x-aptos-request-name", self.processor.name()),
+        # Create a transaction fetcher task that will continuously fetch transactions from the GRPC stream
+        # and write into a channel. Each item is of type (chain_id, vec of transactions)
+        logging.info(
+            json.dumps(
+                {
+                    "processor_name": processor_name,
+                    "stream_address": self.config.grpc_data_stream_endpoint,
+                    "start_version": starting_version,
+                    "message": "[Parser] Starting fetcher task",
+                }
+            )
         )
-        options = [
-            ("grpc.max_receive_message_length", -1),
-            (
-                "grpc.keepalive_time_ms",
-                self.config.indexer_grpc_http2_ping_interval_in_secs * 1000,
+        q = queue.Queue(FETCHER_QUEUE_SIZE)
+        producer_thread = threading.Thread(
+            target=producer,
+            args=(
+                q,
+                self.config.grpc_data_stream_endpoint,
+                self.config.grpc_data_stream_api_key,
+                self.config.indexer_grpc_http2_ping_interval_in_secs,
+                self.config.indexer_grpc_http2_ping_timeout_in_secs,
+                starting_version,
+                ending_version,
+                processor_name,
+                starting_version,
             ),
-            (
-                "grpc.keepalive_timeout_ms",
-                self.config.indexer_grpc_http2_ping_timeout_in_secs * 1000,
+        )
+        producer_thread.start()
+
+        consumer_thread = threading.Thread(
+            target=consumer,
+            args=(
+                q,
+                producer_thread,
+                self.config.grpc_data_stream_endpoint,
+                self.processor,
+                self.num_concurrent_processing_tasks,
+                starting_version,
+                processor_name,
             ),
-        ]
+        )
+        consumer_thread.start()
 
-        # Connect to indexer grpc endpoint
-        with grpc.secure_channel(
-            self.config.grpc_data_stream_endpoint,
-            options=options,
-            credentials=grpc.ssl_channel_credentials(),
-        ) as channel:
-            print(
-                json.dumps(
-                    {
-                        "message": f"Connected to grpc data stream endpoint: {self.config.grpc_data_stream_endpoint}",
-                        "starting_version": starting_version,
-                    }
-                ),
-                flush=True,
-            )
-
-            batch_start_version = starting_version
-            batch_end_version = None
-            prev_processed_start_version = None
-            prev_processed_end_version = None
-
-            # Create GPRC request and get the responses
-            stub = raw_data_pb2_grpc.RawDataStub(channel)
-            request = raw_data_pb2.GetTransactionsRequest(
-                starting_version=batch_start_version
-            )
-            responses = stub.GetTransactions(request, metadata=metadata)
-            responses = iter(responses)
-
-            while True:
-                perf_start_time = perf_counter()
-                transaction_batches: List[List[transaction_pb2.Transaction]] = []
-
-                # Get batches of transactions for processing
-                for _ in range(self.num_concurrent_processing_tasks):
-                    response = next(responses)
-                    transactions = response.transactions
-
-                    current_batch_size = len(transactions)
-                    if current_batch_size == 0:
-                        print("[Parser] Received empty batch from GRPC stream")
-                        sys.exit(1)
-
-                    batch_start_version = transactions[0].version
-                    batch_end_version = transactions[-1].version
-
-                    # If ending version is in the current batch, truncate the transactions in this batcch
-                    if ending_version != None and batch_end_version >= ending_version:
-                        batch_end_version = ending_version
-                        transactions = transactions[
-                            : batch_end_version - batch_start_version + 1
-                        ]
-                        current_batch_size = len(transactions)
-
-                    transaction_batches.append(transactions)
-
-                    # If it is a partial batch, then skip polling and head to process it first.
-                    if current_batch_size < INDEXER_GRPC_BLOB_STORAGE_SIZE:
-                        break
-
-                # Process transactions in batches
-                threads: List[IndexerProcessorServer.WorkerThread] = []
-                for transactions in transaction_batches:
-                    thread = IndexerProcessorServer.WorkerThread(
-                        self.processor, transactions
-                    )
-                    threads.append(thread)
-                    thread.start()
-
-                # Wait for processor threads to finish
-                for thread in threads:
-                    thread.join()
-
-                # Update state depending on the results of the batch processing
-                processed_versions: List[ProcessingResult] = []
-                for thread in threads:
-                    processing_result = thread.processing_result
-                    exception = thread.exception
-
-                    # TODO: Log errors metric
-                    if thread.exception:
-                        print(
-                            json.dumps(
-                                {
-                                    "message": f"[Parser] Error processing transactions {processing_result.start_version} to {processing_result.end_version}",
-                                    "error": str(exception),
-                                    "error_stacktrace": traceback.format_exception(
-                                        exception
-                                    ),
-                                }
-                            )
-                        )
-                        sys.exit(1)
-                    elif processing_result:
-                        processed_versions.append(processing_result)
-
-                # Make sure there are no gaps and advance states
-                processed_versions.sort(key=lambda x: x.start_version)
-
-                for version in processed_versions:
-                    if prev_processed_start_version == None:
-                        if version.start_version != starting_version:
-                            print(
-                                json.dumps(
-                                    {
-                                        "message": "[Parser] Detected gap in processed transactions",
-                                        "error": f"Gap between transactions {starting_version} and {version.start_version}",
-                                    }
-                                )
-                            )
-                        prev_processed_start_version = version.start_version
-                        prev_processed_end_version = version.end_version
-                    else:
-                        assert prev_processed_end_version
-                        if prev_processed_end_version + 1 != version.start_version:
-                            print(
-                                json.dumps(
-                                    {
-                                        "message": "[Parser] Detected gap in processed transactions",
-                                        "error": f"Gap between transactions {prev_processed_end_version} and {version.start_version}",
-                                    }
-                                )
-                            )
-                            sys.exit(1)
-                        else:
-                            prev_processed_start_version = version.start_version
-                            prev_processed_end_version = version.end_version
-
-                batch_start = processed_versions[0].start_version
-                batch_end = processed_versions[-1].end_version
-
-                batch_start_version = batch_end + 1
-
-                # TODO: Update latest processed version metric
-                self.processor.update_last_processed_version(batch_end)
-                PROCESSED_TRANSACTIONS_COUNTER.inc(len(processed_versions))
-
-                perf_end_time = perf_counter()
-
-                print(
-                    json.dumps(
-                        {
-                            "message": f"[Parser] Processed transactions",
-                            "processor_name": self.processor.name(),
-                            "start_version": str(batch_start),
-                            "end_version": str(batch_end),
-                            "batch_size": str(batch_end - batch_start + 1),
-                            "tps": f"{(batch_end - batch_start + 1) / (perf_end_time - perf_start_time)}",
-                        }
-                    ),
-                    flush=True,
-                )
-
-                # Stop processing if reached ending version
-                if batch_end == ending_version:
-                    print(
-                        json.dumps(
-                            {
-                                "message": f"[Parser] Reached ending version {ending_version}. Exiting..."
-                            }
-                        ),
-                        flush=True,
-                    )
-                    break
+        producer_thread.join()
+        consumer_thread.join()
 
     def init_db_tables(self, schema_name: str) -> None:
         engine = create_engine(self.config.db_connection_uri)

--- a/python/utils/worker.py
+++ b/python/utils/worker.py
@@ -548,7 +548,7 @@ class IndexerProcessorServer:
             except Exception as e:
                 self.exception = e
 
-    async def run(self):
+    def run(self):
         processor_name = self.config.processor_name
         # Run DB migrations
         logging.info(
@@ -575,7 +575,7 @@ class IndexerProcessorServer:
         starting_version = self.config.get_starting_version(self.processor.name())
         ending_version = self.config.ending_version
 
-        # Create a transaction fetcher task that will continuously fetch transactions from the GRPC stream
+        # Create a transaction fetcher thread that will continuously fetch transactions from the GRPC stream
         # and write into a channel. Each item is of type (chain_id, vec of transactions)
         logging.info(
             json.dumps(


### PR DESCRIPTION
## Description
Add reconnection logic to Python processors because the GRPC stream isn't expected to persist forever. 

While testing, I found that the `channel_recv_latency_in_secs` is relatively high and dominates the overall processor performance.
```
INFO:root:{"processor_name": "nft_marketplace_v2_processor", "start_version": "189806000", "end_version": "189806999", "batch_size": "1000", "tps": "1668.5985310137194", "message": "[Parser] Processed transactions"}
INFO:root:{"processor_name": "nft_marketplace_v2_processor", "start_version": "189807000", "end_version": "189807999", "channel_size": 1, "channel_recv_latency_in_secs": "0.69648696", "message": "[Parser] Received chunk of transactions"}
INFO:root:{"processor_name": "nft_marketplace_v2_processor", "task_count": 1, "processing_duration": "0.00000113", "message": "[Parser] Finished processing transaction batches"}
```
Need to look into this further.

### `threading` vs `asyncio`

I also attempted to switch from threads to asyncio, but found that it was much slower. Probably because asyncio runs its tasks within a single process. Asyncio seems to be better for slow I/O tasks, but processors shouldn't be that slow. In fact, a majority of transactions are irrelevant to a processor, so using for threads > asyncio is the better choice here. 

## Testing
Throw `grpc.RpcError` in the producer thread and see that it reconnects.
Verify that transaction batches don't have any gaps.