### PR TITLE
[hotfix] fix panic where coin type is too long

### DIFF
--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -125,6 +125,7 @@ impl FungibleAssetBalance {
     }
 
     /// Getting coin balances from resources for v1
+    /// If the fully qualified coin type is too long (currently 1000 length), we exclude from indexing
     pub fn get_v1_from_write_resource(
         write_resource: &WriteResource,
         write_set_change_index: i64,


### PR DESCRIPTION
## Summary
If coin type is too long so we’re not tracking it under the new logic (> 1K length). But the lookup logic was still there so it caused some issues. 

This skips cases where the mapping isn't there. 

Also this only applies to coin v1.

## Test
No longer panics