### PR TITLE
add block timestmap into the processor status rest api endpoint.

### DIFF
--- a/hasura-api/metadata-json/unified.json
+++ b/hasura-api/metadata-json/unified.json
@@ -1,5 +1,5 @@
 {
-  "resource_version": 357,
+  "resource_version": 363,
   "metadata": {
     "version": 3,
     "sources": [
@@ -2399,7 +2399,7 @@
           "queries": [
             {
               "name": "Latest Processor Status",
-              "query": "query LatestProcessorStatus {\n  processor_status {\n    processor\n    last_updated\n    last_success_version\n  }\n}"
+              "query": "query LatestProcessorStatus {\n  processor_status {\n    processor\n    last_updated\n    last_success_version\n    last_transaction_timestamp\n  }\n}"
             }
           ]
         }

--- a/hasura-api/metadata-json/unified.json
+++ b/hasura-api/metadata-json/unified.json
@@ -1,5 +1,5 @@
 {
-  "resource_version": 363,
+  "resource_version": 364,
   "metadata": {
     "version": 3,
     "sources": [
@@ -2011,6 +2011,7 @@
                 "permission": {
                   "columns": [
                     "last_success_version",
+                    "last_transaction_timestamp",
                     "last_updated",
                     "processor"
                   ],


### PR DESCRIPTION
## Summary

* Add the block timestamp into processor status rest api to monitor the end-2-end latency.

## Test Plan

* Tested in Hasura console; looks good. 
![image](https://github.com/aptos-labs/internal-ops/assets/112209412/312cdde5-5cb7-492f-a4b9-0d0ba30b1012)
