### PR TITLE
[DONT COMMIT] add cockroach db schema design

### DIFF
--- a/rust/processor/migrations/2023-10-20-212109_create_cockroach_tables/down.sql
+++ b/rust/processor/migrations/2023-10-20-212109_create_cockroach_tables/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS events_cockroach;
+DROP TABLE IF EXISTS wsc_cockroach;
+DROP TABLE IF EXISTS transactions_cockroach;

--- a/rust/processor/migrations/2023-10-20-212109_create_cockroach_tables/up.sql
+++ b/rust/processor/migrations/2023-10-20-212109_create_cockroach_tables/up.sql
@@ -1,0 +1,88 @@
+-- Your SQL goes here
+
+-- transactions_cockroach
+CREATE TABLE IF NOT EXISTS transactions_cockroach (
+  transaction_version BIGINT UNIQUE PRIMARY KEY NOT NULL,
+  transaction_block_height BIGINT NOT NULL,
+  hash VARCHAR(66) NOT NULL,
+  transaction_type VARCHAR(50) NOT NULL,
+  payload jsonb,
+  state_change_hash VARCHAR(66) NOT NULL,
+  event_root_hash VARCHAR(66) NOT NULL,
+  state_checkpoint_hash VARCHAR(66),
+  gas_used NUMERIC NOT NULL,
+  success BOOLEAN NOT NULL,
+  vm_status TEXT NOT NULL,
+  accumulator_root_hash VARCHAR(66) NOT NULL,
+  num_events BIGINT NOT NULL,
+  num_write_set_changes BIGINT NOT NULL,
+  epoch BIGINT NOT NULL,
+  parent_signature_type TEXT,
+  sender VARCHAR(66),
+  sequence_number BIGINT,
+  max_gas_amount NUMERIC,
+  expiration_timestamp_secs TIMESTAMP,
+  gas_unit_price NUMERIC,
+  "timestamp" TIMESTAMP,
+  entry_function_id_str TEXT,
+  signature jsonb,
+  id VARCHAR(66),
+  round BIGINT,
+  previous_block_votes_bitvec jsonb,
+  proposer VARCHAR(66),
+  failed_proposer_indices jsonb,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX txn_cockroach_insat_index ON transactions_cockroach (inserted_at);
+
+-- events_cockroach
+CREATE TABLE events_cockroach (
+  sequence_number BIGINT NOT NULL,
+  creation_number BIGINT NOT NULL,
+  account_address VARCHAR(66) NOT NULL,
+  transaction_version BIGINT NOT NULL,
+  transaction_block_height BIGINT NOT NULL,
+  event_index BIGINT NOT NULL,
+  event_type TEXT NOT NULL,
+  data jsonb NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (
+    transaction_version,
+    event_index
+  ),
+  CONSTRAINT fk_transaction_versions FOREIGN KEY (transaction_version) REFERENCES transactions_cockroach (transaction_version)
+);
+CREATE INDEX ev_cockroach_addr_type_index ON events_cockroach (account_address);
+CREATE INDEX ev_cockroach_insat_index ON events_cockroach (inserted_at);
+
+-- wsc_cockroach
+CREATE TABLE IF NOT EXISTS wsc_cockroach (
+  transaction_version BIGINT NOT NULL,
+  transaction_block_height BIGINT NOT NULL,
+  hash VARCHAR(66) NOT NULL,
+  write_set_change_type TEXT NOT NULL,
+  address VARCHAR(66) NOT NULL,
+  index BIGINT NOT NULL,
+  payload jsonb,
+  bytecode bytea,
+  friends jsonb,
+  exposed_functions jsonb,
+  structs jsonb,
+  is_deleted BOOLEAN NOT NULL,
+  name TEXT,
+  module TEXT,
+  generic_type_params jsonb,
+  state_key_hash VARCHAR(66),
+  table_handle VARCHAR(66),
+  decoded_key jsonb,
+  decoded_value jsonb,
+  key_type TEXT,
+  value_type TEXT,
+  key text,
+  data jsonb,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (transaction_version, index),
+  CONSTRAINT fk_transaction_versions FOREIGN KEY (transaction_version) REFERENCES transactions_cockroach (transaction_version)
+);
+CREATE INDEX wsc_cockroach_addr_type_ver_index ON wsc_cockroach (address, transaction_version DESC);
+CREATE INDEX wsc_cockroach_insat_index ON wsc_cockroach (inserted_at);

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -687,6 +687,21 @@ diesel::table! {
 }
 
 diesel::table! {
+    events_cockroach (transaction_version, event_index) {
+        sequence_number -> Int8,
+        creation_number -> Int8,
+        #[max_length = 66]
+        account_address -> Varchar,
+        transaction_version -> Int8,
+        transaction_block_height -> Int8,
+        event_index -> Int8,
+        event_type -> Text,
+        data -> Jsonb,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     fungible_asset_activities (transaction_version, event_index) {
         transaction_version -> Int8,
         event_index -> Int8,
@@ -1132,6 +1147,50 @@ diesel::table! {
 }
 
 diesel::table! {
+    transactions_cockroach (transaction_version) {
+        transaction_version -> Int8,
+        transaction_block_height -> Int8,
+        #[max_length = 66]
+        hash -> Varchar,
+        #[max_length = 50]
+        transaction_type -> Varchar,
+        payload -> Nullable<Jsonb>,
+        #[max_length = 66]
+        state_change_hash -> Varchar,
+        #[max_length = 66]
+        event_root_hash -> Varchar,
+        #[max_length = 66]
+        state_checkpoint_hash -> Nullable<Varchar>,
+        gas_used -> Numeric,
+        success -> Bool,
+        vm_status -> Text,
+        #[max_length = 66]
+        accumulator_root_hash -> Varchar,
+        num_events -> Int8,
+        num_write_set_changes -> Int8,
+        epoch -> Int8,
+        parent_signature_type -> Nullable<Text>,
+        #[max_length = 66]
+        sender -> Nullable<Varchar>,
+        sequence_number -> Nullable<Int8>,
+        max_gas_amount -> Nullable<Numeric>,
+        expiration_timestamp_secs -> Nullable<Timestamp>,
+        gas_unit_price -> Nullable<Numeric>,
+        timestamp -> Nullable<Timestamp>,
+        entry_function_id_str -> Nullable<Text>,
+        signature -> Nullable<Jsonb>,
+        #[max_length = 66]
+        id -> Nullable<Varchar>,
+        round -> Nullable<Int8>,
+        previous_block_votes_bitvec -> Nullable<Jsonb>,
+        #[max_length = 66]
+        proposer -> Nullable<Varchar>,
+        failed_proposer_indices -> Nullable<Jsonb>,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     user_transactions (version) {
         version -> Int8,
         block_height -> Int8,
@@ -1166,11 +1225,46 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    wsc_cockroach (transaction_version, index) {
+        transaction_version -> Int8,
+        transaction_block_height -> Int8,
+        #[max_length = 66]
+        hash -> Varchar,
+        write_set_change_type -> Text,
+        #[max_length = 66]
+        address -> Varchar,
+        index -> Int8,
+        payload -> Nullable<Jsonb>,
+        bytecode -> Nullable<Bytea>,
+        friends -> Nullable<Jsonb>,
+        exposed_functions -> Nullable<Jsonb>,
+        structs -> Nullable<Jsonb>,
+        is_deleted -> Bool,
+        name -> Nullable<Text>,
+        module -> Nullable<Text>,
+        generic_type_params -> Nullable<Jsonb>,
+        #[max_length = 66]
+        state_key_hash -> Nullable<Varchar>,
+        #[max_length = 66]
+        table_handle -> Nullable<Varchar>,
+        decoded_key -> Nullable<Jsonb>,
+        decoded_value -> Nullable<Jsonb>,
+        key_type -> Nullable<Text>,
+        value_type -> Nullable<Text>,
+        key -> Nullable<Text>,
+        data -> Nullable<Jsonb>,
+        inserted_at -> Timestamp,
+    }
+}
+
 diesel::joinable!(block_metadata_transactions -> transactions (version));
+diesel::joinable!(events_cockroach -> transactions_cockroach (transaction_version));
 diesel::joinable!(move_modules -> transactions (transaction_version));
 diesel::joinable!(move_resources -> transactions (transaction_version));
 diesel::joinable!(table_items -> transactions (transaction_version));
 diesel::joinable!(write_set_changes -> transactions (transaction_version));
+diesel::joinable!(wsc_cockroach -> transactions_cockroach (transaction_version));
 
 diesel::allow_tables_to_appear_in_same_query!(
     account_transactions,
@@ -1209,6 +1303,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     delegated_staking_pool_balances,
     delegated_staking_pools,
     events,
+    events_cockroach,
     fungible_asset_activities,
     fungible_asset_balances,
     fungible_asset_metadata,
@@ -1231,6 +1326,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     token_ownerships_v2,
     tokens,
     transactions,
+    transactions_cockroach,
     user_transactions,
     write_set_changes,
+    wsc_cockroach,
 );


### PR DESCRIPTION
eventually moving it to use prisma db schema management instead of diesel since diesel's not compatible with cockroach, but ready for review here.

https://www.notion.so/aptoslabs/Explorer-Indexer-Project-bbcf6acd98e345ac879758cc1eb76aff?pvs=4

https://dbdiagram.io/d/65330709ffbf5169f023ce51
