### PR TITLE
add the monitoring piece to the monitoring.

### DIFF
--- a/rust/indexer-metrics/src/main.rs
+++ b/rust/indexer-metrics/src/main.rs
@@ -149,19 +149,19 @@ async fn start_processor_status_fetch(url: String, chain_name: String) {
                             .set(processor.last_success_version as i64);
                         HASURA_API_LATEST_VERSION_TIMESTAMP
                             .with_label_values(&[&processor.processor, &chain_name])
-                            .set(processor.last_updated.timestamp_micros() as f64 / 1e-6);
+                            .set(processor.last_updated.timestamp_micros() as f64 * 1e-6);
                         HASURA_API_LATEST_TRANSACTION_TIMESTAMP
                             .with_label_values(&[&processor.processor, &chain_name])
                             .set(
                                 processor.last_transaction_timestamp.timestamp_micros() as f64
-                                    / 1e-6,
+                                    * 1e-6,
                             );
                         HASURA_API_LATEST_TRANSACTION_LATENCY_IN_SECS
                             .with_label_values(&[&processor.processor, &chain_name])
                             .set(
                                 (processor.last_updated - processor.last_transaction_timestamp)
                                     .num_milliseconds() as f64
-                                    / 1e-3,
+                                    * 1e-3,
                             );
                     }
                 },

--- a/rust/indexer-metrics/src/main.rs
+++ b/rust/indexer-metrics/src/main.rs
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use chrono::NaiveDateTime;
 use clap::Parser;
 use indexer_metrics::{
-    metrics::{PFN_LEDGER_TIMESTAMP, PFN_LEDGER_VERSION, TASK_FAILURE_COUNT},
+    metrics::{
+        HASURA_API_LATEST_TRANSACTION_LATENCY_IN_SECS, HASURA_API_LATEST_TRANSACTION_TIMESTAMP,
+        HASURA_API_LATEST_VERSION, HASURA_API_LATEST_VERSION_TIMESTAMP, PFN_LEDGER_TIMESTAMP,
+        PFN_LEDGER_VERSION, TASK_FAILURE_COUNT,
+    },
     util::{deserialize_from_string, fetch_url_with_timeout},
 };
 use serde::{Deserialize, Serialize};
