### PR TITLE
[Rust] Update codegen deps

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -100,11 +100,12 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 name = "aptos-indexer-protos"
 version = "1.1.0"
 dependencies = [
+ "futures-core",
  "pbjson",
- "prost",
- "prost-types",
+ "prost 0.12.1",
+ "prost-types 0.12.1",
  "serde",
- "tonic",
+ "tonic 0.10.2",
 ]
 
 [[package]]
@@ -857,14 +858,14 @@ dependencies = [
  "hyper",
  "jsonwebtoken",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "reqwest",
  "secret-vault-value",
  "serde",
  "serde_json",
  "tokio",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "tower-layer",
  "tower-util",
@@ -932,7 +933,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-retry",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "tracing",
 ]
@@ -943,9 +944,9 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a3b24a3f57be08afc02344e693afb55e48172c9c2ab86ff3fdb8efff550e4b9"
 dependencies = [
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "tonic 0.9.2",
 ]
 
 [[package]]
@@ -971,7 +972,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-googleapis",
  "google-cloud-token",
- "prost-types",
+ "prost-types 0.11.9",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -1146,7 +1147,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -1854,8 +1855,8 @@ dependencies = [
  "hex",
  "once_cell",
  "prometheus",
- "prost",
- "prost-types",
+ "prost 0.12.1",
+ "prost-types 0.12.1",
  "regex",
  "serde",
  "serde_json",
@@ -1864,7 +1865,7 @@ dependencies = [
  "sha3",
  "strum",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
  "unescape",
  "url",
@@ -1891,7 +1892,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.1",
 ]
 
 [[package]]
@@ -1908,12 +1919,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
+dependencies = [
+ "prost 0.12.1",
 ]
 
 [[package]]
@@ -2053,7 +2086,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2134,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -2244,8 +2277,8 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddaf2631e82016a3262ce75575ec245ceef9a7115ddf8576851302efe6bdece"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "serde",
  "serde_json",
  "zeroize",
@@ -2764,7 +2797,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "tokio",
 ]
 
@@ -2860,7 +2893,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.1.2",
- "prost",
+ "prost 0.11.9",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
@@ -2871,6 +2904,38 @@ dependencies = [
  "tower-service",
  "tracing",
  "webpki-roots 0.23.1",
+]
+
+[[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.2",
+ "bytes",
+ "flate2",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project 1.1.2",
+ "prost 0.12.1",
+ "rustls 0.21.7",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -45,6 +45,7 @@ diesel_async_migrations = { git = "https://github.com/niroco/diesel_async_migrat
 enum_dispatch = "0.3.12"
 field_count = "0.1.1"
 futures = "0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.
+futures-core = "0.3.25"
 futures-util = "0.3.21"
 gcloud-sdk = { version = "0.20.4", features = [
     "google-cloud-bigquery-storage-v1",
@@ -56,8 +57,8 @@ hex = "0.4.3"
 once_cell = "1.10.0"
 pbjson = "0.5.1"
 prometheus = { version = "0.13.0", default-features = false }
-prost = "0.11.9"
-prost-types = "0.11.9"
+prost = "0.12.1"
+prost-types = "0.12.1"
 regex = "1.5.5"
 reqwest = { version = "0.11.20", features = [
     "blocking",
@@ -65,7 +66,7 @@ reqwest = { version = "0.11.20", features = [
     "json",
     "stream",
 ] }
-serde = { version = "1.0.137", features = ["derive", "rc"] }
+serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 serde_yaml = "0.8.24"
 sha2 = "0.9.3"
@@ -75,7 +76,7 @@ tempfile = "3.3.0"
 toml = "0.7.4"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 tokio = { version = "1.21.0", features = ["full"] }
-tonic = { version = "0.9.2", features = [
+tonic = { version = "0.10.2", features = [
     "tls",
     "tls-roots",
     "transport",

--- a/rust/aptos-indexer-protos/Cargo.toml
+++ b/rust/aptos-indexer-protos/Cargo.toml
@@ -10,6 +10,7 @@ publish = true
 edition = "2021"
 
 [dependencies]
+futures-core = { workspace = true }
 pbjson = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/rust/processor/src/models/default_models/transactions.rs
+++ b/rust/processor/src/models/default_models/transactions.rs
@@ -95,7 +95,7 @@ impl Transaction {
             .as_ref()
             .expect("Txn Data doesn't exit!");
         let version = transaction.version as i64;
-        let transaction_type = TransactionType::from_i32(transaction.r#type)
+        let transaction_type = TransactionType::try_from(transaction.r#type)
             .expect("Transaction type doesn't exist!")
             .as_str_name()
             .to_string();

--- a/rust/processor/src/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/models/default_models/write_set_changes.rs
@@ -185,7 +185,7 @@ impl WriteSetChange {
     }
 
     fn get_write_set_change_type(t: &WriteSetChangePB) -> String {
-        match WriteSetChangeTypeEnum::from_i32(t.r#type)
+        match WriteSetChangeTypeEnum::try_from(t.r#type)
             .expect("WriteSetChange must have a valid type.")
         {
             WriteSetChangeTypeEnum::DeleteModule => "delete_module".to_string(),


### PR DESCRIPTION
## Summary
In order to use aptos-indexer-protos in aptos-core we need to make sure the crate versions between the two repos match. This PR does that and makes the appropriate fixes.

## Test Plan
I ran a processor with this config:
```
health_check_port: 8084
server_config:
  processor_config:
    type: default_processor
  postgres_connection_string: postgresql://postgres:@localhost:5432/default_processor
  indexer_grpc_data_service_address: https://grpc.testnet.aptoslabs.com
  auth_token: <token>
```

With this command:
```
cargo run -p processor -- -c ~/config.yaml
```

The processor started up and processed txns successfully.