### PR TITLE
Split token v2 db txn

### DIFF
--- a/rust/processor/src/models/account_transaction_models/account_transactions.rs
+++ b/rust/processor/src/models/account_transaction_models/account_transactions.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 
 pub type AccountTransactionPK = (String, i64);
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(account_address, transaction_version))]
 #[diesel(table_name = account_transactions)]
 pub struct AccountTransaction {

--- a/rust/processor/src/models/coin_models/coin_activities.rs
+++ b/rust/processor/src/models/coin_models/coin_activities.rs
@@ -36,7 +36,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(
     transaction_version,
     event_account_address,

--- a/rust/processor/src/models/coin_models/coin_balances.rs
+++ b/rust/processor/src/models/coin_models/coin_balances.rs
@@ -17,7 +17,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, owner_address, coin_type))]
 #[diesel(table_name = coin_balances)]
 pub struct CoinBalance {
@@ -29,7 +29,7 @@ pub struct CoinBalance {
     pub transaction_timestamp: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(owner_address, coin_type))]
 #[diesel(table_name = current_coin_balances)]
 pub struct CurrentCoinBalance {

--- a/rust/processor/src/models/coin_models/coin_infos.rs
+++ b/rust/processor/src/models/coin_models/coin_infos.rs
@@ -11,7 +11,7 @@ use aptos_protos::transaction::v1::WriteResource;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(coin_type_hash))]
 #[diesel(table_name = coin_infos)]
 pub struct CoinInfo {

--- a/rust/processor/src/models/coin_models/coin_supply.rs
+++ b/rust/processor/src/models/coin_models/coin_supply.rs
@@ -20,7 +20,7 @@ const APTOS_COIN_SUPPLY_TABLE_HANDLE: &str =
 const APTOS_COIN_SUPPLY_TABLE_KEY: &str =
     "0x619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935";
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, coin_type_hash))]
 #[diesel(table_name = coin_supply)]
 pub struct CoinSupply {

--- a/rust/processor/src/models/default_models/move_modules.rs
+++ b/rust/processor/src/models/default_models/move_modules.rs
@@ -54,20 +54,14 @@ impl MoveModule {
             // TODO: remove the useless_asref lint when new clippy nighly is released.
             #[allow(clippy::useless_asref)]
             name: parsed_data
-                .as_ref()
+                .clone()
                 .map(|d| d.name.clone())
                 .unwrap_or_default(),
             address: standardize_address(&write_module.address.to_string()),
-            // TODO: remove the useless_asref lint when new clippy nighly is released.
-            #[allow(clippy::useless_asref)]
-            bytecode: parsed_data.as_ref().map(|d| d.bytecode.clone()),
-            // TODO: remove the useless_asref lint when new clippy nighly is released.
-            #[allow(clippy::useless_asref)]
-            exposed_functions: parsed_data.as_ref().map(|d| d.exposed_functions.clone()),
-            // TODO: remove the useless_asref lint when new clippy nighly is released.
-            #[allow(clippy::useless_asref)]
-            friends: parsed_data.as_ref().map(|d| d.friends.clone()),
-            structs: parsed_data.map(|d| d.structs),
+            bytecode: parsed_data.clone().map(|d| d.bytecode.clone()),
+            exposed_functions: parsed_data.clone().map(|d| d.exposed_functions.clone()),
+            friends: parsed_data.clone().map(|d| d.friends.clone()),
+            structs: parsed_data.map(|d| d.structs.clone()),
             is_deleted: false,
         }
     }
@@ -86,7 +80,7 @@ impl MoveModule {
             #[allow(clippy::useless_asref)]
             name: delete_module
                 .module
-                .as_ref()
+                .clone()
                 .map(|d| d.name.clone())
                 .unwrap_or_default(),
             address: standardize_address(&delete_module.address.to_string()),

--- a/rust/processor/src/models/default_models/transactions.rs
+++ b/rust/processor/src/models/default_models/transactions.rs
@@ -24,7 +24,7 @@ use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(version))]
 #[diesel(table_name = transactions)]
 pub struct Transaction {

--- a/rust/processor/src/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/models/default_models/write_set_changes.rs
@@ -16,7 +16,9 @@ use aptos_protos::transaction::v1::{
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Associations, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(
+    Associations, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone,
+)]
 #[diesel(belongs_to(Transaction, foreign_key = transaction_version))]
 #[diesel(primary_key(transaction_version, index))]
 #[diesel(table_name = write_set_changes)]

--- a/rust/processor/src/models/events_models/events.rs
+++ b/rust/processor/src/models/events_models/events.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 // p99 currently is 303 so using 300 as a safe max length
 const EVENT_TYPE_MAX_LENGTH: usize = 300;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, event_index))]
 #[diesel(table_name = events)]
 pub struct Event {

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
@@ -39,7 +39,7 @@ pub type CoinType = String;
 pub type CurrentCoinBalancePK = (OwnerAddress, CoinType);
 pub type EventToCoinType = HashMap<EventGuidResource, CoinType>;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, event_index))]
 #[diesel(table_name = fungible_asset_activities)]
 pub struct FungibleAssetActivity {

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -32,7 +32,7 @@ pub type CurrentFungibleAssetBalancePK = String;
 pub type CurrentFungibleAssetMapping =
     HashMap<CurrentFungibleAssetBalancePK, CurrentFungibleAssetBalance>;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
 #[diesel(table_name = fungible_asset_balances)]
 pub struct FungibleAssetBalance {

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -29,7 +29,7 @@ pub type FungibleAssetMetadataPK = String;
 pub type FungibleAssetMetadataMapping =
     HashMap<FungibleAssetMetadataPK, FungibleAssetMetadataModel>;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(asset_type))]
 #[diesel(table_name = fungible_asset_metadata)]
 pub struct FungibleAssetMetadataModel {

--- a/rust/processor/src/models/stake_models/current_delegated_voter.rs
+++ b/rust/processor/src/models/stake_models/current_delegated_voter.rs
@@ -34,7 +34,9 @@ pub struct CurrentDelegatedVoterQuery {
     pub inserted_at: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Deserialize, Eq, FieldCount, Identifiable, Insertable, PartialEq, Serialize)]
