### PR TITLE
[Rust SDK] Add SDK boilerplate with utils

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -104,6 +104,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-processor-sdk"
+version = "0.1.0"
+dependencies = [
+ "aptos-protos",
+ "bcs",
+ "bigdecimal",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "tracing",
+]
+
+[[package]]
 name = "aptos-protos"
 version = "1.1.2"
 source = "git+https://github.com/aptos-labs/aptos-core.git?rev=af0dcea7144225a709e4f595e58f8026b99e901c#af0dcea7144225a709e4f595e58f8026b99e901c"
@@ -1862,6 +1877,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "aptos-moving-average",
+ "aptos-processor-sdk",
  "aptos-protos",
  "async-trait",
  "base64 0.13.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "moving-average",
     "post-processor",
     "processor",
+    "sdk",
     "server-framework",
 ]
 
@@ -22,6 +23,7 @@ rust-version = "1.70"
 processor = { path = "processor" }
 server-framework = { path = "server-framework" }
 aptos-moving-average = { path = "moving-average" }
+aptos-processor-sdk = { path = "sdk" }
 
 anyhow = "1.0.62"
 async-trait = "0.1.53"
@@ -42,6 +44,7 @@ diesel = { version = "2.1", features = [
 diesel-async = { version = "0.4", features = ["postgres", "bb8", "tokio"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 diesel_async_migrations = { git = "https://github.com/niroco/diesel_async_migrations", rev = "11f331b73c5cfcc894380074f748d8fda710ac12" }
+duration-str = "0.7.0"
 enum_dispatch = "0.3.12"
 field_count = "0.1.1"
 futures = "0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.
@@ -73,6 +76,7 @@ sha2 = "0.9.3"
 sha3 = "0.9.1"
 strum = { version = "0.24.1", features = ["derive"] }
 tempfile = "3.3.0"
+thiserror = "1"
 toml = "0.7.4"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 tokio = { version = "1.21.0", features = ["full"] }

--- a/rust/processor/Cargo.toml
+++ b/rust/processor/Cargo.toml
@@ -13,8 +13,13 @@ repository = "https://github.com/aptos-labs/aptos-core"
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = { workspace = true }
+# Internal dependencies.
 aptos-moving-average = { workspace = true }
+aptos-processor-sdk = { workspace = true }
+server-framework = { workspace = true }
+
+# External dependencies.
+anyhow = { workspace = true }
 aptos-protos = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
@@ -41,7 +46,6 @@ prost-types = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-server-framework = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
 strum = { workspace = true }

--- a/rust/processor/src/models/ans_models/ans_utils.rs
+++ b/rust/processor/src/models/ans_models/ans_utils.rs
@@ -6,12 +6,10 @@
 
 use crate::{
     models::default_models::move_resources::MoveResource,
-    utils::util::{
-        bigdecimal_to_u64, deserialize_from_string, parse_timestamp_secs, standardize_address,
-        truncate_str,
-    },
+    utils::util::{bigdecimal_to_u64, deserialize_from_string, standardize_address, truncate_str},
 };
 use anyhow::Context;
+use aptos_processor_sdk::utils::parse_timestamp_secs;
 use aptos_protos::transaction::v1::{Event, WriteResource};
 use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};

--- a/rust/processor/src/models/default_models/block_metadata_transactions.rs
+++ b/rust/processor/src/models/default_models/block_metadata_transactions.rs
@@ -6,10 +6,8 @@
 #![allow(clippy::unused_unit)]
 
 use super::transactions::Transaction;
-use crate::{
-    schema::block_metadata_transactions,
-    utils::util::{parse_timestamp, standardize_address},
-};
+use crate::{schema::block_metadata_transactions, utils::util::standardize_address};
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::{
     transaction::v1::BlockMetadataTransaction as BlockMetadataTransactionPB,
     util::timestamp::Timestamp,

--- a/rust/processor/src/models/stake_models/proposal_votes.rs
+++ b/rust/processor/src/models/stake_models/proposal_votes.rs
@@ -5,10 +5,8 @@
 #![allow(clippy::extra_unused_lifetimes)]
 
 use super::stake_utils::StakeEvent;
-use crate::{
-    schema::proposal_votes,
-    utils::util::{parse_timestamp, standardize_address},
-};
+use crate::{schema::proposal_votes, utils::util::standardize_address};
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::transaction::v1::{transaction::TxnData, Transaction};
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;

--- a/rust/processor/src/models/token_models/nft_points.rs
+++ b/rust/processor/src/models/token_models/nft_points.rs
@@ -7,11 +7,9 @@
 
 use crate::{
     schema::nft_points,
-    utils::util::{
-        get_clean_payload, get_entry_function_from_user_request, parse_timestamp,
-        standardize_address,
-    },
+    utils::util::{get_clean_payload, get_entry_function_from_user_request, standardize_address},
 };
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::transaction::v1::{transaction::TxnData, Transaction};
 use bigdecimal::BigDecimal;
 use diesel::prelude::*;

--- a/rust/processor/src/models/token_models/token_activities.rs
+++ b/rust/processor/src/models/token_models/token_activities.rs
@@ -6,10 +6,8 @@
 #![allow(clippy::unused_unit)]
 
 use super::token_utils::{TokenDataIdType, TokenEvent};
-use crate::{
-    schema::token_activities,
-    utils::util::{parse_timestamp, standardize_address},
-};
+use crate::{schema::token_activities, utils::util::standardize_address};
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::transaction::v1::{transaction::TxnData, Event, Transaction};
 use bigdecimal::{BigDecimal, Zero};
 use field_count::FieldCount;

--- a/rust/processor/src/models/token_models/tokens.rs
+++ b/rust/processor/src/models/token_models/tokens.rs
@@ -17,9 +17,10 @@ use crate::{
     schema::tokens,
     utils::{
         database::PgPoolConnection,
-        util::{ensure_not_negative, parse_timestamp, standardize_address},
+        util::{ensure_not_negative, standardize_address},
     },
 };
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::transaction::v1::{
     transaction::TxnData, write_set_change::Change as WriteSetChangeEnum, DeleteTableItem,
     Transaction, WriteResource, WriteTableItem,

--- a/rust/processor/src/models/user_transactions_models/user_transactions.rs
+++ b/rust/processor/src/models/user_transactions_models/user_transactions.rs
@@ -10,11 +10,9 @@
 use super::signatures::Signature;
 use crate::{
     schema::user_transactions,
-    utils::util::{
-        get_entry_function_from_user_request, parse_timestamp, standardize_address,
-        u64_to_bigdecimal,
-    },
+    utils::util::{get_entry_function_from_user_request, standardize_address, u64_to_bigdecimal},
 };
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::{
     transaction::v1::{UserTransaction as UserTransactionPB, UserTransactionRequest},
     util::timestamp::Timestamp,

--- a/rust/processor/src/processors/mod.rs
+++ b/rust/processor/src/processors/mod.rs
@@ -40,9 +40,9 @@ use crate::{
     utils::{
         counters::{GOT_CONNECTION_COUNT, UNABLE_TO_GET_CONNECTION_COUNT},
         database::{execute_with_better_error, PgDbPool, PgPoolConnection},
-        util::parse_timestamp,
     },
 };
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::transaction::v1::Transaction as ProtoTransaction;
 use async_trait::async_trait;
 use diesel::{pg::upsert::excluded, prelude::*};

--- a/rust/processor/src/processors/nft_metadata_processor.rs
+++ b/rust/processor/src/processors/nft_metadata_processor.rs
@@ -15,9 +15,10 @@ use crate::{
     },
     utils::{
         database::{PgDbPool, PgPoolConnection},
-        util::{parse_timestamp, standardize_address},
+        util::standardize_address,
     },
 };
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::transaction::v1::{write_set_change::Change, Transaction};
 use async_trait::async_trait;
 use futures_util::future::try_join_all;

--- a/rust/processor/src/processors/stake_processor.rs
+++ b/rust/processor/src/processors/stake_processor.rs
@@ -22,10 +22,11 @@ use crate::{
             clean_data_for_db, execute_with_better_error, get_chunks, MyDbConnection, PgDbPool,
             PgPoolConnection,
         },
-        util::{parse_timestamp, standardize_address},
+        util::standardize_address,
     },
 };
 use anyhow::bail;
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::transaction::v1::{write_set_change::Change, Transaction};
 use async_trait::async_trait;
 use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods};

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -32,10 +32,11 @@ use crate::{
             clean_data_for_db, execute_with_better_error, get_chunks, MyDbConnection, PgDbPool,
             PgPoolConnection,
         },
-        util::{get_entry_function_from_user_request, parse_timestamp, standardize_address},
+        util::{get_entry_function_from_user_request, standardize_address},
     },
 };
 use anyhow::bail;
