### PR TITLE
Fix Dockerfile

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /app
 COPY poetry.lock pyproject.toml /app/
 
 # Copy files and folders
-COPY /aptos-indexer-protos /app
-COPY /utils/ /app
-COPY /processors/ /app
+COPY /aptos-indexer-protos/ /app/aptos-indexer-protos
+COPY /utils/ /app/utils
+COPY /processors/ /app/processors
 
 # Project initialization
 RUN poetry config virtualenvs.create false \


### PR DESCRIPTION
Fix `/usr/local/bin/python: Error while finding module specification for 'processors.main' (ModuleNotFoundError: No module named 'processors')` error when running Python processors

## Testing
Run `docker compose up --build --force-recreate `
![Screenshot 2023-10-16 at 2 58 58 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/e8c81c5c-cc81-4694-b050-80a10bfdf350)
