### PR TITLE
[hotfix] Fix fungible asset logic

### DIFF
--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -168,7 +168,7 @@ impl FungibleAssetMetadataModel {
                 }
 
                 // If is_token_v2 is null, then the metadata is a v1 coin info, and it's not a token
-                false
+                true
             },
             Err(_) => {
                 tracing::error!(

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -154,6 +154,7 @@ fn insert_fungible_asset_metadata_query(
                     supply_aggregator_table_key_v1.eq(excluded(supply_aggregator_table_key_v1)),
                     token_standard.eq(excluded(token_standard)),
                     inserted_at.eq(excluded(inserted_at)),
+                    is_token_v2.eq(excluded(is_token_v2)),
                 )
             ),
         Some(" WHERE fungible_asset_metadata.last_transaction_version <= excluded.last_transaction_version "),


### PR DESCRIPTION
The logic was wrongly excluding fungible asset, also didn't backfill is_token column properly. 

## Backfill

## Test
Confirm that it overrides the old field
<img width="539" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/6e80efea-3b94-4956-8904-665ac0e90924">


Also that the reported cellana issue for transaction 490148488 is cleared
<img width="613" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/26b6c11c-c82d-4519-b26f-40b4a06be336">

