### PR TITLE
default for TransactionFilter config

### DIFF
--- a/rust/processor/src/config.rs
+++ b/rust/processor/src/config.rs
@@ -28,6 +28,7 @@ pub struct IndexerGrpcProcessorConfig {
     #[serde(default = "IndexerGrpcProcessorConfig::default_gap_detection_batch_size")]
     pub gap_detection_batch_size: u64,
     pub enable_verbose_logging: Option<bool>,
+    #[serde(default)]
     pub transaction_filter: TransactionFilter,
 }
 

--- a/rust/processor/src/transaction_filter.rs
+++ b/rust/processor/src/transaction_filter.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 /// Criteria will be loaded from the config file
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct TransactionFilter {
     // Only allow transactions from these contract addresses
     focus_contract_addresses: Option<ahash::HashSet<String>>,


### PR DESCRIPTION
Make config work even when `TransactionFilter` is not there