### PR TITLE
[rust][fix] Fix move module crash

### DIFF
--- a/rust/processor/src/models/default_models/move_modules.rs
+++ b/rust/processor/src/models/default_models/move_modules.rs
@@ -90,14 +90,9 @@ impl MoveModule {
     pub fn convert_move_module_bytecode(
         mmb: &MoveModuleBytecode,
     ) -> Option<MoveModuleByteCodeParsed> {
-        let abi = mmb.abi.as_ref();
-        if abi.is_none() {
-            return None;
-        }
-        Some(Self::convert_move_module(
-            abi.unwrap(),
-            mmb.bytecode.clone(),
-        ))
+        mmb.abi
+            .as_ref()
+            .map(|abi| Self::convert_move_module(abi, mmb.bytecode.clone()))
     }
 
     pub fn convert_move_module(

--- a/rust/processor/src/models/default_models/move_modules.rs
+++ b/rust/processor/src/models/default_models/move_modules.rs
@@ -73,7 +73,11 @@ impl MoveModule {
             transaction_version,
             transaction_block_height,
             write_set_change_index,
-            name: delete_module.module.as_ref().unwrap().name.to_string(),
+            name: delete_module
+                .module
+                .as_ref()
+                .map(|d| d.name.clone())
+                .unwrap_or_default(),
             address: standardize_address(&delete_module.address.to_string()),
             bytecode: None,
             exposed_functions: None,
@@ -86,8 +90,12 @@ impl MoveModule {
     pub fn convert_move_module_bytecode(
         mmb: &MoveModuleBytecode,
     ) -> Option<MoveModuleByteCodeParsed> {
+        let abi = mmb.abi.as_ref();
+        if abi.is_none() {
+            return None;
+        }
         Some(Self::convert_move_module(
-            mmb.abi.as_ref().unwrap(),
+            abi.unwrap(),
             mmb.bytecode.clone(),
         ))
     }

--- a/rust/processor/src/processors/ans_processor.rs
+++ b/rust/processor/src/processors/ans_processor.rs
@@ -524,7 +524,7 @@ fn parse_ans(
             }
 
             // Parse V2 ANS subdomain exts
-            for (_, wsc) in transaction_info.changes.iter().enumerate() {
+            for wsc in transaction_info.changes.iter() {
                 match wsc.change.as_ref().unwrap() {
                     WriteSetChange::WriteResource(write_resource) => {
                         if let Some(subdomain_ext) = SubdomainExtV2::from_write_resource(

--- a/rust/processor/src/processors/nft_metadata_processor.rs
+++ b/rust/processor/src/processors/nft_metadata_processor.rs
@@ -192,7 +192,7 @@ async fn parse_v2_token(
         let transaction_info = txn.info.as_ref().expect("Transaction info doesn't exist!");
 
         let mut token_v2_metadata_helper: TokenV2AggregatedDataMapping = HashMap::new();
-        for (_, wsc) in transaction_info.changes.iter().enumerate() {
+        for wsc in transaction_info.changes.iter() {
             if let Change::WriteResource(wr) = wsc.change.as_ref().unwrap() {
                 if let Some(object) =
                     ObjectWithMetadata::from_write_resource(wr, txn_version).unwrap()

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -514,7 +514,7 @@ async fn parse_v2_token(
             let mut tokens_burned: TokenV2Burned = HashSet::new();
 
             // Need to do a first pass to get all the objects
-            for (_, wsc) in transaction_info.changes.iter().enumerate() {
+            for wsc in transaction_info.changes.iter() {
                 if let Change::WriteResource(wr) = wsc.change.as_ref().unwrap() {
                     if let Some(object) =
                         ObjectWithMetadata::from_write_resource(wr, txn_version).unwrap()
@@ -539,7 +539,7 @@ async fn parse_v2_token(
             }
 
             // Need to do a second pass to get all the structs related to the object
-            for (_, wsc) in transaction_info.changes.iter().enumerate() {
+            for wsc in transaction_info.changes.iter() {
                 if let Change::WriteResource(wr) = wsc.change.as_ref().unwrap() {
                     let address = standardize_address(&wr.address.to_string());
                     if let Some(aggregated_data) = token_v2_metadata_helper.get_mut(&address) {

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -279,11 +279,11 @@ impl Worker {
                     let txn_time = transactions.as_slice().first().unwrap().timestamp.clone();
                     if let Some(ref t) = txn_time {
                         PROCESSOR_DATA_RECEIVED_LATENCY_IN_SECS
-                            .with_label_values(&[auth_token.as_str(), &processor_name])
+                            .with_label_values(&[auth_token.as_str(), processor_name])
                             .set(time_diff_since_pb_timestamp_in_secs(t));
                     }
                     PROCESSOR_INVOCATIONS_COUNT
-                        .with_label_values(&[&processor_name])
+                        .with_label_values(&[processor_name])
                         .inc();
 
                     let processed_result = processor_clone
@@ -291,7 +291,7 @@ impl Worker {
                         .await;
                     if let Some(ref t) = txn_time {
                         PROCESSOR_DATA_PROCESSED_LATENCY_IN_SECS
-                            .with_label_values(&[auth_token.as_str(), &processor_name])
+                            .with_label_values(&[auth_token.as_str(), processor_name])
                             .set(time_diff_since_pb_timestamp_in_secs(t));
                     }
                     processed_result
@@ -316,7 +316,7 @@ impl Worker {
                 let processed: ProcessingResult = match res {
                     Ok(versions) => {
                         PROCESSOR_SUCCESSES_COUNT
-                            .with_label_values(&[&processor_name])
+                            .with_label_values(&[processor_name])
                             .inc();
                         versions
                     },
@@ -328,7 +328,7 @@ impl Worker {
                             "[Parser] Error processing transactions"
                         );
                         PROCESSOR_ERRORS_COUNT
-                            .with_label_values(&[&processor_name])
+                            .with_label_values(&[processor_name])
                             .inc();
                         panic!();
                     },
@@ -368,7 +368,7 @@ impl Worker {
             batch_start_version = batch_end + 1;
 
             LATEST_PROCESSED_VERSION
-                .with_label_values(&[&processor_name])
+                .with_label_values(&[processor_name])
                 .set(batch_end as i64);
             processor
                 .update_last_processed_version(batch_end)


### PR DESCRIPTION
## Summary
Basically we didn't realize that ABI could be empty when uploading a new module. But it is possible. 

## Testing
No longer crashes
<img width="998" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/d3a3538a-582e-4d14-8e79-2259713941fe">
