### PR TITLE
coin_processor optimization: compile regex once

### DIFF
--- a/rust/processor/src/models/coin_models/coin_utils.rs
+++ b/rust/processor/src/models/coin_models/coin_utils.rs
@@ -163,9 +163,7 @@ pub struct CoinInfoType {
     creator_address: String,
 }
 
-static RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(<(.*)>)").unwrap()
-});
+static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(<(.*)>)").unwrap());
 
 static COIN_RESOURCES: Lazy<[String; 2]> = Lazy::new(|| {
     [

--- a/rust/processor/src/models/coin_models/coin_utils.rs
+++ b/rust/processor/src/models/coin_models/coin_utils.rs
@@ -11,6 +11,7 @@ use crate::{
 use anyhow::{Context, Result};
 use aptos_protos::transaction::v1::{move_type::Content, MoveType, WriteResource};
 use bigdecimal::BigDecimal;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -162,15 +163,24 @@ pub struct CoinInfoType {
     creator_address: String,
 }
 
+static RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(<(.*)>)").unwrap()
+});
+
+static COIN_RESOURCES: Lazy<[String; 2]> = Lazy::new(|| {
+    [
+        format!("{}::coin::CoinInfo", COIN_ADDR),
+        format!("{}::coin::CoinStore", COIN_ADDR),
+    ]
+});
+
 impl CoinInfoType {
     /// get creator address from move_type, and get coin type from move_type_str
     /// Since move_type_str will contain things we don't need, e.g. 0x1::coin::CoinInfo<T>. We will use
     /// regex to extract T.
     pub fn from_move_type(move_type: &MoveType, move_type_str: &str, txn_version: i64) -> Self {
         if let Content::Struct(struct_tag) = move_type.content.as_ref().unwrap() {
-            let re = Regex::new(r"(<(.*)>)").unwrap();
-
-            let matched = re.captures(move_type_str).unwrap_or_else(|| {
+            let matched = RE.captures(move_type_str).unwrap_or_else(|| {
                 error!(
                     txn_version = txn_version,
                     move_type_str = move_type_str,
@@ -225,11 +235,7 @@ pub enum CoinResource {
 
 impl CoinResource {
     pub fn is_resource_supported(data_type: &str) -> bool {
-        [
-            format!("{}::coin::CoinInfo", COIN_ADDR),
-            format!("{}::coin::CoinStore", COIN_ADDR),
-        ]
-        .contains(&data_type.to_string())
+        COIN_RESOURCES.contains(&data_type.to_string())
     }
 
     pub fn from_resource(


### PR DESCRIPTION
Currently, the regular expression is compiled anew with each iteration of the loop. This compilation process is resource-intensive, and there's no built-in caching mechanism. Consider utilizing lazy_static to cache the compiled result for optimization.