+#[derive(
+    Debug, Deserialize, Eq, FieldCount, Identifiable, Insertable, PartialEq, Serialize, Clone,
+)]
 #[diesel(primary_key(delegator_address, delegation_pool_address))]
 #[diesel(table_name = current_delegated_voter)]
 pub struct CurrentDelegatedVoter {

--- a/rust/processor/src/models/stake_models/delegator_activities.rs
+++ b/rust/processor/src/models/stake_models/delegator_activities.rs
@@ -13,7 +13,7 @@ use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, event_index))]
 #[diesel(table_name = delegated_staking_activities)]
 pub struct DelegatedStakingActivity {

--- a/rust/processor/src/models/stake_models/delegator_balances.rs
+++ b/rust/processor/src/models/stake_models/delegator_balances.rs
@@ -30,7 +30,7 @@ pub type ShareToPoolMapping = HashMap<TableHandle, PoolBalanceMetadata>;
 pub type CurrentDelegatorBalancePK = (Address, Address, String);
 pub type CurrentDelegatorBalanceMap = HashMap<CurrentDelegatorBalancePK, CurrentDelegatorBalance>;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(delegator_address, pool_address, pool_type))]
 #[diesel(table_name = current_delegator_balances)]
 pub struct CurrentDelegatorBalance {
@@ -43,7 +43,7 @@ pub struct CurrentDelegatorBalance {
     pub parent_table_handle: String,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
 #[diesel(table_name = delegator_balances)]
 pub struct DelegatorBalance {

--- a/rust/processor/src/models/stake_models/delegator_pools.rs
+++ b/rust/processor/src/models/stake_models/delegator_pools.rs
@@ -25,7 +25,7 @@ pub type DelegatorPoolMap = HashMap<StakingPoolAddress, DelegatorPool>;
 pub type DelegatorPoolBalanceMap = HashMap<StakingPoolAddress, CurrentDelegatorPoolBalance>;
 
 // All pools
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(staking_pool_address))]
 #[diesel(table_name = delegated_staking_pools)]
 pub struct DelegatorPool {
@@ -58,7 +58,7 @@ pub struct PoolBalanceMetadata {
 }
 
 // Pools balances
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, staking_pool_address))]
 #[diesel(table_name = delegated_staking_pool_balances)]
 pub struct DelegatorPoolBalance {
@@ -72,7 +72,7 @@ pub struct DelegatorPoolBalance {
 }
 
 // All pools w latest balances (really a more comprehensive version than DelegatorPool)
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(staking_pool_address))]
 #[diesel(table_name = current_delegated_staking_pool_balances)]
 pub struct CurrentDelegatorPoolBalance {

--- a/rust/processor/src/models/stake_models/proposal_votes.rs
+++ b/rust/processor/src/models/stake_models/proposal_votes.rs
@@ -14,7 +14,7 @@ use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, proposal_id, voter_address))]
 #[diesel(table_name = proposal_votes)]
 pub struct ProposalVote {

--- a/rust/processor/src/models/stake_models/staking_pool_voter.rs
+++ b/rust/processor/src/models/stake_models/staking_pool_voter.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 type StakingPoolAddress = String;
 pub type StakingPoolVoterMap = HashMap<StakingPoolAddress, CurrentStakingPoolVoter>;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(staking_pool_address))]
 #[diesel(table_name = current_staking_pool_voter)]
 pub struct CurrentStakingPoolVoter {

--- a/rust/processor/src/models/token_models/collection_datas.rs
+++ b/rust/processor/src/models/token_models/collection_datas.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 
 pub const QUERY_RETRIES: u32 = 5;
 pub const QUERY_RETRY_DELAY_MS: u64 = 500;
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(collection_data_id_hash, transaction_version))]
 #[diesel(table_name = collection_datas)]
 pub struct CollectionData {
@@ -41,7 +41,7 @@ pub struct CollectionData {
     pub transaction_timestamp: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(collection_data_id_hash))]
 #[diesel(table_name = current_collection_datas)]
 pub struct CurrentCollectionData {

--- a/rust/processor/src/models/token_models/nft_points.rs
+++ b/rust/processor/src/models/token_models/nft_points.rs
@@ -18,7 +18,7 @@ use diesel::prelude::*;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version))]
 #[diesel(table_name = nft_points)]
 pub struct NftPoints {

--- a/rust/processor/src/models/token_models/token_activities.rs
+++ b/rust/processor/src/models/token_models/token_activities.rs
@@ -15,7 +15,7 @@ use bigdecimal::{BigDecimal, Zero};
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(
     transaction_version,
     event_account_address,

--- a/rust/processor/src/models/token_models/token_claims.rs
+++ b/rust/processor/src/models/token_models/token_claims.rs
@@ -12,7 +12,7 @@ use bigdecimal::{BigDecimal, Zero};
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(token_data_id_hash, property_version, from_address, to_address))]
 #[diesel(table_name = current_token_pending_claims)]
 pub struct CurrentTokenPendingClaim {

--- a/rust/processor/src/models/token_models/token_datas.rs
+++ b/rust/processor/src/models/token_models/token_datas.rs
@@ -12,7 +12,7 @@ use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(token_data_id_hash, transaction_version))]
 #[diesel(table_name = token_datas)]
 pub struct TokenData {
@@ -39,7 +39,7 @@ pub struct TokenData {
     pub description: String,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(token_data_id_hash))]
 #[diesel(table_name = current_token_datas)]
 pub struct CurrentTokenData {

--- a/rust/processor/src/models/token_models/token_ownerships.rs
+++ b/rust/processor/src/models/token_models/token_ownerships.rs
@@ -17,7 +17,7 @@ use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(
     token_data_id_hash,
     property_version,
@@ -40,7 +40,7 @@ pub struct TokenOwnership {
     pub transaction_timestamp: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(token_data_id_hash, property_version, owner_address))]
 #[diesel(table_name = current_token_ownerships)]
 pub struct CurrentTokenOwnership {

--- a/rust/processor/src/models/token_models/tokens.rs
+++ b/rust/processor/src/models/token_models/tokens.rs
@@ -41,7 +41,7 @@ pub type CurrentTokenPendingClaimPK = (TokenDataIdHash, BigDecimal, Address, Add
 // PK of tokens table, used to dedupe tokens
 pub type TokenPK = (TokenDataIdHash, BigDecimal);
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(token_data_id_hash, property_version, transaction_version))]
 #[diesel(table_name = tokens)]
 pub struct Token {

--- a/rust/processor/src/models/token_v2_models/v2_collections.rs
+++ b/rust/processor/src/models/token_v2_models/v2_collections.rs
@@ -29,8 +29,7 @@ use serde::{Deserialize, Serialize};
 
 // PK of current_collections_v2, i.e. collection_id
 pub type CurrentCollectionV2PK = String;
-
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
 #[diesel(table_name = collections_v2)]
 pub struct CollectionV2 {
@@ -51,7 +50,7 @@ pub struct CollectionV2 {
     pub transaction_timestamp: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(collection_id))]
 #[diesel(table_name = current_collections_v2)]
 pub struct CurrentCollectionV2 {

--- a/rust/processor/src/models/token_v2_models/v2_token_activities.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_activities.rs
@@ -23,7 +23,7 @@ use bigdecimal::{BigDecimal, One, Zero};
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, event_index))]
 #[diesel(table_name = token_activities_v2)]
 pub struct TokenActivityV2 {

--- a/rust/processor/src/models/token_v2_models/v2_token_datas.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_datas.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 // PK of current_token_datas_v2, i.e. token_data_id
 pub type CurrentTokenDataV2PK = String;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
 #[diesel(table_name = token_datas_v2)]
 pub struct TokenDataV2 {
@@ -50,7 +50,7 @@ pub struct TokenDataV2 {
     pub decimals: i64,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(token_data_id))]
 #[diesel(table_name = current_token_datas_v2)]
 pub struct CurrentTokenDataV2 {

--- a/rust/processor/src/models/token_v2_models/v2_token_datas.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_datas.rs
@@ -106,7 +106,7 @@ impl TokenDataV2 {
                 }
                 token_properties = metadata
                     .property_map
-                    .as_ref()
+                    .clone()
                     .map(|m| m.inner.clone())
                     .unwrap_or(token_properties);
             } else {

--- a/rust/processor/src/models/token_v2_models/v2_token_metadata.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_metadata.rs
@@ -25,7 +25,7 @@ use serde_json::Value;
 // PK of current_objects, i.e. object_address, resource_type
 pub type CurrentTokenV2MetadataPK = (String, String);
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(object_address, resource_type))]
 #[diesel(table_name = current_token_v2_metadata)]
 pub struct CurrentTokenV2Metadata {

--- a/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
@@ -40,7 +40,7 @@ use std::collections::HashMap;
 // PK of current_token_ownerships_v2, i.e. token_data_id, property_version_v1, owner_address, storage_id
 pub type CurrentTokenOwnershipV2PK = (String, BigDecimal, String, String);
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
 #[diesel(table_name = token_ownerships_v2)]
 pub struct TokenOwnershipV2 {
@@ -60,7 +60,7 @@ pub struct TokenOwnershipV2 {
     pub non_transferrable_by_owner: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone)]
 #[diesel(primary_key(token_data_id, property_version_v1, owner_address, storage_id))]
 #[diesel(table_name = current_token_ownerships_v2)]
 pub struct CurrentTokenOwnershipV2 {
@@ -88,7 +88,7 @@ pub struct NFTOwnershipV2 {
 }
 
 /// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
-#[derive(Debug, Identifiable, Queryable)]
+#[derive(Debug, Identifiable, Queryable, Clone)]
 #[diesel(primary_key(token_data_id, property_version_v1, owner_address, storage_id))]
 #[diesel(table_name = current_token_ownerships_v2)]
 pub struct CurrentTokenOwnershipV2Query {

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -28,17 +28,18 @@ use crate::{
     },
     schema,
     utils::{
-        database::{
-            clean_data_for_db, execute_with_better_error, get_chunks, MyDbConnection, PgDbPool,
-            PgPoolConnection,
-        },
+        database::{execute_in_chunks, PgDbPool, PgPoolConnection},
         util::{get_entry_function_from_user_request, parse_timestamp, standardize_address},
     },
 };
 use anyhow::bail;
 use aptos_protos::transaction::v1::{transaction::TxnData, write_set_change::Change, Transaction};
 use async_trait::async_trait;
-use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods};
+use diesel::{
+    pg::{upsert::excluded, Pg},
+    query_builder::QueryFragment,
+    ExpressionMethods,
+};
 use field_count::FieldCount;
 use std::{
     collections::{HashMap, HashSet},
@@ -88,485 +89,252 @@ async fn insert_to_db(
         "Inserting to db",
     );
 
-    insert_collections_v2(conn, collections_v2).await?;
-    insert_token_datas_v2(conn, token_datas_v2).await?;
-    insert_token_ownerships_v2(conn, token_ownerships_v2).await?;
-    insert_current_collections_v2(conn, current_collections_v2).await?;
-    insert_current_token_datas_v2(conn, current_token_datas_v2).await?;
-    insert_current_token_ownerships_v2(conn, current_token_ownerships_v2).await?;
-    insert_token_activities_v2(conn, token_activities_v2).await?;
-    insert_current_token_v2_metadatas(conn, current_token_v2_metadata).await?;
+    execute_in_chunks(
+        conn,
+        insert_collections_v2_query,
+        collections_v2,
+        CollectionV2::field_count(),
+    )
+    .await?;
+    execute_in_chunks(
+        conn,
+        insert_token_datas_v2_query,
+        token_datas_v2,
+        TokenDataV2::field_count(),
+    )
+    .await?;
+    execute_in_chunks(
+        conn,
+        insert_token_ownerships_v2_query,
+        token_ownerships_v2,
+        TokenOwnershipV2::field_count(),
+    )
+    .await?;
+    execute_in_chunks(
+        conn,
+        insert_current_collections_v2_query,
+        current_collections_v2,
+        CurrentCollectionV2::field_count(),
+    )
+    .await?;
+    execute_in_chunks(
+        conn,
+        insert_current_token_datas_v2_query,
+        current_token_datas_v2,
+        CurrentTokenDataV2::field_count(),
+    )
+    .await?;
+    execute_in_chunks(
+        conn,
+        insert_current_token_ownerships_v2_query,
+        current_token_ownerships_v2,
+        CurrentTokenOwnershipV2::field_count(),
+    )
+    .await?;
+    execute_in_chunks(
+        conn,
+        insert_token_activities_v2_query,
+        token_activities_v2,
+        TokenActivityV2::field_count(),
+    )
+    .await?;
+    execute_in_chunks(
+        conn,
+        insert_current_token_v2_metadatas_query,
+        current_token_v2_metadata,
+        CurrentTokenV2Metadata::field_count(),
+    )
+    .await?;
     Ok(())
 }
 
-async fn insert_collections_v2(
-    conn: &mut PgPoolConnection<'_>,
+fn insert_collections_v2_query(
     items_to_insert: Vec<CollectionV2>,
-) -> Result<(), diesel::result::Error> {
-    match conn
-        .build_transaction()
-        .read_write()
-        .run::<_, Error, _>(|pg_conn| {
-            Box::pin(insert_collections_v2_impl(pg_conn, &items_to_insert))
-        })
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(_) => {
-            conn.build_transaction()
-                .read_write()
-                .run::<_, Error, _>(|pg_conn| {
-                    Box::pin(async {
-                        let collections_v2 = clean_data_for_db(items_to_insert, true);
-
-                        insert_collections_v2_impl(pg_conn, &collections_v2).await
-                    })
-                })
-                .await
-        },
-    }
-}
-
-async fn insert_collections_v2_impl(
-    conn: &mut MyDbConnection,
-    items_to_insert: &[CollectionV2],
-) -> Result<(), diesel::result::Error> {
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
     use schema::collections_v2::dsl::*;
-
-    let chunks = get_chunks(items_to_insert.len(), CollectionV2::field_count());
-
-    for (start_ind, end_ind) in chunks {
-        execute_with_better_error(
-            conn,
-            diesel::insert_into(schema::collections_v2::table)
-                .values(&items_to_insert[start_ind..end_ind])
-                .on_conflict((transaction_version, write_set_change_index))
-                .do_nothing(),
-            None,
-        )
-        .await?;
-    }
-    Ok(())
+    (
+        diesel::insert_into(schema::collections_v2::table)
+            .values(items_to_insert)
+            .on_conflict((transaction_version, write_set_change_index))
+            .do_nothing(),
+        None,
+    )
 }
 
-async fn insert_token_datas_v2(
-    conn: &mut MyDbConnection,
+fn insert_token_datas_v2_query(
     items_to_insert: Vec<TokenDataV2>,
-) -> Result<(), diesel::result::Error> {
-    match conn
-        .build_transaction()
-        .read_write()
-        .run::<_, Error, _>(|pg_conn| {
-            Box::pin(insert_token_datas_v2_impl(pg_conn, &items_to_insert))
-        })
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(_) => {
-            conn.build_transaction()
-                .read_write()
-                .run::<_, Error, _>(|pg_conn| {
-                    Box::pin(async {
-                        let token_datas_v2 = clean_data_for_db(items_to_insert, true);
-
-                        insert_token_datas_v2_impl(pg_conn, &token_datas_v2).await
-                    })
-                })
-                .await
-        },
-    }
-}
-
-async fn insert_token_datas_v2_impl(
-    conn: &mut MyDbConnection,
-    items_to_insert: &[TokenDataV2],
-) -> Result<(), diesel::result::Error> {
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
     use schema::token_datas_v2::dsl::*;
 
-    let chunks = get_chunks(items_to_insert.len(), TokenDataV2::field_count());
-
-    for (start_ind, end_ind) in chunks {
-        execute_with_better_error(
-            conn,
-            diesel::insert_into(schema::token_datas_v2::table)
-                .values(&items_to_insert[start_ind..end_ind])
-                .on_conflict((transaction_version, write_set_change_index))
-                .do_nothing(),
-            None,
-        )
-        .await?;
-    }
-    Ok(())
+    (
+        diesel::insert_into(schema::token_datas_v2::table)
+            .values(items_to_insert)
+            .on_conflict((transaction_version, write_set_change_index))
+            .do_nothing(),
+        None,
+    )
 }
 
-async fn insert_token_ownerships_v2(
-    conn: &mut PgPoolConnection<'_>,
+fn insert_token_ownerships_v2_query(
     items_to_insert: Vec<TokenOwnershipV2>,
-) -> Result<(), diesel::result::Error> {
-    match conn
-        .build_transaction()
-        .read_write()
-        .run::<_, Error, _>(|pg_conn| {
-            Box::pin(insert_token_ownerships_v2_impl(pg_conn, &items_to_insert))
-        })
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(_) => {
-            conn.build_transaction()
-                .read_write()
-                .run::<_, Error, _>(|pg_conn| {
-                    Box::pin(async {
-                        let token_ownerships_v2 = clean_data_for_db(items_to_insert, true);
-
-                        insert_token_ownerships_v2_impl(pg_conn, &token_ownerships_v2).await
-                    })
-                })
-                .await
-        },
-    }
-}
-
-async fn insert_token_ownerships_v2_impl(
-    conn: &mut MyDbConnection,
-    items_to_insert: &[TokenOwnershipV2],
-) -> Result<(), diesel::result::Error> {
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
     use schema::token_ownerships_v2::dsl::*;
 
-    let chunks = get_chunks(items_to_insert.len(), TokenOwnershipV2::field_count());
-
-    for (start_ind, end_ind) in chunks {
-        execute_with_better_error(
-            conn,
-            diesel::insert_into(schema::token_ownerships_v2::table)
-                .values(&items_to_insert[start_ind..end_ind])
-                .on_conflict((transaction_version, write_set_change_index))
-                .do_nothing(),
-            None,
-        )
-        .await?;
-    }
-    Ok(())
+    (
+        diesel::insert_into(schema::token_ownerships_v2::table)
+            .values(items_to_insert)
+            .on_conflict((transaction_version, write_set_change_index))
+            .do_nothing(),
+        None,
+    )
 }
 
-async fn insert_current_collections_v2(
-    conn: &mut PgPoolConnection<'_>,
+fn insert_current_collections_v2_query(
     items_to_insert: Vec<CurrentCollectionV2>,
-) -> Result<(), diesel::result::Error> {
-    match conn
-        .build_transaction()
-        .read_write()
-        .run::<_, Error, _>(|pg_conn| {
-            Box::pin(insert_current_collections_v2_impl(
-                pg_conn,
-                &items_to_insert,
-            ))
-        })
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(_) => {
-            conn.build_transaction()
-                .read_write()
-                .run::<_, Error, _>(|pg_conn| {
-                    Box::pin(async {
-                        let current_collections_v2 = clean_data_for_db(items_to_insert, true);
-
-                        insert_current_collections_v2_impl(pg_conn, &current_collections_v2).await
-                    })
-                })
-                .await
-        },
-    }
-}
-
-async fn insert_current_collections_v2_impl(
-    conn: &mut MyDbConnection,
-    items_to_insert: &[CurrentCollectionV2],
-) -> Result<(), diesel::result::Error> {
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
     use schema::current_collections_v2::dsl::*;
 
-    let chunks = get_chunks(items_to_insert.len(), CurrentCollectionV2::field_count());
-
-    for (start_ind, end_ind) in chunks {
-        execute_with_better_error(
-            conn,
-            diesel::insert_into(schema::current_collections_v2::table)
-                .values(&items_to_insert[start_ind..end_ind])
-                .on_conflict(collection_id)
-                .do_update()
-                .set((
-                    creator_address.eq(excluded(creator_address)),
-                    collection_name.eq(excluded(collection_name)),
-                    description.eq(excluded(description)),
-                    uri.eq(excluded(uri)),
-                    current_supply.eq(excluded(current_supply)),
-                    max_supply.eq(excluded(max_supply)),
-                    total_minted_v2.eq(excluded(total_minted_v2)),
-                    mutable_description.eq(excluded(mutable_description)),
-                    mutable_uri.eq(excluded(mutable_uri)),
-                    table_handle_v1.eq(excluded(table_handle_v1)),
-                    token_standard.eq(excluded(token_standard)),
-                    last_transaction_version.eq(excluded(last_transaction_version)),
-                    last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
-                    inserted_at.eq(excluded(inserted_at)),
-                )),
-            Some(" WHERE current_collections_v2.last_transaction_version <= excluded.last_transaction_version "),
-        ).await?;
-    }
-    Ok(())
+    (
+        diesel::insert_into(schema::current_collections_v2::table)
+        .values(items_to_insert)
+        .on_conflict(collection_id)
+        .do_update()
+        .set((
+            creator_address.eq(excluded(creator_address)),
+            collection_name.eq(excluded(collection_name)),
+            description.eq(excluded(description)),
+            uri.eq(excluded(uri)),
+            current_supply.eq(excluded(current_supply)),
+            max_supply.eq(excluded(max_supply)),
+            total_minted_v2.eq(excluded(total_minted_v2)),
+            mutable_description.eq(excluded(mutable_description)),
+            mutable_uri.eq(excluded(mutable_uri)),
+            table_handle_v1.eq(excluded(table_handle_v1)),
+            token_standard.eq(excluded(token_standard)),
+            last_transaction_version.eq(excluded(last_transaction_version)),
+            last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
+            inserted_at.eq(excluded(inserted_at)),
+        )),
+        Some(" WHERE current_collections_v2.last_transaction_version <= excluded.last_transaction_version "),
+    )
 }
 
-async fn insert_current_token_datas_v2(
-    conn: &mut PgPoolConnection<'_>,
+fn insert_current_token_datas_v2_query(
     items_to_insert: Vec<CurrentTokenDataV2>,
-) -> Result<(), diesel::result::Error> {
-    match conn
-        .build_transaction()
-        .read_write()
-        .run::<_, Error, _>(|pg_conn| {
-            Box::pin(insert_current_token_datas_v2_impl(
-                pg_conn,
-                &items_to_insert,
-            ))
-        })
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(_) => {
-            conn.build_transaction()
-                .read_write()
-                .run::<_, Error, _>(|pg_conn| {
-                    Box::pin(async {
-                        let current_token_datas_v2 = clean_data_for_db(items_to_insert, true);
-
-                        insert_current_token_datas_v2_impl(pg_conn, &current_token_datas_v2).await
-                    })
-                })
-                .await
-        },
-    }
-}
-
-async fn insert_current_token_datas_v2_impl(
-    conn: &mut MyDbConnection,
-    items_to_insert: &[CurrentTokenDataV2],
-) -> Result<(), diesel::result::Error> {
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
     use schema::current_token_datas_v2::dsl::*;
 
-    let chunks = get_chunks(items_to_insert.len(), CurrentTokenDataV2::field_count());
-
-    for (start_ind, end_ind) in chunks {
-        execute_with_better_error(
-            conn,
-            diesel::insert_into(schema::current_token_datas_v2::table)
-                .values(&items_to_insert[start_ind..end_ind])
-                .on_conflict(token_data_id)
-                .do_update()
-                .set((
-                    collection_id.eq(excluded(collection_id)),
-                    token_name.eq(excluded(token_name)),
-                    maximum.eq(excluded(maximum)),
-                    supply.eq(excluded(supply)),
-                    largest_property_version_v1.eq(excluded(largest_property_version_v1)),
-                    token_uri.eq(excluded(token_uri)),
-                    description.eq(excluded(description)),
-                    token_properties.eq(excluded(token_properties)),
-                    token_standard.eq(excluded(token_standard)),
-                    is_fungible_v2.eq(excluded(is_fungible_v2)),
-                    last_transaction_version.eq(excluded(last_transaction_version)),
-                    last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
-                    inserted_at.eq(excluded(inserted_at)),
-                    decimals.eq(excluded(decimals)),
-                )),
-            Some(" WHERE current_token_datas_v2.last_transaction_version <= excluded.last_transaction_version "),
-        ).await?;
-    }
-    Ok(())
+    (
+        diesel::insert_into(schema::current_token_datas_v2::table)
+        .values(items_to_insert)
+        .on_conflict(token_data_id)
+        .do_update()
+        .set((
+            collection_id.eq(excluded(collection_id)),
+            token_name.eq(excluded(token_name)),
+            maximum.eq(excluded(maximum)),
+            supply.eq(excluded(supply)),
+            largest_property_version_v1.eq(excluded(largest_property_version_v1)),
+            token_uri.eq(excluded(token_uri)),
+            description.eq(excluded(description)),
+            token_properties.eq(excluded(token_properties)),
+            token_standard.eq(excluded(token_standard)),
+            is_fungible_v2.eq(excluded(is_fungible_v2)),
+            last_transaction_version.eq(excluded(last_transaction_version)),
+            last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
+            inserted_at.eq(excluded(inserted_at)),
+            decimals.eq(excluded(decimals)),
+        )),
+        Some(" WHERE current_token_datas_v2.last_transaction_version <= excluded.last_transaction_version "),
+    )
 }
 
-async fn insert_current_token_ownerships_v2(
-    conn: &mut PgPoolConnection<'_>,
+fn insert_current_token_ownerships_v2_query(
     items_to_insert: Vec<CurrentTokenOwnershipV2>,
-) -> Result<(), diesel::result::Error> {
-    match conn
-        .build_transaction()
-        .read_write()
-        .run::<_, Error, _>(|pg_conn| {
-            Box::pin(insert_current_token_ownerships_v2_impl(
-                pg_conn,
-                &items_to_insert,
-            ))
-        })
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(_) => {
-            conn.build_transaction()
-                .read_write()
-                .run::<_, Error, _>(|pg_conn| {
-                    Box::pin(async {
-                        let current_token_ownerships_v2 = clean_data_for_db(items_to_insert, true);
-
-                        insert_current_token_ownerships_v2_impl(
-                            pg_conn,
-                            &current_token_ownerships_v2,
-                        )
-                        .await
-                    })
-                })
-                .await
-        },
-    }
-}
-
-async fn insert_current_token_ownerships_v2_impl(
-    conn: &mut MyDbConnection,
-    items_to_insert: &[CurrentTokenOwnershipV2],
-) -> Result<(), diesel::result::Error> {
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
     use schema::current_token_ownerships_v2::dsl::*;
 
-    let chunks = get_chunks(
-        items_to_insert.len(),
-        CurrentTokenOwnershipV2::field_count(),
-    );
-
-    for (start_ind, end_ind) in chunks {
-        execute_with_better_error(
-            conn,
-            diesel::insert_into(schema::current_token_ownerships_v2::table)
-                .values(&items_to_insert[start_ind..end_ind])
-                .on_conflict((token_data_id, property_version_v1, owner_address, storage_id))
-                .do_update()
-                .set((
-                    amount.eq(excluded(amount)),
-                    table_type_v1.eq(excluded(table_type_v1)),
-                    token_properties_mutated_v1.eq(excluded(token_properties_mutated_v1)),
-                    is_soulbound_v2.eq(excluded(is_soulbound_v2)),
-                    token_standard.eq(excluded(token_standard)),
-                    is_fungible_v2.eq(excluded(is_fungible_v2)),
-                    last_transaction_version.eq(excluded(last_transaction_version)),
-                    last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
-                    inserted_at.eq(excluded(inserted_at)),
-                    non_transferrable_by_owner.eq(excluded(non_transferrable_by_owner)),
-                )),
-            Some(" WHERE current_token_ownerships_v2.last_transaction_version <= excluded.last_transaction_version "),
-        ).await?;
-    }
-    Ok(())
+    (
+        diesel::insert_into(schema::current_token_ownerships_v2::table)
+        .values(items_to_insert)
+        .on_conflict((token_data_id, property_version_v1, owner_address, storage_id))
+        .do_update()
+        .set((
+            amount.eq(excluded(amount)),
+            table_type_v1.eq(excluded(table_type_v1)),
+            token_properties_mutated_v1.eq(excluded(token_properties_mutated_v1)),
+            is_soulbound_v2.eq(excluded(is_soulbound_v2)),
+            token_standard.eq(excluded(token_standard)),
+            is_fungible_v2.eq(excluded(is_fungible_v2)),
+            last_transaction_version.eq(excluded(last_transaction_version)),
+            last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
+            inserted_at.eq(excluded(inserted_at)),
+            non_transferrable_by_owner.eq(excluded(non_transferrable_by_owner)),
+        )),
+        Some(" WHERE current_token_ownerships_v2.last_transaction_version <= excluded.last_transaction_version "),
+    )
 }
 
-async fn insert_token_activities_v2(
-    conn: &mut PgPoolConnection<'_>,
+fn insert_token_activities_v2_query(
     items_to_insert: Vec<TokenActivityV2>,
-) -> Result<(), diesel::result::Error> {
-    match conn
-        .build_transaction()
-        .read_write()
-        .run::<_, Error, _>(|pg_conn| {
-            Box::pin(insert_token_activities_v2_impl(pg_conn, &items_to_insert))
-        })
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(_) => {
-            conn.build_transaction()
-                .read_write()
-                .run::<_, Error, _>(|pg_conn| {
-                    Box::pin(async {
-                        let token_activities_v2 = clean_data_for_db(items_to_insert, true);
-
-                        insert_token_activities_v2_impl(pg_conn, &token_activities_v2).await
-                    })
-                })
-                .await
-        },
-    }
-}
-
-async fn insert_token_activities_v2_impl(
-    conn: &mut MyDbConnection,
-    items_to_insert: &[TokenActivityV2],
-) -> Result<(), diesel::result::Error> {
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
     use schema::token_activities_v2::dsl::*;
 
-    let chunks = get_chunks(items_to_insert.len(), TokenActivityV2::field_count());
-
-    for (start_ind, end_ind) in chunks {
-        execute_with_better_error(
-            conn,
-            diesel::insert_into(schema::token_activities_v2::table)
-                .values(&items_to_insert[start_ind..end_ind])
-                .on_conflict((transaction_version, event_index))
-                .do_update()
-                .set((
-                    entry_function_id_str.eq(excluded(entry_function_id_str)),
-                    inserted_at.eq(excluded(inserted_at)),
-                )),
-            None,
-        )
-        .await?;
-    }
-    Ok(())
+    (
+        diesel::insert_into(schema::token_activities_v2::table)
+            .values(items_to_insert)
+            .on_conflict((transaction_version, event_index))
+            .do_update()
+            .set((
+                entry_function_id_str.eq(excluded(entry_function_id_str)),
+                inserted_at.eq(excluded(inserted_at)),
+            )),
+        None,
+    )
 }
 
-async fn insert_current_token_v2_metadatas(
-    conn: &mut PgPoolConnection<'_>,
+fn insert_current_token_v2_metadatas_query(
     items_to_insert: Vec<CurrentTokenV2Metadata>,
-) -> Result<(), diesel::result::Error> {
-    match conn
-        .build_transaction()
-        .read_write()
-        .run::<_, Error, _>(|pg_conn| {
-            Box::pin(insert_current_token_v2_metadatas_impl(
-                pg_conn,
-                &items_to_insert,
-            ))
-        })
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(_) => {
-            conn.build_transaction()
-                .read_write()
-                .run::<_, Error, _>(|pg_conn| {
-                    Box::pin(async {
-                        let current_token_v2_metadatas = clean_data_for_db(items_to_insert, true);
-
-                        insert_current_token_v2_metadatas_impl(pg_conn, &current_token_v2_metadatas)
-                            .await
-                    })
-                })
-                .await
-        },
-    }
-}
-
-async fn insert_current_token_v2_metadatas_impl(
-    conn: &mut MyDbConnection,
-    items_to_insert: &[CurrentTokenV2Metadata],
-) -> Result<(), diesel::result::Error> {
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
     use schema::current_token_v2_metadata::dsl::*;
 
-    let chunks = get_chunks(items_to_insert.len(), CurrentTokenV2Metadata::field_count());
-
-    for (start_ind, end_ind) in chunks {
-        execute_with_better_error(
-            conn,
-            diesel::insert_into(schema::current_token_v2_metadata::table)
-                .values(&items_to_insert[start_ind..end_ind])
-                .on_conflict((object_address, resource_type))
-                .do_update()
-                .set((
-                    data.eq(excluded(data)),
-                    state_key_hash.eq(excluded(state_key_hash)),
-                    last_transaction_version.eq(excluded(last_transaction_version)),
-                    inserted_at.eq(excluded(inserted_at)),
-                )),
-            Some(" WHERE current_token_v2_metadata.last_transaction_version <= excluded.last_transaction_version "),
-        ).await?;
-    }
-    Ok(())
+    (
+        diesel::insert_into(schema::current_token_v2_metadata::table)
+            .values(items_to_insert)
+            .on_conflict((object_address, resource_type))
+            .do_update()
+            .set((
+                data.eq(excluded(data)),
+                state_key_hash.eq(excluded(state_key_hash)),
+                last_transaction_version.eq(excluded(last_transaction_version)),
+                inserted_at.eq(excluded(inserted_at)),
+            )),
+        Some(" WHERE current_token_v2_metadata.last_transaction_version <= excluded.last_transaction_version "),
+    )
 }
 
 #[async_trait]
@@ -605,15 +373,15 @@ impl ProcessorTrait for TokenV2Processor {
         let processing_duration_in_secs = processing_start.elapsed().as_secs_f64();
         let db_insertion_start = std::time::Instant::now();
 
-        let token_result = insert_to_db(
+        let tx_result = insert_to_db(
             &mut conn,
             self.name(),
             start_version,
             end_version,
-            vec![],
+            collections_v2,
             token_datas_v2,
             token_ownerships_v2,
-            vec![],
+            current_collections_v2,
             current_token_ownerships_v2,
             current_token_datas_v2,
             token_activities_v2,
@@ -621,35 +389,8 @@ impl ProcessorTrait for TokenV2Processor {
         )
         .await;
 
-        if let Err(e) = token_result {
-            error!(
-                start_version = start_version,
-                end_version = end_version,
-                processor_name = self.name(),
-                error = ?e,
-                "[Parser] Error inserting transactions to db",
-            );
-            bail!(e)
-        }
-
-        let collection_result = insert_to_db(
-            &mut conn,
-            self.name(),
-            start_version,
-            end_version,
-            collections_v2,
-            vec![],
-            vec![],
-            current_collections_v2,
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-        )
-        .await;
-
         let db_insertion_duration_in_secs = db_insertion_start.elapsed().as_secs_f64();
-        match collection_result {
+        match tx_result {
             Ok(_) => Ok(ProcessingResult {
                 start_version,
                 end_version,


### PR DESCRIPTION
## Test plan
Run token_v2 processor and verify data is accurate in DB
![Screenshot 2024-01-12 at 4 52 47 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/ac5ed41c-4eb8-4cd5-a715-71232b672506)
![Screenshot 2024-01-12 at 4 52 39 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/dbfcf5ee-a5de-4220-9c95-38ed7099a22b)
![Screenshot 2024-01-12 at 4 52 33 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/8af65bc2-446b-495c-908c-7ece3d854170)

Deploy de-batching fix to scratchnet and run token minting load test on testnet.

* De-batching fix removed all the lock wait time in the db insertions. there's still some IO wait time but that also already exists in testnet.

| Scratchnet | Testnet |
| ---- | ---- |
| ![Screenshot 2024-01-18 at 11 18 59 AM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/0b5d4664-d3eb-44c7-8095-9f1ea97fd5ed) | ![Screenshot 2024-01-18 at 11 18 53 AM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/17603699-d2d4-46d4-9098-ede3c60489b3) |

The  perf improvement is more prominent on the processors that touch current_ tables, like default, object, and token v2.
* for default and object, scratchnet fell behind fullnode by max 8s, whereas testnet fell behind by almost 3 mins ([grafana](https://aptoslabs.grafana.net/d/cf659b9f-d337-4044-8604-e13596313a3f/indexer-processors-debug-testing?orgId=1&var-chain_name=scratchnet&var-upstream_chain_name=testnet&var-processor_name=default_processor&var-processor_name=objects_processor&var-internal_processors=account_transactions_processor%7Ccoin_processor%7Cdefault_processor%7Cevents_processor%7Cfungible_asset_processor%7Cstake_processor%7Ctoken_processor%7Ctoken_v2_processor%7Cuser_transaction_processor%7Cobjects_processor&from=1705593572069&to=1705594204922))
* for token v2,  scratchnet fell behidn by max 20s, whereas testnet is still falling behind and gap is still increasing ([grafana](https://aptoslabs.grafana.net/d/cf659b9f-d337-4044-8604-e13596313a3f/indexer-processors-debug-testing?orgId=1&var-chain_name=scratchnet&var-upstream_chain_name=testnet&var-processor_name=token_v2_processor&var-internal_processors=account_transactions_processor%7Ccoin_processor%7Cdefault_processor%7Cevents_processor%7Cfungible_asset_processor%7Cstake_processor%7Ctoken_processor%7Ctoken_v2_processor%7Cuser_transaction_processor%7Cobjects_processor&from=1705593572069&to=1705594204922))