@@ -23,6 +28,21 @@ struct FullnodeResponse {
     ledger_timestamp: u64,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct ProcessorStatus {
+    processor: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    last_updated: NaiveDateTime,
+    last_success_version: u64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    last_transaction_timestamp: NaiveDateTime,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ProcessorsResponse {
+    processor_status: Vec<ProcessorStatus>,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PostProcessorConfig {
@@ -35,11 +55,16 @@ pub struct PostProcessorConfig {
 impl RunnableConfig for PostProcessorConfig {
     async fn run(&self) -> Result<()> {
         let mut tasks = vec![];
-        let _hasura_rest_api_endpoint = self.hasura_rest_api_endpoint.clone();
+        let hasura_rest_api_endpoint = self.hasura_rest_api_endpoint.clone();
         let fullnode_rest_api_endpoint = self.fullnode_rest_api_endpoint.clone();
         let chain_name = self.chain_name.clone();
 
-        // if let Some(hasura) = hasura_rest_api_endpoint {}
+        if let Some(hasura) = hasura_rest_api_endpoint {
+            tasks.push(tokio::spawn(start_processor_status_fetch(
+                hasura,
+                chain_name.clone(),
+            )));
+        }
         if let Some(fullnode) = fullnode_rest_api_endpoint {
             tasks.push(tokio::spawn(start_fn_fetch(fullnode, chain_name)));
         }
@@ -99,6 +124,64 @@ async fn start_fn_fetch(url: String, chain_name: String) {
                     .inc();
             },
         }
+        let elapsed = time_now.elapsed().as_millis() as u64;
+        // Sleep for a max of 500ms between queries
+        if elapsed < MIN_TIME_QUERIES_MS {
+            tokio::time::sleep(Duration::from_millis(MIN_TIME_QUERIES_MS - elapsed)).await;
+        }
+    }
+}
+
+async fn start_processor_status_fetch(url: String, chain_name: String) {
+    loop {
+        let result = fetch_url_with_timeout(&url, QUERY_TIMEOUT_MS).await;
+        let time_now = tokio::time::Instant::now();
+
+        // Handle the result
+        match result {
+            Ok(Ok(response)) => match response.json::<ProcessorsResponse>().await {
+                Ok(resp) => {
+                    tracing::info!(url = &url, response = ?resp, "Request succeeded");
+                    // Process the data as needed
+                    for processor in resp.processor_status {
+                        HASURA_API_LATEST_VERSION
+                            .with_label_values(&[&processor.processor, &chain_name])
+                            .set(processor.last_success_version as i64);
+                        HASURA_API_LATEST_VERSION_TIMESTAMP
+                            .with_label_values(&[&processor.processor, &chain_name])
+                            .set(processor.last_updated.timestamp_micros() as f64 / 1e-6);
+                        HASURA_API_LATEST_TRANSACTION_TIMESTAMP
+                            .with_label_values(&[&processor.processor, &chain_name])
+                            .set(
+                                processor.last_transaction_timestamp.timestamp_micros() as f64
+                                    / 1e-6,
+                            );
+                        HASURA_API_LATEST_TRANSACTION_LATENCY_IN_SECS
+                            .with_label_values(&[&processor.processor, &chain_name])
+                            .set(
+                                (processor.last_updated - processor.last_transaction_timestamp)
+                                    .num_milliseconds() as f64
+                                    / 1e-3,
+                            );
+                    }
+                },
+                Err(err) => {
+                    tracing::error!(url = &url, error = ?err, "Parsing error");
+                    // Increment failure count or other error handling
+                },
+            },
+            Ok(Err(err)) => {
+                // Request encountered an error within the timeout
+                tracing::error!(url = &url, error = ?err, "Request error");
+                // Increment failure count or other error handling
+            },
+            Err(_) => {
+                // Request timed out
+                tracing::error!(url = &url, "Request timed out");
+                // Increment failure count or other error handling
+            },
+        }
+
         let elapsed = time_now.elapsed().as_millis() as u64;
         // Sleep for a max of 500ms between queries
         if elapsed < MIN_TIME_QUERIES_MS {

--- a/rust/indexer-metrics/src/metrics.rs
+++ b/rust/indexer-metrics/src/metrics.rs
@@ -35,6 +35,24 @@ pub static HASURA_API_LATEST_VERSION_TIMESTAMP: Lazy<GaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static HASURA_API_LATEST_TRANSACTION_TIMESTAMP: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        "indexer_metrics_hasura_latest_transaction_timestamp_secs",
+        "Latest transaction timestamp (unix timestamp), i.e., block timestamp.",
+        &["processor_name", "chain_name"],
+    )
+    .unwrap()
+});
+
+pub static HASURA_API_LATEST_TRANSACTION_LATENCY_IN_SECS: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        "indexer_metrics_hasura_latest_transaction_latency_secs",
+        "Latest transaction e2e latency, from block timestamp to insertion time of db.",
+        &["processor_name", "chain_name"],
+    )
+    .unwrap()
+});
+
 pub static PFN_LEDGER_VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "indexer_metrics_pfn_ledger_version",


### PR DESCRIPTION
* Adds e2e latency monitoring for processors. 

## Test Plan

* locally tested, looks good.

* Example response

```json
{
  "processor_status": [
    {
      "processor": "objects_processor",
      "last_updated": "2024-01-16T21:59:54.425376",
      "last_transaction_timestamp": "2024-01-16T21:59:54.425376",
      "last_success_version": 853440763
    },
    {
      "processor": "token_v2_processor",
      "last_updated": "2024-01-16T21:59:54.407772",
      "last_transaction_timestamp": "2024-01-16T21:59:54.407772",
      "last_success_version": 853440763
    },
    {
      "processor": "account_transactions_processor",
      "last_updated": "2024-01-16T21:59:54.392648",
      "last_transaction_timestamp": "2024-01-16T21:59:54.392648",
      "last_success_version": 853440763
    },
    {
      "processor": "fungible_asset_processor",
      "last_updated": "2024-01-16T21:59:54.40526",
      "last_transaction_timestamp": "2024-01-16T21:59:54.40526",
      "last_success_version": 853440763
    },
    {
      "processor": "ans_processor",
      "last_updated": "2024-01-16T21:59:54.422825",
      "last_transaction_timestamp": "2024-01-16T21:59:54.422825",
      "last_success_version": 853440763
    },
    {
      "processor": "token_processor",
      "last_updated": "2024-01-16T21:59:54.438418",
      "last_transaction_timestamp": "2024-01-16T21:59:54.438418",
      "last_success_version": 853440763
    },
    {
      "processor": "user_transaction_processor",
      "last_updated": "2024-01-16T21:59:54.386354",
      "last_transaction_timestamp": "2024-01-16T21:59:54.386354",
      "last_success_version": 853440763
    },
    {
      "processor": "events_processor",
      "last_updated": "2024-01-16T21:59:54.419373",
      "last_transaction_timestamp": "2024-01-16T21:59:54.419373",
      "last_success_version": 853440763
    },
    {
      "processor": "default_processor",
      "last_updated": "2024-01-16T21:59:54.40956",
      "last_transaction_timestamp": "2024-01-16T21:59:54.40956",
      "last_success_version": 853440763
    },
    {
      "processor": "nft_metadata_processor",
      "last_updated": "2024-01-16T21:59:54.556318",
      "last_transaction_timestamp": "2024-01-16T21:59:54.556318",
      "last_success_version": 853440763
    },
    {
      "processor": "stake_processor",
      "last_updated": "2024-01-16T21:59:54.42362",
      "last_transaction_timestamp": "2024-01-16T21:59:54.42362",
      "last_success_version": 853440763
    },
    {
      "processor": "coin_processor",
      "last_updated": "2024-01-16T21:59:54.425671",
      "last_transaction_timestamp": "2024-01-16T21:59:54.425671",
      "last_success_version": 853440763
    }
  ]
}
```

* Testing Result

![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/112209412/f79e8692-853b-4cd8-9571-ace02122651e)

* Metrics result

![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/112209412/4dfcf6ab-a7e5-48ff-8ca2-22be09bbaea6)

