### PR TITLE
Fix fungible asset metadata

### DIFF
--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -84,7 +84,7 @@ impl FungibleAssetBalance {
                 // If it's a fungible token, return early
                 if !FungibleAssetMetadataModel::is_address_fungible_asset(
                     conn,
-                    &storage_id,
+                    &asset_type,
                     object_metadatas,
                     txn_version,
                 )

--- a/rust/processor/src/models/object_models/v2_objects.rs
+++ b/rust/processor/src/models/object_models/v2_objects.rs
@@ -93,7 +93,7 @@ impl Object {
                     allow_ungated_transfer: object_core.allow_ungated_transfer,
                     is_token: Some(object_aggregated_metadata.token.is_some()),
                     is_fungible_asset: Some(
-                        object_aggregated_metadata.fungible_asset_store.is_some(),
+                        object_aggregated_metadata.fungible_asset_metadata.is_some(),
                     ),
                     is_deleted: false,
                 },
@@ -106,7 +106,7 @@ impl Object {
                     last_transaction_version: txn_version,
                     is_token: Some(object_aggregated_metadata.token.is_some()),
                     is_fungible_asset: Some(
-                        object_aggregated_metadata.fungible_asset_store.is_some(),
+                        object_aggregated_metadata.fungible_asset_metadata.is_some(),
                     ),
                     is_deleted: false,
                 },

--- a/rust/processor/src/processors/objects_processor.rs
+++ b/rust/processor/src/processors/objects_processor.rs
@@ -4,7 +4,7 @@
 use super::{ProcessingResult, ProcessorName, ProcessorTrait};
 use crate::{
     models::{
-        fungible_asset_models::v2_fungible_asset_utils::FungibleAssetStore,
+        fungible_asset_models::v2_fungible_asset_utils::FungibleAssetMetadata,
         object_models::{
             v2_object_utils::{
                 ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata,
@@ -209,11 +209,11 @@ impl ProcessorTrait for ObjectsProcessor {
                             // Object is a token if it has 0x4::token::Token struct
                             aggregated_data.token = Some(token);
                         }
-                        if let Some(fungible_asset_store) =
-                            FungibleAssetStore::from_write_resource(wr, txn_version).unwrap()
+                        if let Some(fungible_asset_metadata) =
+                            FungibleAssetMetadata::from_write_resource(wr, txn_version).unwrap()
                         {
-                            // Object is a fungible asset if it has a 0x1::fungible_asset::FungibleAssetStore
-                            aggregated_data.fungible_asset_store = Some(fungible_asset_store);
+                            // Object is a fungible asset if it has a 0x1::fungible_asset::FungibleAssetMetadata
+                            aggregated_data.fungible_asset_metadata = Some(fungible_asset_metadata);
                         }
                     }
                 }


### PR DESCRIPTION
## Description 
* Use the correct metadata address to lookup whether an object is a fungible asset
* Fix current_object is_fungible_asset to check for existence of FungibleAssetMetadata, not FungibleAssetStore

## Testing
https://explorer.aptoslabs.com/txn/313811207/userTxnOverview?network=mainnet
Run objects_processor with version 313811207. See that is_fungible_asset is true. 
<img width="1251" alt="Screenshot 2024-03-05 at 4 10 50 PM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/e9347a3a-07a9-4b76-a8cf-57021b68b180">
<img width="1030" alt="Screenshot 2024-03-05 at 4 16 44 PM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/f4564397-8ed1-4d8d-8c59-e957067b45df">


Run fungible_asset_processor with version 313811207. Fungible asset store is indexed
<img width="1288" alt="Screenshot 2024-03-05 at 4 32 55 PM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/c6900983-a328-43eb-bfe2-7b05acf67baa">

