### PR TITLE
Pass around DB pools instead of holding connections for long periods

### DIFF
--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -60,7 +60,7 @@ impl Debug for FungibleAssetProcessor {
 }
 
 async fn insert_to_db(
-    conn: &mut PgPoolConnection<'_>,
+    conn: PgDbPool,
     name: &'static str,
     start_version: u64,
     end_version: u64,
@@ -77,28 +77,28 @@ async fn insert_to_db(
     );
 
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_fungible_asset_activities_query,
         fungible_asset_activities,
         FungibleAssetActivity::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_fungible_asset_metadata_query,
         fungible_asset_metadata,
         FungibleAssetMetadataModel::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_fungible_asset_balances_query,
         fungible_asset_balances,
         FungibleAssetBalance::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_current_fungible_asset_balances_query,
         current_fungible_asset_balances,
         CurrentFungibleAssetBalance::field_count(),
@@ -235,7 +235,7 @@ impl ProcessorTrait for FungibleAssetProcessor {
         let db_insertion_start = std::time::Instant::now();
 
         let tx_result = insert_to_db(
-            &mut conn,
+            self.get_pool(),
             self.name(),
             start_version,
             end_version,

--- a/rust/processor/src/processors/stake_processor.rs
+++ b/rust/processor/src/processors/stake_processor.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     schema,
     utils::{
-        database::{execute_in_chunks, PgDbPool, PgPoolConnection},
+        database::{execute_in_chunks, PgDbPool},
         util::{parse_timestamp, standardize_address},
     },
 };
@@ -57,7 +57,7 @@ impl Debug for StakeProcessor {
 }
 
 async fn insert_to_db(
-    conn: &mut PgPoolConnection<'_>,
+    conn: PgDbPool,
     name: &'static str,
     start_version: u64,
     end_version: u64,
@@ -79,63 +79,63 @@ async fn insert_to_db(
     );
 
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_current_stake_pool_voter_query,
         current_stake_pool_voters,
         CurrentStakingPoolVoter::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_proposal_votes_query,
         proposal_votes,
         ProposalVote::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_delegator_activities_query,
         delegator_actvities,
         DelegatedStakingActivity::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_delegator_balances_query,
         delegator_balances,
         DelegatorBalance::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_current_delegator_balances_query,
         current_delegator_balances,
         CurrentDelegatorBalance::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_delegator_pools_query,
         delegator_pools,
         DelegatorPool::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_delegator_pool_balances_query,
         delegator_pool_balances,
         DelegatorPoolBalance::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_current_delegator_pool_balances_query,
         current_delegator_pool_balances,
         CurrentDelegatorPoolBalance::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_current_delegated_voter_query,
         current_delegated_voter,
         CurrentDelegatedVoter::field_count(),
@@ -506,7 +506,7 @@ impl ProcessorTrait for StakeProcessor {
         let db_insertion_start = std::time::Instant::now();
 
         let tx_result = insert_to_db(
-            &mut conn,
+            self.get_pool(),
             self.name(),
             start_version,
             end_version,

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -68,7 +68,7 @@ impl Debug for TokenV2Processor {
 }
 
 async fn insert_to_db(
-    conn: &mut PgPoolConnection<'_>,
+    conn: PgDbPool,
     name: &'static str,
     start_version: u64,
     end_version: u64,
@@ -89,56 +89,56 @@ async fn insert_to_db(
     );
 
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_collections_v2_query,
         collections_v2,
         CollectionV2::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_token_datas_v2_query,
         token_datas_v2,
         TokenDataV2::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_token_ownerships_v2_query,
         token_ownerships_v2,
         TokenOwnershipV2::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_current_collections_v2_query,
         current_collections_v2,
         CurrentCollectionV2::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_current_token_datas_v2_query,
         current_token_datas_v2,
         CurrentTokenDataV2::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_current_token_ownerships_v2_query,
         current_token_ownerships_v2,
         CurrentTokenOwnershipV2::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_token_activities_v2_query,
         token_activities_v2,
         TokenActivityV2::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_current_token_v2_metadatas_query,
         current_token_v2_metadata,
         CurrentTokenV2Metadata::field_count(),
@@ -373,7 +373,7 @@ impl ProcessorTrait for TokenV2Processor {
         let db_insertion_start = std::time::Instant::now();
 
         let tx_result = insert_to_db(
-            &mut conn,
+            self.get_pool(),
             self.name(),
             start_version,
             end_version,

--- a/rust/processor/src/processors/user_transaction_processor.rs
+++ b/rust/processor/src/processors/user_transaction_processor.rs
@@ -7,7 +7,7 @@ use crate::{
         signatures::Signature, user_transactions::UserTransactionModel,
     },
     schema,
-    utils::database::{execute_in_chunks, PgDbPool, PgPoolConnection},
+    utils::database::{execute_in_chunks, PgDbPool},
 };
 use anyhow::bail;
 use aptos_protos::transaction::v1::{transaction::TxnData, Transaction};
@@ -43,7 +43,7 @@ impl Debug for UserTransactionProcessor {
 }
 
 async fn insert_to_db(
-    conn: &mut PgPoolConnection<'_>,
+    conn: PgDbPool,
     name: &'static str,
     start_version: u64,
     end_version: u64,
@@ -58,14 +58,14 @@ async fn insert_to_db(
     );
 
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_user_transactions_query,
         user_transactions,
         UserTransactionModel::field_count(),
     )
     .await?;
     execute_in_chunks(
-        conn,
+        conn.clone(),
         insert_signatures_query,
         signatures,
         Signature::field_count(),
@@ -130,7 +130,6 @@ impl ProcessorTrait for UserTransactionProcessor {
         _: Option<u64>,
     ) -> anyhow::Result<ProcessingResult> {
         let processing_start = std::time::Instant::now();
-        let mut conn = self.get_conn().await;
         let mut signatures = vec![];
         let mut user_transactions = vec![];
         for txn in transactions {
@@ -154,7 +153,7 @@ impl ProcessorTrait for UserTransactionProcessor {
         let db_insertion_start = std::time::Instant::now();
 
         let tx_result = insert_to_db(
-            &mut conn,
+            self.get_pool(),
             self.name(),
             start_version,
             end_version,

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -720,7 +720,7 @@ impl Worker {
                     "[Parser] Adding chain id to db, continue to index..."
                 );
                 execute_with_better_error(
-                    &mut conn,
+                    self.db_pool.clone(),
                     diesel::insert_into(ledger_infos::table)
                         .values(LedgerInfo {
                             chain_id: grpc_chain_id,


### PR DESCRIPTION
small theoretical performance gain, but mainly in preparation for a world of parallelism, so each sub-task is able to pull from the DB pool whenever it needs a connection, instead of re-using the same one