### PR TITLE
upgrade processor to grpc 1.4 (node 1.10)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -119,8 +119,8 @@ dependencies = [
 
 [[package]]
 name = "aptos-protos"
-version = "1.1.2"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=af0dcea7144225a709e4f595e58f8026b99e901c#af0dcea7144225a709e4f595e58f8026b99e901c"
+version = "1.3.0"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=5d1cefad0ea0d37fb08e9aec7847080745c83f9c#5d1cefad0ea0d37fb08e9aec7847080745c83f9c"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -784,15 +784,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -801,15 +801,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -818,21 +818,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ aptos-moving-average = { path = "moving-average" }
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.62"
 async-trait = "0.1.53"
-aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "af0dcea7144225a709e4f595e58f8026b99e901c" }
+aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5d1cefad0ea0d37fb08e9aec7847080745c83f9c" }
 backtrace = "0.3.58"
 base64 = "0.13.0"
 bb8 = "0.8.1"
@@ -45,7 +45,7 @@ diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 diesel_async_migrations = { git = "https://github.com/niroco/diesel_async_migrations", rev = "11f331b73c5cfcc894380074f748d8fda710ac12" }
 enum_dispatch = "0.3.12"
 field_count = "0.1.1"
-futures = "0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.
+futures = "0.3.30"
 futures-core = "0.3.25"
 futures-util = "0.3.21"
 gcloud-sdk = { version = "0.20.4", features = [

--- a/rust/processor/migrations/2024-02-16-234847_any_signature/down.sql
+++ b/rust/processor/migrations/2024-02-16-234847_any_signature/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE signatures
+ALTER COLUMN signature TYPE VARCHAR(200);

--- a/rust/processor/migrations/2024-02-16-234847_any_signature/up.sql
+++ b/rust/processor/migrations/2024-02-16-234847_any_signature/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE signatures
+ALTER COLUMN signature TYPE text;

--- a/rust/processor/src/models/default_models/transactions.rs
+++ b/rust/processor/src/models/default_models/transactions.rs
@@ -273,7 +273,22 @@ impl Transaction {
                     wsc_detail,
                 )
             },
-            TxnData::StateCheckpoint(_state_checkpoint_txn) => (
+            TxnData::StateCheckpoint(_) => (
+                Self::from_transaction_info_with_data(
+                    transaction_info,
+                    None,
+                    None,
+                    version,
+                    transaction_type,
+                    0,
+                    block_height,
+                    epoch,
+                ),
+                None,
+                vec![],
+                vec![],
+            ),
+            TxnData::Validator(_) => (
                 Self::from_transaction_info_with_data(
                     transaction_info,
                     None,

--- a/rust/processor/src/models/user_transactions_models/signatures.rs
+++ b/rust/processor/src/models/user_transactions_models/signatures.rs
@@ -9,10 +9,10 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use aptos_protos::transaction::v1::{
-    account_signature::Signature as AccountSignatureEnum,
-    any_signature::SignatureVariant, signature::Signature as SignatureEnum,
-    AccountSignature as ProtoAccountSignature, Ed25519Signature as Ed25519SignaturePB,
-    FeePayerSignature as ProtoFeePayerSignature, MultiAgentSignature as ProtoMultiAgentSignature,
+    account_signature::Signature as AccountSignatureEnum, any_signature::SignatureVariant,
+    signature::Signature as SignatureEnum, AccountSignature as ProtoAccountSignature,
+    Ed25519Signature as Ed25519SignaturePB, FeePayerSignature as ProtoFeePayerSignature,
+    MultiAgentSignature as ProtoMultiAgentSignature,
     MultiEd25519Signature as MultiEd25519SignaturePb, MultiKeySignature as MultiKeySignaturePb,
     Signature as TransactionSignaturePb, SingleKeySignature as SingleKeySignaturePb,
     SingleSender as SingleSenderPb,
@@ -337,8 +337,10 @@ impl Signature {
     ) -> Self {
         let signer = standardize_address(override_address.unwrap_or(sender));
         let signature = s.signature.as_ref().unwrap();
-        let signature_bytes = Self::get_any_signature_bytes(&signature.signature_variant, transaction_version);
-        let type_ = Self::get_any_signature_type(&signature.signature_variant, true, transaction_version);
+        let signature_bytes =
+            Self::get_any_signature_bytes(&signature.signature_variant, transaction_version);
+        let type_ =
+            Self::get_any_signature_type(&signature.signature_variant, true, transaction_version);
         Self {
             transaction_version,
             transaction_block_height,
@@ -380,8 +382,15 @@ impl Signature {
                 .unwrap()
                 .public_key
                 .clone();
-            let signature_bytes = Self::get_any_signature_bytes(&signature.signature.as_ref().unwrap().signature_variant, transaction_version);
-            let type_ = Self::get_any_signature_type(&signature.signature.as_ref().unwrap().signature_variant, false, transaction_version);
+            let signature_bytes = Self::get_any_signature_bytes(
+                &signature.signature.as_ref().unwrap().signature_variant,
+                transaction_version,
+            );
+            let type_ = Self::get_any_signature_type(
+                &signature.signature.as_ref().unwrap().signature_variant,
+                false,
+                transaction_version,
+            );
             signatures.push(Self {
                 transaction_version,
                 transaction_block_height,
@@ -406,7 +415,10 @@ impl Signature {
         signatures
     }
 
-    fn get_any_signature_bytes(signature_variant: &Option<SignatureVariant>, transaction_version: i64) -> Vec<u8> {
+    fn get_any_signature_bytes(
+        signature_variant: &Option<SignatureVariant>,
+        transaction_version: i64,
+    ) -> Vec<u8> {
         match signature_variant {
             Some(SignatureVariant::Ed25519(sig)) => sig.signature.clone(),
             Some(SignatureVariant::Zkid(sig)) => sig.signature.clone(),
@@ -414,8 +426,8 @@ impl Signature {
             Some(SignatureVariant::Secp256k1Ecdsa(sig)) => sig.signature.clone(),
             None => {
                 PROCESSOR_UNKNOWN_TYPE_COUNT
-                .with_label_values(&["SignatureVariant"])
-                .inc();
+                    .with_label_values(&["SignatureVariant"])
+                    .inc();
                 tracing::warn!(
                     transaction_version = transaction_version,
                     "Signature variant doesn't exist",
@@ -425,7 +437,11 @@ impl Signature {
         }
     }
 
-    fn get_any_signature_type(signature_variant: &Option<SignatureVariant>, is_single_sender: bool, transaction_version: i64) -> String {
+    fn get_any_signature_type(
+        signature_variant: &Option<SignatureVariant>,
+        is_single_sender: bool,
+        transaction_version: i64,
+    ) -> String {
         let prefix = if is_single_sender {
             "single_sender"
         } else {
@@ -435,11 +451,13 @@ impl Signature {
             Some(SignatureVariant::Ed25519(_)) => format!("{}_ed25519_signature", prefix),
             Some(SignatureVariant::Zkid(_)) => format!("{}_zkid_signature", prefix),
             Some(SignatureVariant::Webauthn(_)) => format!("{}_webauthn_signature", prefix),
-            Some(SignatureVariant::Secp256k1Ecdsa(_)) => format!("{}_secp256k1_ecdsa_signature", prefix),
+            Some(SignatureVariant::Secp256k1Ecdsa(_)) => {
+                format!("{}_secp256k1_ecdsa_signature", prefix)
+            },
             None => {
                 PROCESSOR_UNKNOWN_TYPE_COUNT
-                .with_label_values(&["SignatureVariant"])
-                .inc();
+                    .with_label_values(&["SignatureVariant"])
+                    .inc();
                 tracing::warn!(
                     transaction_version = transaction_version,
                     "Signature variant doesn't exist",

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -906,8 +906,7 @@ diesel::table! {
         type_ -> Varchar,
         #[max_length = 136]
         public_key -> Varchar,
-        #[max_length = 200]
-        signature -> Varchar,
+        signature -> Text,
         threshold -> Int8,
         public_key_indices -> Jsonb,
         inserted_at -> Timestamp,

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -1,7 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{models::property_map::{PropertyMap, TokenObjectPropertyMap}, utils::counters::PROCESSOR_UNKNOWN_TYPE_COUNT};
+use crate::{
+    models::property_map::{PropertyMap, TokenObjectPropertyMap},
+    utils::counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
+};
 use aptos_protos::{
     transaction::v1::{
         multisig_transaction_payload::Payload as MultisigPayloadType,
@@ -116,8 +119,8 @@ pub fn get_payload_type(payload: &TransactionPayload) -> String {
 pub fn get_clean_payload(payload: &TransactionPayload, version: i64) -> Option<Value> {
     if payload.payload.as_ref().is_none() {
         PROCESSOR_UNKNOWN_TYPE_COUNT
-        .with_label_values(&["TransactionPayload"])
-        .inc();
+            .with_label_values(&["TransactionPayload"])
+            .inc();
         tracing::warn!(
             transaction_version = version,
             "Transaction payload doesn't exist",


### PR DESCRIPTION
https://github.com/aptos-labs/aptos-core/releases/tag/aptos-indexer-grpc-v1.4.0

Add new validator transaction handling and change signature parsing

also remove ModuleBundlePayload b/c protobuf doesn't support anymore. 

## Backfill
None

## Testing
in case of an unknown transaction
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/9a606f64-0c77-4823-a6f8-2c116b236ec5)

yay! it works for new types
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/7d016823-f112-457d-a8eb-f68a978cd777)
