### PR TITLE
[rust] Index events type, backfill fungible assets fix, and create spam table

### DIFF
--- a/hasura-api/metadata-json/unified.json
+++ b/hasura-api/metadata-json/unified.json
@@ -1809,7 +1809,7 @@
                     "transaction_block_height",
                     "transaction_version",
                     "type",
-                    "ev_itype_index"
+                    "indexed_type"
                   ],
                   "filter": {},
                   "limit": 100

--- a/hasura-api/metadata-json/unified.json
+++ b/hasura-api/metadata-json/unified.json
@@ -1808,7 +1808,8 @@
                     "sequence_number",
                     "transaction_block_height",
                     "transaction_version",
-                    "type"
+                    "type",
+                    "ev_itype_index"
                   ],
                   "filter": {},
                   "limit": 100

--- a/rust/processor/migrations/2023-10-27-030502_event_type/down.sql
+++ b/rust/processor/migrations/2023-10-27-030502_event_type/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX IF EXISTS ev_itype_index;
+ALTER TABLE events DROP COLUMN IF EXISTS indexed_type;
+DROP TABLE IF EXISTS spam_assets;

--- a/rust/processor/migrations/2023-10-27-030502_event_type/up.sql
+++ b/rust/processor/migrations/2023-10-27-030502_event_type/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+-- p99 currently is 303 so using 300 as a safe max length 
+ALTER TABLE events ADD COLUMN IF NOT EXISTS indexed_type VARCHAR(300) NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS ev_itype_index ON events (indexed_type);
+CREATE TABLE IF NOT EXISTS spam_assets (
+  asset VARCHAR(1100) PRIMARY KEY NOT NULL,
+  is_spam BOOLEAN NOT NULL DEFAULT TRUE,
+  last_updated TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/rust/processor/src/models/events_models/events.rs
+++ b/rust/processor/src/models/events_models/events.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{schema::events, utils::util::{standardize_address, truncate_str}};
-use aptos_indexer_protos::transaction::v1::Event as EventPB;
+use aptos_protos::transaction::v1::Event as EventPB;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 

--- a/rust/processor/src/models/events_models/events.rs
+++ b/rust/processor/src/models/events_models/events.rs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::extra_unused_lifetimes)]
-use crate::{schema::events, utils::util::{standardize_address, truncate_str}};
+use crate::{
+    schema::events,
+    utils::util::{standardize_address, truncate_str},
+};
 use aptos_protos::transaction::v1::Event as EventPB;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-// p99 currently is 303 so using 300 as a safe max length 
+// p99 currently is 303 so using 300 as a safe max length
 const EVENT_TYPE_MAX_LENGTH: usize = 300;
 
 #[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]

--- a/rust/processor/src/models/events_models/events.rs
+++ b/rust/processor/src/models/events_models/events.rs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::extra_unused_lifetimes)]
-use crate::{schema::events, utils::util::standardize_address};
-use aptos_protos::transaction::v1::Event as EventPB;
+use crate::{schema::events, utils::util::{standardize_address, truncate_str}};
+use aptos_indexer_protos::transaction::v1::Event as EventPB;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
+
+// p99 currently is 303 so using 300 as a safe max length 
+const EVENT_TYPE_MAX_LENGTH: usize = 300;
 
 #[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(transaction_version, event_index))]
@@ -19,6 +22,7 @@ pub struct Event {
     pub type_: String,
     pub data: serde_json::Value,
     pub event_index: i64,
+    pub indexed_type: String,
 }
 
 impl Event {
@@ -28,6 +32,7 @@ impl Event {
         transaction_block_height: i64,
         event_index: i64,
     ) -> Self {
+        let t: &str = event.type_str.as_ref();
         Event {
             account_address: standardize_address(
                 event.key.as_ref().unwrap().account_address.as_str(),
@@ -36,9 +41,10 @@ impl Event {
             sequence_number: event.sequence_number as i64,
             transaction_version,
             transaction_block_height,
-            type_: event.type_str.clone(),
+            type_: t.to_string(),
             data: serde_json::from_str(event.data.as_str()).unwrap(),
             event_index,
+            indexed_type: truncate_str(t, EVENT_TYPE_MAX_LENGTH),
         }
     }
 

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -683,6 +683,8 @@ diesel::table! {
         data -> Jsonb,
         inserted_at -> Timestamp,
         event_index -> Int8,
+        #[max_length = 300]
+        indexed_type -> Varchar,
     }
 }
 
@@ -885,6 +887,15 @@ diesel::table! {
         threshold -> Int8,
         public_key_indices -> Jsonb,
         inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    spam_assets (asset) {
+        #[max_length = 1100]
+        asset -> Varchar,
+        is_spam -> Bool,
+        last_updated -> Timestamp,
     }
 }
 
@@ -1167,10 +1178,6 @@ diesel::table! {
 }
 
 diesel::joinable!(block_metadata_transactions -> transactions (version));
-diesel::joinable!(move_modules -> transactions (transaction_version));
-diesel::joinable!(move_resources -> transactions (transaction_version));
-diesel::joinable!(table_items -> transactions (transaction_version));
-diesel::joinable!(write_set_changes -> transactions (transaction_version));
 
 diesel::allow_tables_to_appear_in_same_query!(
     account_transactions,
@@ -1221,6 +1228,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     processor_status,
     proposal_votes,
     signatures,
+    spam_assets,
     table_items,
     table_metadatas,
     token_activities,


### PR DESCRIPTION
2 changes in this PR
* create a new indexed_type field for events (I couldn't just replace the old one due to a diesel migration bug)
* create spam table

Note that the new field indexed_type field needs to be limited length. I picked 300 b/c that's the current p99 in mainnet. 

We also need to backfill fungible asset fix from https://github.com/aptos-labs/aptos-indexer-processors/pull/167

## Backfill
fungible_asset_processor
testnet: 553151941
mainnet: 199271122

events_processor
testnet: 0
mainnet: 0

## Testing
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/acc52fc5-42f7-4299-ba89-298b57b297d7)

new field is indexed
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/9fa478d2-b7c8-423b-9e00-127bb57044be)

