### PR TITLE
Update fungible asset and token processor queries to use objects table

### DIFF
--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
@@ -89,6 +89,7 @@ impl FungibleAssetActivity {
                     conn,
                     &asset_type,
                     fungible_asset_metadata,
+                    txn_version,
                 )
                 .await
                 {

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
@@ -69,7 +69,7 @@ impl FungibleAssetActivity {
         txn_timestamp: chrono::NaiveDateTime,
         event_index: i64,
         entry_function_id_str: &Option<String>,
-        fungible_asset_metadata: &ObjectAggregatedDataMapping,
+        object_aggregated_data_mapping: &ObjectAggregatedDataMapping,
         conn: &mut PgPoolConnection<'_>,
     ) -> anyhow::Result<Option<Self>> {
         let event_type = event.type_str.clone();
@@ -80,15 +80,15 @@ impl FungibleAssetActivity {
 
             // The event account address will also help us find fungible store which tells us where to find
             // the metadata
-            if let Some(metadata) = fungible_asset_metadata.get(&storage_id) {
-                let object_core = &metadata.object.object_core;
-                let fungible_asset = metadata.fungible_asset_store.as_ref().unwrap();
+            if let Some(object_metadata) = object_aggregated_data_mapping.get(&storage_id) {
+                let object_core = &object_metadata.object.object_core;
+                let fungible_asset = object_metadata.fungible_asset_store.as_ref().unwrap();
                 let asset_type = fungible_asset.metadata.get_reference_address();
                 // If it's a fungible token, return early
                 if !FungibleAssetMetadataModel::is_address_fungible_asset(
                     conn,
                     &asset_type,
-                    fungible_asset_metadata,
+                    object_aggregated_data_mapping,
                     txn_version,
                 )
                 .await

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -86,6 +86,7 @@ impl FungibleAssetBalance {
                     conn,
                     &asset_type,
                     fungible_asset_metadata,
+                    txn_version,
                 )
                 .await
                 {

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -70,22 +70,22 @@ impl FungibleAssetBalance {
         write_set_change_index: i64,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
-        fungible_asset_metadata: &ObjectAggregatedDataMapping,
+        object_metadatas: &ObjectAggregatedDataMapping,
         conn: &mut PgPoolConnection<'_>,
     ) -> anyhow::Result<Option<(Self, CurrentFungibleAssetBalance)>> {
         if let Some(inner) = &FungibleAssetStore::from_write_resource(write_resource, txn_version)?
         {
             let storage_id = standardize_address(write_resource.address.as_str());
             // Need to get the object of the store
-            if let Some(store_metadata) = fungible_asset_metadata.get(&storage_id) {
-                let object = &store_metadata.object.object_core;
+            if let Some(object_data) = object_metadatas.get(&storage_id) {
+                let object = &object_data.object.object_core;
                 let owner_address = object.get_owner_address();
                 let asset_type = inner.metadata.get_reference_address();
                 // If it's a fungible token, return early
                 if !FungibleAssetMetadataModel::is_address_fungible_asset(
                     conn,
-                    &asset_type,
-                    fungible_asset_metadata,
+                    &storage_id,
+                    object_metadatas,
                     txn_version,
                 )
                 .await

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -9,7 +9,8 @@ use super::v2_fungible_asset_utils::FungibleAssetMetadata;
 use crate::{
     models::{
         coin_models::coin_utils::{CoinInfoType, CoinResource},
-        object_models::v2_object_utils::{Object, ObjectAggregatedDataMapping},
+        object_models::v2_object_utils::ObjectAggregatedDataMapping,
+        object_models::v2_objects::Object,
         token_v2_models::v2_token_utils::TokenStandard,
     },
     schema::fungible_asset_metadata,

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -16,7 +16,6 @@ use crate::{
     utils::{database::PgPoolConnection, util::standardize_address},
 };
 use ahash::AHashMap;
-use anyhow::Context;
 use aptos_protos::transaction::v1::WriteResource;
 use diesel::sql_types::Text;
 use field_count::FieldCount;

--- a/rust/processor/src/models/object_models/v2_objects.rs
+++ b/rust/processor/src/models/object_models/v2_objects.rs
@@ -21,6 +21,7 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
@@ -135,17 +136,7 @@ impl Object {
             let previous_object = if let Some(object) = object_mapping.get(&resource.address) {
                 object.clone()
             } else {
-                match Self::get_object_owner(conn, &resource.address).await {
-                    Ok(owner) => owner,
-                    Err(_) => {
-                        tracing::error!(
-                            transaction_version = txn_version,
-                            lookup_key = &resource.address,
-                            "Missing object owner for object. You probably should backfill db.",
-                        );
-                        return Ok(None);
-                    },
-                }
+                Self::get_object(conn, &resource.address, txn_version).await
             };
             Ok(Some((
                 Self {
@@ -177,17 +168,18 @@ impl Object {
         }
     }
 
-    /// This is actually not great because object owner can change. The best we can do now though
-    async fn get_object_owner(
+    /// This is actually not great because object owner can change. The best we can do now though.
+    /// This will loop forever until we get the object from the db
+    pub async fn get_object(
         conn: &mut PgPoolConnection<'_>,
         object_address: &str,
-    ) -> anyhow::Result<CurrentObject> {
-        let mut retried = 0;
-        while retried < QUERY_RETRIES {
-            retried += 1;
+        transaction_version: i64,
+    ) -> CurrentObject {
+        let retries = 0;
+        while retries < QUERY_RETRIES {
             match CurrentObjectQuery::get_by_address(object_address, conn).await {
                 Ok(res) => {
-                    return Ok(CurrentObject {
+                    return CurrentObject {
                         object_address: res.object_address,
                         owner_address: res.owner_address,
                         state_key_hash: res.state_key_hash,
@@ -197,15 +189,22 @@ impl Object {
                         is_token: res.is_token,
                         is_fungible_asset: res.is_fungible_asset,
                         is_deleted: res.is_deleted,
-                    });
+                    };
                 },
-                Err(_) => {
+                Err(e) => {
+                    warn!(
+                        transaction_version,
+                        error = ?e,
+                        "Failed to get object from current_objects table for object_address: {}, retrying in {} ms. ",
+                        object_address,
+                        QUERY_RETRY_DELAY_MS,
+                    );
                     tokio::time::sleep(std::time::Duration::from_millis(QUERY_RETRY_DELAY_MS))
                         .await;
                 },
             }
         }
-        Err(anyhow::anyhow!("Failed to get object owner"))
+        panic!("Failed to get object from current_objects table for object_address: {}. You should probably backfill db.", object_address);
     }
 }
 

--- a/rust/processor/src/models/token_v2_models/v2_collections.rs
+++ b/rust/processor/src/models/token_v2_models/v2_collections.rs
@@ -124,7 +124,7 @@ impl CollectionV2 {
                 }
 
                 // Aggregator V2 enables a separate struct for supply
-                let concurrent_supply = metadata.concurrent_supply.as_ref();
+                let concurrent_supply = object_data.concurrent_supply.as_ref();
                 if let Some(supply) = concurrent_supply {
                     (current_supply, max_supply, total_minted_v2) = (
                         supply.current_supply.value.clone(),

--- a/rust/processor/src/models/token_v2_models/v2_collections.rs
+++ b/rust/processor/src/models/token_v2_models/v2_collections.rs
@@ -83,7 +83,7 @@ impl CollectionV2 {
         txn_version: i64,
         write_set_change_index: i64,
         txn_timestamp: chrono::NaiveDateTime,
-        token_v2_metadata: &ObjectAggregatedDataMapping,
+        object_metadatas: &ObjectAggregatedDataMapping,
     ) -> anyhow::Result<Option<(Self, CurrentCollectionV2)>> {
         let type_str = MoveResource::get_outer_type_from_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
@@ -104,10 +104,10 @@ impl CollectionV2 {
             let (mut current_supply, mut max_supply, mut total_minted_v2) =
                 (BigDecimal::zero(), None, None);
             let (mut mutable_description, mut mutable_uri) = (None, None);
-            if let Some(metadata) = token_v2_metadata.get(&resource.address) {
+            if let Some(object_data) = object_metadatas.get(&resource.address) {
                 // Getting supply data (prefer fixed supply over unlimited supply although they should never appear at the same time anyway)
-                let fixed_supply = metadata.fixed_supply.as_ref();
-                let unlimited_supply = metadata.unlimited_supply.as_ref();
+                let fixed_supply = object_data.fixed_supply.as_ref();
+                let unlimited_supply = object_data.unlimited_supply.as_ref();
                 if let Some(supply) = unlimited_supply {
                     (current_supply, max_supply, total_minted_v2) = (
                         supply.current_supply.clone(),
@@ -138,7 +138,7 @@ impl CollectionV2 {
                 }
 
                 // Getting collection mutability config from AptosCollection
-                let collection = metadata.aptos_collection.as_ref();
+                let collection = object_data.aptos_collection.as_ref();
                 if let Some(collection) = collection {
                     mutable_description = Some(collection.mutable_description);
                     mutable_uri = Some(collection.mutable_uri);

--- a/rust/processor/src/models/token_v2_models/v2_token_activities.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_activities.rs
@@ -94,8 +94,13 @@ impl TokenActivityV2 {
                 let fungible_asset = metadata.fungible_asset_store.as_ref().unwrap();
                 let token_data_id = fungible_asset.metadata.get_reference_address();
                 // Exit early if it's not a token
-                if !TokenDataV2::is_address_fungible_token(conn, &token_data_id, token_v2_metadata)
-                    .await
+                if !TokenDataV2::is_address_fungible_token(
+                    conn,
+                    &token_data_id,
+                    token_v2_metadata,
+                    txn_version,
+                )
+                .await
                 {
                     return Ok(None);
                 }

--- a/rust/processor/src/models/token_v2_models/v2_token_activities.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_activities.rs
@@ -77,7 +77,7 @@ impl TokenActivityV2 {
         txn_timestamp: chrono::NaiveDateTime,
         event_index: i64,
         entry_function_id_str: &Option<String>,
-        token_v2_metadata: &ObjectAggregatedDataMapping,
+        object_metadatas: &ObjectAggregatedDataMapping,
         conn: &mut PgPoolConnection<'_>,
     ) -> anyhow::Result<Option<Self>> {
         let event_type = event.type_str.clone();
@@ -89,15 +89,15 @@ impl TokenActivityV2 {
 
             // The event account address will also help us find fungible store which tells us where to find
             // the metadata
-            if let Some(metadata) = token_v2_metadata.get(&event_account_address) {
-                let object_core = &metadata.object.object_core;
-                let fungible_asset = metadata.fungible_asset_store.as_ref().unwrap();
+            if let Some(object_data) = object_metadatas.get(&event_account_address) {
+                let object_core = &object_data.object.object_core;
+                let fungible_asset = object_data.fungible_asset_store.as_ref().unwrap();
                 let token_data_id = fungible_asset.metadata.get_reference_address();
                 // Exit early if it's not a token
                 if !TokenDataV2::is_address_fungible_token(
                     conn,
                     &token_data_id,
-                    token_v2_metadata,
+                    object_metadatas,
                     txn_version,
                 )
                 .await

--- a/rust/processor/src/models/token_v2_models/v2_token_datas.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_datas.rs
@@ -8,8 +8,8 @@
 use super::v2_token_utils::{TokenStandard, TokenV2};
 use crate::{
     models::{
-        object_models::v2_object_utils::{Object, ObjectAggregatedDataMapping},
-        token_models::token_utils::TokenWriteSet,
+        object_models::v2_object_utils::ObjectAggregatedDataMapping,
+        object_models::v2_objects::Object, token_models::token_utils::TokenWriteSet,
     },
     schema::{current_token_datas_v2, token_datas_v2},
     utils::{database::PgPoolConnection, util::standardize_address},

--- a/rust/processor/src/models/token_v2_models/v2_token_datas.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_datas.rs
@@ -98,7 +98,7 @@ impl TokenDataV2 {
                     .map(|m| m.inner.clone())
                     .unwrap_or(token_properties);
                 // In aggregator V2 name is now derived from a separate struct
-                if let Some(token_identifier) = metadata.token_identifier.as_ref() {
+                if let Some(token_identifier) = object_metadata.token_identifier.as_ref() {
                     token_name = token_identifier.get_name_trunc();
                 }
             } else {

--- a/rust/processor/src/models/token_v2_models/v2_token_metadata.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_metadata.rs
@@ -41,12 +41,12 @@ impl CurrentTokenV2Metadata {
     pub fn from_write_resource(
         write_resource: &WriteResource,
         txn_version: i64,
-        token_v2_metadata: &ObjectAggregatedDataMapping,
+        object_metadatas: &ObjectAggregatedDataMapping,
     ) -> anyhow::Result<Option<Self>> {
         let object_address = standardize_address(&write_resource.address.to_string());
-        if let Some(metadata) = token_v2_metadata.get(&object_address) {
+        if let Some(object_data) = object_metadatas.get(&object_address) {
             // checking if token_v2
-            if metadata.token.is_some() {
+            if object_data.token.is_some() {
                 let move_tag =
                     MoveResource::convert_move_struct_tag(write_resource.r#type.as_ref().unwrap());
                 let resource_type_addr = move_tag.get_address();
@@ -59,7 +59,7 @@ impl CurrentTokenV2Metadata {
 
                 let resource = MoveResource::from_write_resource(write_resource, 0, txn_version, 0);
 
-                let state_key_hash = metadata.object.get_state_key_hash();
+                let state_key_hash = object_data.object.get_state_key_hash();
                 if state_key_hash != resource.state_key_hash {
                     return Ok(None);
                 }

--- a/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
@@ -394,8 +394,13 @@ impl TokenOwnershipV2 {
                 let object_core = &metadata.object.object_core;
                 let token_data_id = inner.metadata.get_reference_address();
                 // Exit early if it's not a token
-                if !TokenDataV2::is_address_fungible_token(conn, &token_data_id, token_v2_metadata)
-                    .await
+                if !TokenDataV2::is_address_fungible_token(
+                    conn,
+                    &token_data_id,
+                    token_v2_metadata,
+                    txn_version,
+                )
+                .await
                 {
                     return Ok(None);
                 }

--- a/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
@@ -113,7 +113,7 @@ impl TokenOwnershipV2 {
     /// Vecs are returned because there could be multiple transfers and we need to document each one here.
     pub fn get_nft_v2_from_token_data(
         token_data: &TokenDataV2,
-        token_v2_metadata: &ObjectAggregatedDataMapping,
+        object_metadatas: &ObjectAggregatedDataMapping,
     ) -> anyhow::Result<(
         Vec<Self>,
         AHashMap<CurrentTokenOwnershipV2PK, CurrentTokenOwnershipV2>,
@@ -125,10 +125,10 @@ impl TokenOwnershipV2 {
         let mut ownerships = vec![];
         let mut current_ownerships = AHashMap::new();
 
-        let metadata = token_v2_metadata
+        let object_data = object_metadatas
             .get(&token_data.token_data_id)
             .context("If token data exists objectcore must exist")?;
-        let object_core = metadata.object.object_core.clone();
+        let object_core = object_data.object.object_core.clone();
         let token_data_id = token_data.token_data_id.clone();
         let owner_address = object_core.get_owner_address();
         let storage_id = token_data_id.clone();
@@ -175,7 +175,7 @@ impl TokenOwnershipV2 {
         );
 
         // check if token was transferred
-        for (event_index, transfer_event) in &metadata.transfer_events {
+        for (event_index, transfer_event) in &object_data.transfer_events {
             // If it's a self transfer then skip
             if transfer_event.get_to_address() == transfer_event.get_from_address() {
                 continue;
@@ -369,7 +369,7 @@ impl TokenOwnershipV2 {
         txn_version: i64,
         write_set_change_index: i64,
         txn_timestamp: chrono::NaiveDateTime,
-        token_v2_metadata: &ObjectAggregatedDataMapping,
+        object_metadatas: &ObjectAggregatedDataMapping,
         conn: &mut PgPoolConnection<'_>,
     ) -> anyhow::Result<Option<(Self, CurrentTokenOwnershipV2)>> {
         let type_str = MoveResource::get_outer_type_from_resource(write_resource);
@@ -390,14 +390,14 @@ impl TokenOwnershipV2 {
                 txn_version,
             )?
         {
-            if let Some(metadata) = token_v2_metadata.get(&resource.address) {
-                let object_core = &metadata.object.object_core;
+            if let Some(object_data) = object_metadatas.get(&resource.address) {
+                let object_core = &object_data.object.object_core;
                 let token_data_id = inner.metadata.get_reference_address();
                 // Exit early if it's not a token
                 if !TokenDataV2::is_address_fungible_token(
                     conn,
                     &token_data_id,
-                    token_v2_metadata,
+                    object_metadatas,
                     txn_version,
                 )
                 .await


### PR DESCRIPTION
## Description 
* Update the fungible asset and token v2 processors to query for whether an object is token and/or fungible asset using the current_objects table 
* Also use ObjectAggregatedDataMapping everywhere instead of TokenV2DataMapping or FungibleAssetMetadataMapping

## Breaking change
* Dependent on this PR: https://github.com/aptos-labs/aptos-indexer-processors/pull/215
* If you're running fungible asset processor or token v2 processor, you must also run objects processor to lookup object data
* Testnet: Backfill objects processor
```
server_config:
  processor_config:
    type: "objects_processor"
  starting_version: 469526272
```
* Mainnet: Backfill objects processor
```
server_config:
  processor_config:
    type: "objects_processor"
  starting_version: 144201952
```

## Testing
### Before
Run token v2 processor starting_version = 803795000 (when the polling ended)
Processor is slow/stuck > 10 min. 

### After 
Run objects processor starting_version = 802980551 (when the question was created) 
Run token v2 processor starting_version = 803795000 (when the polling ended)

Duration to process version 803795008: 0.061555459s
```
{"timestamp":"2023-12-08T17:33:19.184016Z","level":"INFO","fields":{"message":"[Parser] Parsing time of one batch of transactions","processor_name":"token_v2_processor","service_type":"processor","start_version":803795008,"end_version":803795008,"start_txn_timestamp_iso":"2023-12-07T05:26:38.527385000Z","end_txn_timestamp_iso":"2023-12-07T05:26:38.527385000Z","size_in_bytes":281546,"duration_in_secs":0.061555459,"tps":0.0,"bytes_per_sec":4251470.2700600065},"filename":"processor/src/worker.rs","line_number":501,"threadName":"tokio-runtime-worker","threadId":"ThreadId(11)"}
```