+use aptos_processor_sdk::utils::parse_timestamp;
 use aptos_protos::transaction::v1::{transaction::TxnData, write_set_change::Change, Transaction};
 use async_trait::async_trait;
 use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods};

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -25,11 +25,12 @@ use crate::{
             SINGLE_BATCH_PROCESSING_TIME_IN_SECS, TRANSACTION_UNIX_TIMESTAMP,
         },
         database::{execute_with_better_error, new_db_pool, run_pending_migrations, PgDbPool},
-        util::{time_diff_since_pb_timestamp_in_secs, timestamp_to_iso, timestamp_to_unixtime},
+        util::time_diff_since_pb_timestamp_in_secs,
     },
 };
 use anyhow::{Context, Result};
 use aptos_moving_average::MovingAverage;
+use aptos_processor_sdk::utils::{timestamp_to_iso, timestamp_to_unixtime};
 use aptos_protos::{
     indexer::v1::{raw_data_client::RawDataClient, GetTransactionsRequest, TransactionsResponse},
     transaction::v1::Transaction,

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "aptos-processor-sdk"
+description = "Everything you need to write a processor for the Aptos indexer stack"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+# External dependencies.
+aptos-protos = { workspace = true }
+bcs = { workspace = true }
+bigdecimal = { workspace = true }
+chrono = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tracing = { workspace = true }

--- a/rust/sdk/README.md
+++ b/rust/sdk/README.md
@@ -1,0 +1,3 @@
+# Aptos Processor SDK
+
+todo

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod utils;
+
+// Re-export other crates devs will need to write processors.
+pub use aptos_protos;

--- a/rust/sdk/src/utils/mod.rs
+++ b/rust/sdk/src/utils/mod.rs
@@ -1,0 +1,64 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_protos::util::timestamp::Timestamp;
+
+// 9999-12-31 23:59:59, this is the max supported by Google BigQuery
+pub const MAX_TIMESTAMP_SECS: i64 = 253_402_300_799;
+
+pub fn parse_timestamp(ts: &Timestamp, version: i64) -> chrono::NaiveDateTime {
+    let final_ts = if ts.seconds >= MAX_TIMESTAMP_SECS {
+        Timestamp {
+            seconds: MAX_TIMESTAMP_SECS,
+            nanos: 0,
+        }
+    } else {
+        ts.clone()
+    };
+    chrono::NaiveDateTime::from_timestamp_opt(final_ts.seconds, final_ts.nanos as u32)
+        .unwrap_or_else(|| panic!("Could not parse timestamp {:?} for version {}", ts, version))
+}
+
+pub fn parse_timestamp_secs(ts: u64, version: i64) -> chrono::NaiveDateTime {
+    chrono::NaiveDateTime::from_timestamp_opt(
+        std::cmp::min(ts, MAX_TIMESTAMP_SECS as u64) as i64,
+        0,
+    )
+    .unwrap_or_else(|| panic!("Could not parse timestamp {:?} for version {}", ts, version))
+}
+
+/// Convert the protobuf timestamp to ISO format
+pub fn timestamp_to_iso(timestamp: &Timestamp) -> String {
+    let dt = parse_timestamp(timestamp, 0);
+    dt.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string()
+}
+
+/// Convert the protobuf timestamp to unixtime
+pub fn timestamp_to_unixtime(timestamp: &Timestamp) -> f64 {
+    timestamp.seconds as f64 + timestamp.nanos as f64 * 1e-9
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Datelike;
+
+    #[test]
+    fn test_parse_timestamp() {
+        let ts = parse_timestamp(
+            &Timestamp {
+                seconds: 1649560602,
+                nanos: 0,
+            },
+            1,
+        );
+        assert_eq!(ts.timestamp(), 1649560602);
+        assert_eq!(ts.year(), 2022);
+
+        let ts2 = parse_timestamp_secs(600000000000000, 2);
+        assert_eq!(ts2.year(), 9999);
+
+        let ts3 = parse_timestamp_secs(1659386386, 2);
+        assert_eq!(ts3.timestamp(), 1659386386);
+    }
+}


### PR DESCRIPTION
## Stack
- Prev: N/A
- Next: https://github.com/aptos-labs/aptos-indexer-processors/pull/203

## Summary
This PR makes the beginning of a processor SDK for Rust. All I move for now is util functions that aren't specific to the core processors. I separated this from https://github.com/aptos-labs/aptos-indexer-processors/pull/203 to make it easier to review that PR. We can discuss whether we want to move all these util functions over separately from that PR.

Update: I only move the utils necessary for StreamSubscriber now.

## Test Plan
See https://github.com/aptos-labs/aptos-indexer-processors/pull/207.