### PR TITLE
[Hasura] Include pool settings in Hasura metadata

### DIFF
--- a/hasura-api/metadata-json/README.md
+++ b/hasura-api/metadata-json/README.md
@@ -1,0 +1,1 @@
+Note that `max_connections` is ignored if `total_max_connections` is set.

--- a/hasura-api/metadata-json/unified.json
+++ b/hasura-api/metadata-json/unified.json
@@ -1,5 +1,5 @@
 {
-  "resource_version": 288,
+  "resource_version": 296,
   "metadata": {
     "version": 3,
     "sources": [
@@ -375,7 +375,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["account_address", "transaction_version"],
+                  "columns": [
+                    "account_address",
+                    "transaction_version"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -491,7 +494,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["account_address", "transaction_version"],
+                  "columns": [
+                    "account_address",
+                    "transaction_version"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -570,7 +576,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["address", "transaction_version"],
+                  "columns": [
+                    "address",
+                    "transaction_version"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -1783,7 +1792,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["delegator_address", "pool_address"],
+                  "columns": [
+                    "delegator_address",
+                    "pool_address"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -1922,7 +1934,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["db", "is_indexer_up"],
+                  "columns": [
+                    "db",
+                    "is_indexer_up"
+                  ],
                   "filter": {},
                   "limit": 100
                 }
@@ -1938,7 +1953,9 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["chain_id"],
+                  "columns": [
+                    "chain_id"
+                  ],
                   "filter": {}
                 }
               }
@@ -1953,7 +1970,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["address", "transaction_version"],
+                  "columns": [
+                    "address",
+                    "transaction_version"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -1970,7 +1990,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["num_active_delegator", "pool_address"],
+                  "columns": [
+                    "num_active_delegator",
+                    "pool_address"
+                  ],
                   "filter": {},
                   "limit": 100
                 }
@@ -2054,7 +2077,11 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["handle", "key_type", "value_type"],
+                  "columns": [
+                    "handle",
+                    "key_type",
+                    "value_type"
+                  ],
                   "filter": {},
                   "limit": 100
                 }
@@ -2356,6 +2383,13 @@
               "from_env": "INDEXER_V2_POSTGRES_URL"
             },
             "isolation_level": "read-committed",
+            "pool_settings": {
+              "connection_lifetime": 600,
+              "idle_timeout": 180,
+              "max_connections": 100,
+              "total_max_connections": 1500,
+              "pool_timeout": 120
+            },
             "use_prepared_statements": false
           }
         }
@@ -2391,7 +2425,9 @@
             "query_name": "Latest Processor Status"
           }
         },
-        "methods": ["GET"],
+        "methods": [
+          "GET"
+        ],
         "name": "Latest Processor Status",
         "url": "get_lastest_processor_status"
       }


### PR DESCRIPTION
This PR adds the pool settings to the Hasura metadata and sets total_max_connections rather than max_connections. This increases the overall max connections from Hasura to the DB.

Live in prod already.

See here for more info: https://aptos-org.slack.com/archives/C06AP2QT3TM/p1702989622752439?thread_ts=1702982946.408549&cid=C06AP2QT3TM.