### PR TITLE
[gha] build and release images based on new branching strategy

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - main
+      # aptos-indexer-processors network-specific release branches
+      - aptos-indexer-processors-devnet
+      - aptos-indexer-processors-testnet
+      - aptos-indexer-processors-mainnet
 
 # cancel redundant builds
 concurrency:

--- a/.github/workflows/copy-processor-images-to-dockerhub-release.yaml
+++ b/.github/workflows/copy-processor-images-to-dockerhub-release.yaml
@@ -1,0 +1,26 @@
+name: Copy images to dockerhub on release
+on:
+  push:
+    branches:
+      # aptos-indexer-processors network-specific release branches
+      - aptos-indexer-processors-devnet
+      - aptos-indexer-processors-testnet
+      - aptos-indexer-processors-mainnet
+    tags:
+      - aptos-indexer-processors-v*
+
+permissions:
+  contents: read
+  id-token: write #required for GCP Workload Identity federation
+
+jobs:
+  copy-images-to-docker-hub:
+    strategy:
+      matrix:
+        lanuage: ["rust", "python", "typescript"]
+    uses: ./.github/workflows/copy-processor-images-to-dockerhub.yaml
+    with:
+      processor_language: ${{ matrix.language }}
+      version_tag: ${{ github.ref_name }}
+      GIT_SHA: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/copy-processor-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-processor-images-to-dockerhub.yaml
@@ -1,12 +1,27 @@
 name: Release Processor Images
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       processor_language:
         required: true
         type: string
         default: rust
-        choices: [rust, python, typescript]
+      version_tag:
+        required: false
+        type: string
+        description: After we copy the image from GAR to DockerHub, we will add this tag to the image. For example aptos-indexer-processors-v1.0.4.
+      GIT_SHA:
+        required: true
+        type: string
+        description: The git SHA you want to copy from GAR to DockerHub. For example de766ae36a1c74212d370aae75bf234320612bbc.
+
+  workflow_dispatch:
+    inputs:
+      processor_language:
+        required: true
+        type: choice
+        default: rust
+        options: [rust, python, typescript]
       version_tag:
         required: false
         type: string

--- a/scripts/release-processor-images.mjs
+++ b/scripts/release-processor-images.mjs
@@ -107,8 +107,9 @@ console.info(chalk.green(`INFO: Tagging image as latest`));
 await $`${crane} tag ${imageGitShaTarget} latest`;
 
 if(parsedArgs.VERSION_TAG !== null) {
-    console.info(chalk.green(`INFO: Tagging image as ${parsedArgs.VERSION_TAG}`));
-    await $`${crane} tag ${imageGitShaTarget} ${parsedArgs.VERSION_TAG}`;
+    console.info(chalk.green(`INFO: Tagging image as ${parsedArgs.VERSION_TAG} and ${parsedArgs.VERSION_TAG}_${parsedArgs.GIT_SHA}`));
+    await $`${crane} tag ${imageGitShaTarget} ${parsedArgs.VERSION_TAG}`; // just the version tag
+    await $`${crane} tag ${imageGitShaTarget} ${parsedArgs.VERSION_TAG}_${parsedArgs.GIT_SHA}`; // version tag with git sha
 }
 
 async function waitForImageToBecomeAvailable(imageToWaitFor, waitForImageSeconds) {


### PR DESCRIPTION
Build:
* on push to new versioned release branches `aptos-indexer-processors-v*`
* on push to new network-specific release branches `aptos-indexer-processors-{devnet,testnet,mainnet}`

Release images to dockerhub:
* on push to new network-specific release branches `aptos-indexer-processors-{devnet,testnet,mainnet}`
* on new git tag(release) version X.Y.Z `aptos-indexer-processors-vX.Y.Z`