### PR TITLE
Use aptos-protos 1.1.2-a from crates.io

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -105,8 +105,9 @@ dependencies = [
 
 [[package]]
 name = "aptos-protos"
-version = "1.1.2"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=af0dcea7144225a709e4f595e58f8026b99e901c#af0dcea7144225a709e4f595e58f8026b99e901c"
+version = "1.1.2-a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79a99ec72b1ea1bcc2183bcf483c0aaacdf6777d3e3572779ef9c172782c5062"
 dependencies = [
  "futures-core",
  "pbjson",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ aptos-moving-average = { path = "moving-average" }
 
 anyhow = "1.0.62"
 async-trait = "0.1.53"
-aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "af0dcea7144225a709e4f595e58f8026b99e901c" }
+aptos-protos = "1.1.2-a"
 backtrace = "0.3.58"
 base64 = "0.13.0"
 bb8 = "0.8.1"

--- a/rust/processor/src/lib.rs
+++ b/rust/processor/src/lib.rs
@@ -18,4 +18,6 @@ pub mod schema;
 pub mod utils;
 pub mod worker;
 
+// Re-export crates downstream devs might need.
+pub use aptos_protos;
 pub use config::IndexerGrpcProcessorConfig;


### PR DESCRIPTION
This version is published from af0dcea7144225a709e4f595e58f8026b99e901c so it should be identical to what we were using.