### PR TITLE
fix: wrong auth token header

### DIFF
--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -39,7 +39,7 @@ use tracing::{error, info};
 use url::Url;
 
 /// GRPC request metadata key for the token ID.
-const GRPC_API_GATEWAY_API_KEY_HEADER: &str = "authorization";
+const GRPC_AUTH_TOKEN_HEADER: &str = "x-aptos-data-authorization";
 /// GRPC request metadata key for the request name. This is used to identify the
 /// data destination.
 const GRPC_REQUEST_NAME_HEADER: &str = "x-aptos-request-name";
@@ -495,12 +495,9 @@ pub fn grpc_request_builder(
         transactions_count,
         ..GetTransactionsRequest::default()
     });
-    request.metadata_mut().insert(
-        GRPC_API_GATEWAY_API_KEY_HEADER,
-        format!("Bearer {}", grpc_auth_token.clone())
-            .parse()
-            .unwrap(),
-    );
+    request
+        .metadata_mut()
+        .insert(GRPC_AUTH_TOKEN_HEADER, grpc_auth_token.clone().parse().unwrap());
     request
         .metadata_mut()
         .insert(GRPC_REQUEST_NAME_HEADER, processor_name.parse().unwrap());


### PR DESCRIPTION

* Authorization Header is not correct

https://github.com/aptos-labs/aptos-core/blob/1d47982c93c5b6e7525b0070c85856b8df8c3a3f/ecosystem/indexer-grpc/indexer-grpc-data-service/src/config.rs#L118C4-L135

In `indexer-grpc-data-service`, token verification is working as follows
```
let authentication_inceptor =
            move |req: Request<()>| -> std::result::Result<Request<()>, Status> {
                if disable_auth_check {
                    return std::result::Result::Ok(req);
                }
                let metadata = req.metadata();
                if let Some(token) =
                    metadata.get(aptos_indexer_grpc_utils::constants::GRPC_AUTH_TOKEN_HEADER)
                {
                    if token_set.contains(token) {
                        std::result::Result::Ok(req)
                    } else {
                        Err(Status::unauthenticated("Invalid token"))
                    }
                } else {
                    Err(Status::unauthenticated("Missing token"))
                }
            };
```

But in indexer api processor, that auth token headers is wrongly set.
