### PR TITLE
Introduce txn filter

### DIFF
--- a/rust/processor/README.md
+++ b/rust/processor/README.md
@@ -8,23 +8,33 @@ Indexer GRPC parser is to indexer data processor that leverages the indexer grpc
 
 ### Prerequisite
 
-- A running PostgreSQL instance, with a valid database. More tutorial can be found [here](https://github.com/aptos-labs/aptos-core/tree/main/crates/indexer#postgres)
+- A running PostgreSQL instance, with a valid database. More tutorial can be
+  found [here](https://github.com/aptos-labs/aptos-core/tree/main/crates/indexer#postgres)
 
 - A config YAML file
-  - For exmaple, `config.yaml`
-  - ```yaml
-    health_check_port: 8084
-    server_config:
-      processor_config:
-        type: default_processor
-      postgres_connection_string: postgresql://postgres:@localhost:5432/postgres_v2
-      indexer_grpc_data_service_address: 127.0.0.1:50051
-      indexer_grpc_http2_ping_interval_in_secs: 60
-      indexer_grpc_http2_ping_timeout_in_secs: 10
-      number_concurrent_processing_tasks: 10
-      auth_token: AUTH_TOKEN
-      starting_version: 0 # optional
-      ending_version: 0 # optional
+    - For exmaple, `config.yaml`
+    - ```yaml
+  health_check_port: 8084
+  server_config:
+  processor_config:
+  type: default_processor
+  postgres_connection_string: postgresql://postgres:@localhost:5432/postgres_v2
+  indexer_grpc_data_service_address: 127.0.0.1:50051
+  indexer_grpc_http2_ping_interval_in_secs: 60
+  indexer_grpc_http2_ping_timeout_in_secs: 10
+  number_concurrent_processing_tasks: 10
+  auth_token: AUTH_TOKEN
+  starting_version: 0 # optional
+  ending_version: 0 # optional
+  transaction_filter:
+  # Only allow transactions from these contract addresses
+  #focus_contract_addresses:
+  #- "0x0"
+  # Skip transactions from these sender addresses
+  skip_sender_addresses:
+  - "0x07"
+  # Skip all transactions that aren't user transactions
+  focus_user_transactions: false
     ```
 
 #### Config Explanation
@@ -37,13 +47,14 @@ Indexer GRPC parser is to indexer data processor that leverages the indexer grpc
 - `auth_token`: Auth token used for connection.
 - `starting_version`: start processor at starting_version.
 - `ending_version`: stop processor after ending_version.
-- `number_concurrent_processing_tasks`: number of tasks to parse and insert; 1 means sequential processing, otherwise, transactions are splitted into tasks and inserted with random order.
+- `number_concurrent_processing_tasks`: number of tasks to parse and insert; 1 means sequential processing, otherwise,
+  transactions are splitted into tasks and inserted with random order.
 
 ### Use docker image for existing parsers(Only for **Unix/Linux**)
 
 - Use the provided `Dockerfile` and `config.yaml`(update accordingly)
-  - Build: `cd ecosystem/indexer-grpc/indexer-grpc-parser && docker build . -t indexer-processor`
-  - Run: `docker run indexer-processor:latest`
+    - Build: `cd ecosystem/indexer-grpc/indexer-grpc-parser && docker build . -t indexer-processor`
+    - Run: `docker run indexer-processor:latest`
 
 ### Use source code for existing parsers
 

--- a/rust/processor/src/config.rs
+++ b/rust/processor/src/config.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    gap_detector::DEFAULT_GAP_DETECTION_BATCH_SIZE, processors::ProcessorConfig, worker::Worker,
+    gap_detector::DEFAULT_GAP_DETECTION_BATCH_SIZE, processors::ProcessorConfig,
+    transaction_filter::TransactionFilter, worker::Worker,
 };
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -27,6 +28,7 @@ pub struct IndexerGrpcProcessorConfig {
     #[serde(default = "IndexerGrpcProcessorConfig::default_gap_detection_batch_size")]
     pub gap_detection_batch_size: u64,
     pub enable_verbose_logging: Option<bool>,
+    pub transaction_filter: TransactionFilter,
 }
 
 impl IndexerGrpcProcessorConfig {
@@ -50,6 +52,7 @@ impl RunnableConfig for IndexerGrpcProcessorConfig {
             self.db_pool_size,
             self.gap_detection_batch_size,
             self.enable_verbose_logging,
+            self.transaction_filter.clone(),
         )
         .await
         .context("Failed to build worker")?;

--- a/rust/processor/src/grpc_stream.rs
+++ b/rust/processor/src/grpc_stream.rs
@@ -291,7 +291,7 @@ pub async fn create_fetcher_loop(
                         .unwrap_or_default(),
                     end_txn_timestamp_iso = end_txn_timestamp
                         .as_ref()
-                        .map(|t| timestamp_to_iso(t))
+                        .map(timestamp_to_iso)
                         .unwrap_or_default(),
                     num_of_transactions = end_version - start_version + 1,
                     channel_size = buffer_size - txn_sender.capacity(),
@@ -336,7 +336,7 @@ pub async fn create_fetcher_loop(
                     .set(
                         start_txn_timestamp
                             .as_ref()
-                            .map(|t| timestamp_to_unixtime(t))
+                            .map(timestamp_to_unixtime)
                             .unwrap_or_default(),
                     );
                 PROCESSED_BYTES_COUNT
@@ -375,21 +375,19 @@ pub async fn create_fetcher_loop(
                 let num_txn_post_filter = txn_pb.transactions.len();
                 let num_filtered_txns = num_txns - num_txn_post_filter;
 
-                if num_txn_post_filter > 0 {
-                    match txn_sender.send(txn_pb).await {
-                        Ok(()) => {},
-                        Err(e) => {
-                            error!(
-                                processor_name = processor_name,
-                                stream_address = indexer_grpc_data_service_address.to_string(),
-                                connection_id,
-                                channel_size = buffer_size - txn_sender.capacity(),
-                                error = ?e,
-                                "[Parser] Error sending GRPC response to channel."
-                            );
-                            panic!("[Parser] Error sending GRPC response to channel.")
-                        },
-                    }
+                match txn_sender.send(txn_pb).await {
+                    Ok(()) => {},
+                    Err(e) => {
+                        error!(
+                            processor_name = processor_name,
+                            stream_address = indexer_grpc_data_service_address.to_string(),
+                            connection_id,
+                            channel_size = buffer_size - txn_sender.capacity(),
+                            error = ?e,
+                            "[Parser] Error sending GRPC response to channel."
+                        );
+                        panic!("[Parser] Error sending GRPC response to channel.")
+                    },
                 }
 
                 let duration_in_secs = txn_channel_send_latency.elapsed().as_secs_f64();

--- a/rust/processor/src/lib.rs
+++ b/rust/processor/src/lib.rs
@@ -19,5 +19,6 @@ pub mod grpc_stream;
 pub mod models;
 pub mod processors;
 pub mod schema;
+pub mod transaction_filter;
 pub mod utils;
 pub mod worker;

--- a/rust/processor/src/processors/mod.rs
+++ b/rust/processor/src/processors/mod.rs
@@ -68,7 +68,7 @@ pub struct ProcessingResult {
 /// Base trait for all processors
 #[async_trait]
 #[enum_dispatch]
-pub trait ProcessorTrait: Send + Sync + Debug + ToOwned {
+pub trait ProcessorTrait: Send + Sync + Debug {
     fn name(&self) -> &'static str;
 
     /// Process all transactions including writing to the database

--- a/rust/processor/src/processors/mod.rs
+++ b/rust/processor/src/processors/mod.rs
@@ -68,7 +68,7 @@ pub struct ProcessingResult {
 /// Base trait for all processors
 #[async_trait]
 #[enum_dispatch]
-pub trait ProcessorTrait: Send + Sync + Debug {
+pub trait ProcessorTrait: Send + Sync + Debug + ToOwned {
     fn name(&self) -> &'static str;
 
     /// Process all transactions including writing to the database

--- a/rust/processor/src/transaction_filter.rs
+++ b/rust/processor/src/transaction_filter.rs
@@ -1,0 +1,77 @@
+use aptos_protos::transaction::v1::{
+    transaction::{TransactionType, TxnData},
+    transaction_payload::Payload,
+    Transaction,
+};
+use serde::{Deserialize, Serialize};
+
+/// Allows filtering transactions based on various criteria
+/// The criteria are combined with `AND`
+/// If a criteria is not set, it is ignored
+/// Criteria will be loaded from the config file
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TransactionFilter {
+    // Only allow transactions from these contract addresses
+    focus_contract_addresses: Option<ahash::HashSet<String>>,
+    // Skip transactions from these sender addresses
+    skip_sender_addresses: Option<ahash::HashSet<String>>,
+    // Skip all transactions that aren't user transactions
+    focus_user_transactions: bool,
+}
+
+impl TransactionFilter {
+    pub fn new(
+        focus_contract_addresses: Option<ahash::HashSet<String>>,
+        skip_sender_addresses: Option<ahash::HashSet<String>>,
+        focus_user_transactions: bool,
+    ) -> Self {
+        // TODO: normalize addresses
+        Self {
+            focus_contract_addresses,
+            skip_sender_addresses,
+            focus_user_transactions,
+        }
+    }
+
+    /// Returns true if the transaction should be included
+    pub fn include(&self, transaction: &Transaction) -> bool {
+        let is_user_txn = transaction.r#type == TransactionType::User as i32;
+        if self.focus_user_transactions && !is_user_txn {
+            return false;
+        }
+
+        // If it's not a user transaction, we can skip the rest of the checks
+        if !is_user_txn {
+            return true;
+        }
+
+        if let Some(txn_data) = transaction.txn_data.as_ref() {
+            if let TxnData::User(user_transaction) = txn_data {
+                if let Some(utr) = user_transaction.request.as_ref() {
+                    // Skip if sender is in the skip list
+                    if let Some(skip_sender_addresses) = &self.skip_sender_addresses {
+                        return !skip_sender_addresses.contains(&utr.sender);
+                    }
+
+                    if let Some(focus_contract_addresses) = &self.focus_contract_addresses {
+                        // Skip if focus contract addresses are set and the transaction isn't in the list
+                        if let Some(payload) = utr.payload.as_ref() {
+                            if let Some(Payload::EntryFunctionPayload(efp)) =
+                                payload.payload.as_ref()
+                            {
+                                if let Some(function) = efp.function.as_ref() {
+                                    if let Some(module) = function.module.as_ref() {
+                                        return focus_contract_addresses.contains(&module.address);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    }
+}

--- a/rust/processor/src/transaction_filter.rs
+++ b/rust/processor/src/transaction_filter.rs
@@ -37,6 +37,7 @@ impl TransactionFilter {
     /// Returns true if the transaction should be included
     pub fn include(&self, transaction: &Transaction) -> bool {
         // If we're only focusing on user transactions, skip if it's not a user transaction
+
         let is_user_txn = transaction.r#type == TransactionType::User as i32;
         if self.focus_user_transactions && !is_user_txn {
             return false;

--- a/rust/processor/src/transaction_filter.rs
+++ b/rust/processor/src/transaction_filter.rs
@@ -36,6 +36,7 @@ impl TransactionFilter {
 
     /// Returns true if the transaction should be included
     pub fn include(&self, transaction: &Transaction) -> bool {
+        // If we're only focusing on user transactions, skip if it's not a user transaction
         let is_user_txn = transaction.r#type == TransactionType::User as i32;
         if self.focus_user_transactions && !is_user_txn {
             return false;

--- a/rust/processor/src/utils/counters.rs
+++ b/rust/processor/src/utils/counters.rs
@@ -157,6 +157,16 @@ pub static NUM_TRANSACTIONS_PROCESSED_COUNT: Lazy<IntCounterVec> = Lazy::new(|| 
     .unwrap()
 });
 
+/// Count of transactions filtered out
+pub static NUM_TRANSACTIONS_FILTERED_OUT_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "indexer_processor_num_transactions_filtered_out_count",
+        "Number of transactions filtered out",
+        &["processor_name"]
+    )
+    .unwrap()
+});
+
 /// Size of the channel containing transactions fetched from GRPC, waiting to be processed
 pub static FETCHER_THREAD_CHANNEL_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(


### PR DESCRIPTION
Allow filtering transactions that reach the processor right after GRPC via config

The criteria are combined with `AND`, if a criteria is not set, it is ignored

adds a config section:
```
server_config:
  transaction_filter:
    # Only allow transactions from these contract addresses
    focus_contract_addresses:
      - "0x0"
    # Skip transactions from these sender addresses
    skip_sender_addresses:
      - "0x0"
    # Skip all transactions that aren't user transactions
    focus_user_transactions: true
  ```