### PR TITLE
[rust] handle burn properly for partial burns

### DIFF
--- a/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
@@ -234,6 +234,8 @@ impl TokenOwnershipV2 {
         prior_nft_ownership: &AHashMap<String, NFTOwnershipV2>,
         tokens_burned: &TokenV2Burned,
         conn: &mut PgPoolConnection<'_>,
+        query_retries: u32,
+        query_retry_delay_ms: u64,
     ) -> anyhow::Result<Option<(Self, CurrentTokenOwnershipV2)>> {
         let token_data_id = standardize_address(&write_resource.address.to_string());
         if tokens_burned
@@ -290,6 +292,8 @@ impl TokenOwnershipV2 {
                     prior_nft_ownership,
                     tokens_burned,
                     conn,
+                    query_retries,
+                    query_retry_delay_ms,
                 )
                 .await;
             }
@@ -318,6 +322,8 @@ impl TokenOwnershipV2 {
             prior_nft_ownership,
             tokens_burned,
             conn,
+            query_retries,
+            query_retry_delay_ms,
         )
         .await
     }
@@ -330,6 +336,8 @@ impl TokenOwnershipV2 {
         prior_nft_ownership: &AHashMap<String, NFTOwnershipV2>,
         tokens_burned: &TokenV2Burned,
         conn: &mut PgPoolConnection<'_>,
+        query_retries: u32,
+        query_retry_delay_ms: u64,
     ) -> anyhow::Result<Option<(Self, CurrentTokenOwnershipV2)>> {
         if let Some(burn_event) = tokens_burned.get(token_address) {
             // 1. Try to lookup token address in burn event mapping

--- a/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
@@ -351,7 +351,7 @@ impl TokenOwnershipV2 {
                     None => {
                         match CurrentTokenOwnershipV2Query::get_latest_owned_nft_by_token_data_id(
                             conn,
-                            &token_address,
+                            token_address,
                             query_retries,
                             query_retry_delay_ms,
                         )

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -925,8 +925,11 @@ async fn parse_v2_token(
                                 txn_version,
                                 wsc_index,
                                 txn_timestamp,
+                                &prior_nft_ownership,
                                 &tokens_burned,
+                                conn,
                             )
+                            .await
                             .unwrap()
                         {
                             token_ownerships_v2.push(nft_ownership);

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -928,6 +928,8 @@ async fn parse_v2_token(
                                 &prior_nft_ownership,
                                 &tokens_burned,
                                 conn,
+                                query_retries,
+                                query_retry_delay_ms,
                             )
                             .await
                             .unwrap()


### PR DESCRIPTION
## Summary
This closes the loop on the messy logic that is burning NFTs: 
There could be a complete burn or a partial burn.
* In the complete burn case, we don’t have anything so we either have the previous_owner field from the new burn event, or have to do a db lookup
* In the partial burn case, we assumed (wrongly) that ObjectCore will be there.

This PR fixes the partial burn case. 

## Backfill
First burn event 
Testnet: 835574507
Mainnet: 151521169

## Testing
NFT burnt!
<img width="755" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/f79b71cb-9a45-4b9e-910e-6fd6116b07cd">
