### PR TITLE
Remove dependency on objects processor

### DIFF
--- a/rust/processor/migrations/2024-03-07-224504_fungible_asset_metadata_is_token_v2/down.sql
+++ b/rust/processor/migrations/2024-03-07-224504_fungible_asset_metadata_is_token_v2/down.sql
@@ -1,0 +1,9 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE fungible_asset_metadata
+DROP COLUMN IF EXISTS is_token_v2;
+ALTER TABLE objects
+ADD COLUMN IF NOT EXISTS is_token BOOLEAN,
+ADD COLUMN IF NOT EXISTS is_fungible_asset BOOLEAN;
+ALTER TABLE current_objects
+ADD COLUMN IF NOT EXISTS is_token BOOLEAN,
+ADD COLUMN IF NOT EXISTS is_fungible_asset BOOLEAN;

--- a/rust/processor/migrations/2024-03-07-224504_fungible_asset_metadata_is_token_v2/up.sql
+++ b/rust/processor/migrations/2024-03-07-224504_fungible_asset_metadata_is_token_v2/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+ALTER TABLE fungible_asset_metadata
+ADD COLUMN IF NOT EXISTS is_token_v2 BOOLEAN;
+ALTER TABLE objects
+DROP COLUMN IF EXISTS is_fungible_asset,
+DROP COLUMN IF EXISTS is_token;
+ALTER TABLE current_objects
+DROP COLUMN IF EXISTS is_fungible_asset,
+DROP COLUMN IF EXISTS is_token;

--- a/rust/processor/src/models/object_models/v2_objects.rs
+++ b/rust/processor/src/models/object_models/v2_objects.rs
@@ -34,8 +34,6 @@ pub struct Object {
     pub state_key_hash: String,
     pub guid_creation_num: BigDecimal,
     pub allow_ungated_transfer: bool,
-    pub is_token: Option<bool>,
-    pub is_fungible_asset: Option<bool>,
     pub is_deleted: bool,
 }
 
@@ -49,8 +47,6 @@ pub struct CurrentObject {
     pub allow_ungated_transfer: bool,
     pub last_guid_creation_num: BigDecimal,
     pub last_transaction_version: i64,
-    pub is_token: Option<bool>,
-    pub is_fungible_asset: Option<bool>,
     pub is_deleted: bool,
 }
 
@@ -66,8 +62,6 @@ pub struct CurrentObjectQuery {
     pub last_transaction_version: i64,
     pub is_deleted: bool,
     pub inserted_at: chrono::NaiveDateTime,
-    pub is_token: Option<bool>,
-    pub is_fungible_asset: Option<bool>,
 }
 
 impl Object {
@@ -91,10 +85,6 @@ impl Object {
                     state_key_hash: object_with_metadata.state_key_hash.clone(),
                     guid_creation_num: object_core.guid_creation_num.clone(),
                     allow_ungated_transfer: object_core.allow_ungated_transfer,
-                    is_token: Some(object_aggregated_metadata.token.is_some()),
-                    is_fungible_asset: Some(
-                        object_aggregated_metadata.fungible_asset_metadata.is_some(),
-                    ),
                     is_deleted: false,
                 },
                 CurrentObject {
@@ -104,10 +94,6 @@ impl Object {
                     allow_ungated_transfer: object_core.allow_ungated_transfer,
                     last_guid_creation_num: object_core.guid_creation_num.clone(),
                     last_transaction_version: txn_version,
-                    is_token: Some(object_aggregated_metadata.token.is_some()),
-                    is_fungible_asset: Some(
-                        object_aggregated_metadata.fungible_asset_metadata.is_some(),
-                    ),
                     is_deleted: false,
                 },
             )))
@@ -158,8 +144,6 @@ impl Object {
                     state_key_hash: resource.state_key_hash.clone(),
                     guid_creation_num: previous_object.last_guid_creation_num.clone(),
                     allow_ungated_transfer: previous_object.allow_ungated_transfer,
-                    is_token: previous_object.is_token,
-                    is_fungible_asset: previous_object.is_fungible_asset,
                     is_deleted: true,
                 },
                 CurrentObject {
@@ -169,8 +153,6 @@ impl Object {
                     last_guid_creation_num: previous_object.last_guid_creation_num.clone(),
                     allow_ungated_transfer: previous_object.allow_ungated_transfer,
                     last_transaction_version: txn_version,
-                    is_token: previous_object.is_token,
-                    is_fungible_asset: previous_object.is_fungible_asset,
                     is_deleted: true,
                 },
             )))
@@ -198,8 +180,6 @@ impl Object {
                         allow_ungated_transfer: res.allow_ungated_transfer,
                         last_guid_creation_num: res.last_guid_creation_num,
                         last_transaction_version: res.last_transaction_version,
-                        is_token: res.is_token,
-                        is_fungible_asset: res.is_fungible_asset,
                         is_deleted: res.is_deleted,
                     });
                 },

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -449,8 +449,6 @@ diesel::table! {
         last_transaction_version -> Int8,
         is_deleted -> Bool,
         inserted_at -> Timestamp,
-        is_token -> Nullable<Bool>,
-        is_fungible_asset -> Nullable<Bool>,
     }
 }
 
@@ -791,6 +789,7 @@ diesel::table! {
         #[max_length = 10]
         token_standard -> Varchar,
         inserted_at -> Timestamp,
+        is_token_v2 -> Nullable<Bool>,
     }
 }
 
@@ -873,8 +872,6 @@ diesel::table! {
         allow_ungated_transfer -> Bool,
         is_deleted -> Bool,
         inserted_at -> Timestamp,
-        is_token -> Nullable<Bool>,
-        is_fungible_asset -> Nullable<Bool>,
     }
 }
 


### PR DESCRIPTION
## Description 
To improve dev ex, we remove the dependency of token v2 / fungible asset processor on objects processor. 

In `fungible_asset_metadata`, introduce a column `is_token_v2`. Fungible asset processor will lookup `is_token_v2` to skip indexing fungible tokens. 

Token v2 processor will lookup `current_token_datas_v2.is_fungible_v2` to index the fungible token. 

## Test

Fungible token with metadata in same txn. https://explorer.aptoslabs.com/txn/351790067/userTxnOverview?network=mainnet
See that the fungible token is indexed in the tokens table and not the fungible balances table. 
![Screenshot 2024-03-07 at 6 46 06 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/3e10c53c-d6b4-4e8a-819c-459174bcacf6)

Normal fungible asset indexing still works
![Screenshot 2024-03-07 at 7 02 18 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/96332779-ae26-4ac2-bcaa-1e576bedc847)

Normal token indexing still works
![Screenshot 2024-03-07 at 7 04 08 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/3470681f-47ea-4a69-b92e-2669c4456f6c)

Objects indexing still works
![Screenshot 2024-03-07 at 7 12 49 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/e455bbed-7ef6-4f42-8ae2-ea27d7b2e575)
![Screenshot 2024-03-07 at 7 12 45 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/17da57cf-bb30-4b3c-af34-e4e3ab8bc760)
