### PR TITLE
Use Kanal for async channels

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1362,6 +1362,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanal"
+version = "0.1.0-pre8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05d55519627edaf7fd0f29981f6dc03fb52df3f5b257130eb8d0bf2801ea1d7"
+dependencies = [
+ "futures-core",
+ "lock_api",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +1918,7 @@ dependencies = [
  "google-cloud-googleapis",
  "google-cloud-pubsub",
  "hex",
+ "kanal",
  "native-tls",
  "num_cpus",
  "once_cell",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,6 +55,7 @@ cloud-storage = { version = "0.11.1", features = ["global-client"] }
 google-cloud-googleapis = "0.10.0"
 google-cloud-pubsub = "0.18.0"
 hex = "0.4.3"
+kanal = { version = "0.1.0-pre8", features = ["async"] }
 once_cell = "1.10.0"
 num_cpus = "1.16.0"
 pbjson = "0.5.1"

--- a/rust/processor/Cargo.toml
+++ b/rust/processor/Cargo.toml
@@ -35,6 +35,7 @@ gcloud-sdk = { workspace = true }
 google-cloud-googleapis = { workspace = true }
 google-cloud-pubsub = { workspace = true }
 hex = { workspace = true }
+kanal = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }
 prometheus = { workspace = true }

--- a/rust/processor/src/grpc_stream.rs
+++ b/rust/processor/src/grpc_stream.rs
@@ -12,6 +12,7 @@ use aptos_protos::indexer::v1::{
     raw_data_client::RawDataClient, GetTransactionsRequest, TransactionsResponse,
 };
 use futures_util::StreamExt;
+use kanal::AsyncSender;
 use prost::Message;
 use std::time::Duration;
 use tonic::{Response, Streaming};
@@ -203,7 +204,7 @@ pub async fn get_chain_id(
 /// 2. If we specified an end version and we hit that, we will stop fetching, but we will make sure that
 /// all existing transactions are processed
 pub async fn create_fetcher_loop(
-    txn_sender: tokio::sync::mpsc::Sender<TransactionsPBResponse>,
+    txn_sender: AsyncSender<TransactionsPBResponse>,
     indexer_grpc_data_service_address: Url,
     indexer_grpc_http2_ping_interval: Duration,
     indexer_grpc_http2_ping_timeout: Duration,

--- a/rust/processor/src/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/models/default_models/write_set_changes.rs
@@ -18,7 +18,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
 #[derive(
-    Associations, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Clone,
+    Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize,
 )]
 #[diesel(belongs_to(Transaction, foreign_key = transaction_version))]
 #[diesel(primary_key(transaction_version, index))]


### PR DESCRIPTION
kanal has higher performance than the tokio MPSC channels in benchmarks, and this sets us up for the next set of PRs utilizing kanal for parallelism

Testing:
Ran locally; saw indexing continued to work