### PR TITLE
[EI-397] Separate fungible asset and token indexing

### DIFF
--- a/rust/processor/migrations/2024-04-18-173631_fungible_token/down.sql
+++ b/rust/processor/migrations/2024-04-18-173631_fungible_token/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE fungible_asset_metadata
+DROP COLUMN supply_v2,
+DROP COLUMN maximum_v2;

--- a/rust/processor/migrations/2024-04-18-173631_fungible_token/up.sql
+++ b/rust/processor/migrations/2024-04-18-173631_fungible_token/up.sql
@@ -2,3 +2,11 @@
 ALTER TABLE fungible_asset_metadata
 ADD COLUMN supply_v2 NUMERIC,
 ADD COLUMN maximum_v2 NUMERIC;
+
+ALTER TABLE current_token_datas_v2
+ALTER COLUMN supply DROP NOT NULL,
+ALTER COLUMN decimals DROP NOT NULL;
+
+ALTER TABLE token_datas_v2
+ALTER COLUMN supply DROP NOT NULL,
+ALTER COLUMN decimals DROP NOT NULL;

--- a/rust/processor/migrations/2024-04-18-173631_fungible_token/up.sql
+++ b/rust/processor/migrations/2024-04-18-173631_fungible_token/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+ALTER TABLE fungible_asset_metadata
+ADD COLUMN supply_v2 NUMERIC,
+ADD COLUMN maximum_v2 NUMERIC;

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
@@ -5,10 +5,7 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::{
-    v2_fungible_asset_utils::{FeeStatement, FungibleAssetEvent},
-    v2_fungible_metadata::FungibleAssetMetadataModel,
-};
+use super::v2_fungible_asset_utils::{FeeStatement, FungibleAssetEvent};
 use crate::{
     models::{
         coin_models::{
@@ -19,7 +16,7 @@ use crate::{
         token_v2_models::v2_token_utils::TokenStandard,
     },
     schema::fungible_asset_activities,
-    utils::{database::PgPoolConnection, util::standardize_address},
+    utils::util::standardize_address,
 };
 use ahash::AHashMap;
 use anyhow::Context;
@@ -70,7 +67,6 @@ impl FungibleAssetActivity {
         event_index: i64,
         entry_function_id_str: &Option<String>,
         object_aggregated_data_mapping: &ObjectAggregatedDataMapping,
-        conn: &mut PgPoolConnection<'_>,
     ) -> anyhow::Result<Option<Self>> {
         let event_type = event.type_str.clone();
         if let Some(fa_event) =
@@ -84,17 +80,6 @@ impl FungibleAssetActivity {
                 let object_core = &object_metadata.object.object_core;
                 let fungible_asset = object_metadata.fungible_asset_store.as_ref().unwrap();
                 let asset_type = fungible_asset.metadata.get_reference_address();
-                // If it's a fungible token, return early
-                if !FungibleAssetMetadataModel::is_address_fungible_asset(
-                    conn,
-                    &asset_type,
-                    object_aggregated_data_mapping,
-                    txn_version,
-                )
-                .await
-                {
-                    return Ok(None);
-                }
 
                 let (is_frozen, amount) = match fa_event {
                     FungibleAssetEvent::WithdrawEvent(inner) => (None, Some(inner.amount.clone())),

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -128,7 +128,7 @@ impl FungibleAssetMetadataModel {
                         supply_aggregator_table_handle_v1: supply_aggregator_table_handle,
                         supply_aggregator_table_key_v1: supply_aggregator_table_key,
                         token_standard: TokenStandard::V1.to_string(),
-                        is_token_v2: Some(false),
+                        is_token_v2: None,
                         supply_v2: None,
                         maximum_v2: None,
                     }))

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -63,12 +63,16 @@ impl FungibleAssetMetadataModel {
             let asset_type = standardize_address(&write_resource.address.to_string());
             if let Some(object_metadata) = object_metadatas.get(&asset_type) {
                 let object = &object_metadata.object.object_core;
-                let (mut maximum_v2, mut supply_v2) = (None, None);
                 let fungible_asset_supply = object_metadata.fungible_asset_supply.as_ref();
-                if let Some(fungible_asset_supply) = fungible_asset_supply {
-                    supply_v2 = Some(fungible_asset_supply.current.clone());
-                    maximum_v2 = fungible_asset_supply.get_maximum();
-                }
+                let (maximum_v2, supply_v2) =
+                    if let Some(fungible_asset_supply) = fungible_asset_supply {
+                        (
+                            fungible_asset_supply.get_maximum(),
+                            Some(fungible_asset_supply.current.clone()),
+                        )
+                    } else {
+                        (None, None)
+                    };
 
                 return Ok(Some(Self {
                     asset_type: asset_type.clone(),

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -13,12 +13,12 @@ use crate::{
         token_v2_models::v2_token_utils::TokenStandard,
     },
     schema::fungible_asset_metadata,
-    utils::{database::PgPoolConnection, util::standardize_address},
+    utils::util::standardize_address,
 };
 use ahash::AHashMap;
 use aptos_protos::transaction::v1::WriteResource;
+use bigdecimal::BigDecimal;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -44,26 +44,8 @@ pub struct FungibleAssetMetadataModel {
     pub supply_aggregator_table_key_v1: Option<String>,
     pub token_standard: String,
     pub is_token_v2: Option<bool>,
-}
-
-#[derive(Debug, Deserialize, Identifiable, Queryable, Serialize)]
-#[diesel(primary_key(asset_type))]
-#[diesel(table_name = fungible_asset_metadata)]
-pub struct FungibleAssetMetadataQuery {
-    pub asset_type: String,
-    pub creator_address: String,
-    pub name: String,
-    pub symbol: String,
-    pub decimals: i32,
-    pub icon_uri: Option<String>,
-    pub project_uri: Option<String>,
-    pub last_transaction_version: i64,
-    pub last_transaction_timestamp: chrono::NaiveDateTime,
-    pub supply_aggregator_table_handle_v1: Option<String>,
-    pub supply_aggregator_table_key_v1: Option<String>,
-    pub token_standard: String,
-    pub inserted_at: chrono::NaiveDateTime,
-    pub is_token_v2: Option<bool>,
+    pub supply_v2: Option<BigDecimal>,
+    pub maximum_v2: Option<BigDecimal>,
 }
 
 impl FungibleAssetMetadataModel {
@@ -81,7 +63,12 @@ impl FungibleAssetMetadataModel {
             let asset_type = standardize_address(&write_resource.address.to_string());
             if let Some(object_metadata) = object_metadatas.get(&asset_type) {
                 let object = &object_metadata.object.object_core;
-                let is_token_v2 = object_metadata.token.is_some();
+                let (mut maximum_v2, mut supply_v2) = (None, None);
+                let fungible_asset_supply = object_metadata.fungible_asset_supply.as_ref();
+                if let Some(fungible_asset_supply) = fungible_asset_supply {
+                    supply_v2 = Some(fungible_asset_supply.current.clone());
+                    maximum_v2 = fungible_asset_supply.get_maximum();
+                }
 
                 return Ok(Some(Self {
                     asset_type: asset_type.clone(),
@@ -96,7 +83,9 @@ impl FungibleAssetMetadataModel {
                     supply_aggregator_table_handle_v1: None,
                     supply_aggregator_table_key_v1: None,
                     token_standard: TokenStandard::V2.to_string(),
-                    is_token_v2: Some(is_token_v2),
+                    is_token_v2: None,
+                    supply_v2,
+                    maximum_v2,
                 }));
             }
         }
@@ -136,6 +125,8 @@ impl FungibleAssetMetadataModel {
                         supply_aggregator_table_key_v1: supply_aggregator_table_key,
                         token_standard: TokenStandard::V1.to_string(),
                         is_token_v2: Some(false),
+                        supply_v2: None,
+                        maximum_v2: None,
                     }))
                 } else {
                     Ok(None)
@@ -143,55 +134,5 @@ impl FungibleAssetMetadataModel {
             },
             _ => Ok(None),
         }
-    }
-
-    /// A fungible asset can also be a token. We will make a best effort guess at whether this is a fungible token.
-    /// 1. If metadata is present without token object, then it's not a token
-    /// 2. If metadata is not present, we will do a lookup in the db.
-    pub async fn is_address_fungible_asset(
-        conn: &mut PgPoolConnection<'_>,
-        asset_type: &str,
-        object_aggregated_data_mapping: &ObjectAggregatedDataMapping,
-        txn_version: i64,
-    ) -> bool {
-        // 1. If metadata is present without token object, then it's not a token
-        if let Some(object_data) = object_aggregated_data_mapping.get(asset_type) {
-            if object_data.fungible_asset_metadata.is_some() {
-                return object_data.token.is_none();
-            }
-        }
-        // 2. If metadata is not present, we will do a lookup in the db.
-        match FungibleAssetMetadataQuery::get_by_asset_type(conn, asset_type).await {
-            Ok(metadata) => {
-                if let Some(is_token_v2) = metadata.is_token_v2 {
-                    return !is_token_v2;
-                }
-
-                // If is_token_v2 is null, then the metadata is a v1 coin info, and it's not a token
-                true
-            },
-            Err(_) => {
-                tracing::error!(
-                    transaction_version = txn_version,
-                    lookup_key = asset_type,
-                    "Missing fungible_asset_metadata for asset_type: {}. You probably should backfill db.",
-                    asset_type,
-                );
-                // Default
-                true
-            },
-        }
-    }
-}
-
-impl FungibleAssetMetadataQuery {
-    pub async fn get_by_asset_type(
-        conn: &mut PgPoolConnection<'_>,
-        asset_type: &str,
-    ) -> diesel::QueryResult<Self> {
-        fungible_asset_metadata::table
-            .filter(fungible_asset_metadata::asset_type.eq(asset_type))
-            .first::<Self>(conn)
-            .await
     }
 }

--- a/rust/processor/src/models/object_models/v2_object_utils.rs
+++ b/rust/processor/src/models/object_models/v2_object_utils.rs
@@ -52,6 +52,32 @@ pub struct ObjectAggregatedData {
     pub token_identifier: Option<TokenIdentifiers>,
 }
 
+impl Default for ObjectAggregatedData {
+    fn default() -> Self {
+        Self {
+            object: ObjectWithMetadata {
+                object_core: ObjectCore {
+                    allow_ungated_transfer: false,
+                    guid_creation_num: BigDecimal::default(),
+                    owner: String::default(),
+                },
+                state_key_hash: String::default(),
+            },
+            transfer_events: Vec::new(),
+            fungible_asset_metadata: None,
+            fungible_asset_supply: None,
+            fungible_asset_store: None,
+            aptos_collection: None,
+            fixed_supply: None,
+            property_map: None,
+            token: None,
+            unlimited_supply: None,
+            concurrent_supply: None,
+            token_identifier: None,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ObjectCore {
     pub allow_ungated_transfer: bool,

--- a/rust/processor/src/models/token_v2_models/v2_token_activities.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_activities.rs
@@ -150,7 +150,7 @@ impl TokenActivityV2 {
                     after_value: token_activity_helper.after_value,
                     entry_function_id_str: entry_function_id_str.clone(),
                     token_standard: TokenStandard::V2.to_string(),
-                    is_fungible_v2: Some(false),
+                    is_fungible_v2: None,
                     transaction_timestamp: txn_timestamp,
                 }));
             } else {
@@ -178,7 +178,7 @@ impl TokenActivityV2 {
                     after_value: None,
                     entry_function_id_str: entry_function_id_str.clone(),
                     token_standard: TokenStandard::V2.to_string(),
-                    is_fungible_v2: Some(false),
+                    is_fungible_v2: None,
                     transaction_timestamp: txn_timestamp,
                 }));
             }

--- a/rust/processor/src/models/token_v2_models/v2_token_activities.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_activities.rs
@@ -5,18 +5,14 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::{
-    v2_token_datas::TokenDataV2,
-    v2_token_utils::{TokenStandard, V2TokenEvent},
-};
+use super::v2_token_utils::{TokenStandard, V2TokenEvent};
 use crate::{
     models::{
-        fungible_asset_models::v2_fungible_asset_utils::FungibleAssetEvent,
         object_models::v2_object_utils::ObjectAggregatedDataMapping,
         token_models::token_utils::{TokenDataIdType, TokenEvent},
     },
     schema::token_activities_v2,
-    utils::{database::PgPoolConnection, util::standardize_address},
+    utils::util::standardize_address,
 };
 use aptos_protos::transaction::v1::Event;
 use bigdecimal::{BigDecimal, One, Zero};
@@ -64,88 +60,6 @@ struct TokenActivityHelperV2 {
 }
 
 impl TokenActivityV2 {
-    /// We'll go from 0x1::fungible_asset::withdraw/deposit events.
-    /// We're guaranteed to find a 0x1::fungible_asset::FungibleStore which has a pointer to the
-    /// fungible asset metadata which could be a token. We'll either find that token in token_v2_metadata
-    /// or by looking up the postgres table.
-    /// TODO: Create artificial events for mint and burn. There are no mint and burn events so we'll have to
-    /// add all the deposits/withdrawals and if it's positive/negative it's a mint/burn.
-    pub async fn get_ft_v2_from_parsed_event(
-        event: &Event,
-        txn_version: i64,
-        txn_timestamp: chrono::NaiveDateTime,
-        event_index: i64,
-        entry_function_id_str: &Option<String>,
-        object_metadatas: &ObjectAggregatedDataMapping,
-        conn: &mut PgPoolConnection<'_>,
-    ) -> anyhow::Result<Option<Self>> {
-        let event_type = event.type_str.clone();
-        if let Some(fa_event) =
-            &FungibleAssetEvent::from_event(event_type.as_str(), &event.data, txn_version)?
-        {
-            let event_account_address =
-                standardize_address(&event.key.as_ref().unwrap().account_address);
-
-            // The event account address will also help us find fungible store which tells us where to find
-            // the metadata
-            if let Some(object_data) = object_metadatas.get(&event_account_address) {
-                let object_core = &object_data.object.object_core;
-                let fungible_asset = object_data.fungible_asset_store.as_ref().unwrap();
-                let token_data_id = fungible_asset.metadata.get_reference_address();
-                // Exit early if it's not a token
-                if !TokenDataV2::is_address_token(
-                    conn,
-                    &token_data_id,
-                    object_metadatas,
-                    txn_version,
-                )
-                .await
-                {
-                    return Ok(None);
-                }
-
-                let token_activity_helper = match fa_event {
-                    FungibleAssetEvent::WithdrawEvent(inner) => TokenActivityHelperV2 {
-                        from_address: Some(object_core.get_owner_address()),
-                        to_address: None,
-                        token_amount: inner.amount.clone(),
-                        before_value: None,
-                        after_value: None,
-                        event_type: event_type.clone(),
-                    },
-                    FungibleAssetEvent::DepositEvent(inner) => TokenActivityHelperV2 {
-                        from_address: None,
-                        to_address: Some(object_core.get_owner_address()),
-                        token_amount: inner.amount.clone(),
-                        before_value: None,
-                        after_value: None,
-                        event_type: event_type.clone(),
-                    },
-                    _ => return Ok(None),
-                };
-
-                return Ok(Some(Self {
-                    transaction_version: txn_version,
-                    event_index,
-                    event_account_address,
-                    token_data_id: token_data_id.clone(),
-                    property_version_v1: BigDecimal::zero(),
-                    type_: token_activity_helper.event_type,
-                    from_address: token_activity_helper.from_address,
-                    to_address: token_activity_helper.to_address,
-                    token_amount: token_activity_helper.token_amount,
-                    before_value: token_activity_helper.before_value,
-                    after_value: token_activity_helper.after_value,
-                    entry_function_id_str: entry_function_id_str.clone(),
-                    token_standard: TokenStandard::V2.to_string(),
-                    is_fungible_v2: Some(true),
-                    transaction_timestamp: txn_timestamp,
-                }));
-            }
-        }
-        Ok(None)
-    }
-
     pub async fn get_nft_v2_from_parsed_event(
         event: &Event,
         txn_version: i64,

--- a/rust/processor/src/models/token_v2_models/v2_token_datas.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_datas.rs
@@ -41,6 +41,7 @@ pub struct TokenDataV2 {
     pub token_standard: String,
     pub is_fungible_v2: Option<bool>,
     pub transaction_timestamp: chrono::NaiveDateTime,
+    // Deperecated, but still here for backwards compatibility
     pub decimals: Option<i64>,
 }
 
@@ -61,6 +62,7 @@ pub struct CurrentTokenDataV2 {
     pub is_fungible_v2: Option<bool>,
     pub last_transaction_version: i64,
     pub last_transaction_timestamp: chrono::NaiveDateTime,
+    // Deperecated, but still here for backwards compatibility
     pub decimals: Option<i64>,
 }
 
@@ -77,13 +79,15 @@ impl TokenDataV2 {
         if let Some(inner) = &TokenV2::from_write_resource(write_resource, txn_version)? {
             let token_data_id = standardize_address(&write_resource.address.to_string());
             let mut token_name = inner.get_name_trunc();
-            let mut is_fungible_v2 = Some(false);
+            let is_fungible_v2;
             // Get token properties from 0x4::property_map::PropertyMap
             let mut token_properties = serde_json::Value::Null;
             if let Some(object_metadata) = object_metadatas.get(&token_data_id) {
                 let fungible_asset_metadata = object_metadata.fungible_asset_metadata.as_ref();
                 if fungible_asset_metadata.is_some() {
                     is_fungible_v2 = Some(true);
+                } else {
+                    is_fungible_v2 = Some(false);
                 }
                 token_properties = object_metadata
                     .property_map
@@ -192,7 +196,7 @@ impl TokenDataV2 {
                         token_standard: TokenStandard::V1.to_string(),
                         is_fungible_v2: None,
                         transaction_timestamp: txn_timestamp,
-                        decimals: Some(0),
+                        decimals: None,
                     },
                     CurrentTokenDataV2 {
                         token_data_id,
@@ -208,7 +212,7 @@ impl TokenDataV2 {
                         is_fungible_v2: None,
                         last_transaction_version: txn_version,
                         last_transaction_timestamp: txn_timestamp,
-                        decimals: Some(0),
+                        decimals: None,
                     },
                 )));
             } else {

--- a/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
@@ -11,8 +11,6 @@ use super::{
 };
 use crate::{
     models::{
-        default_models::move_resources::MoveResource,
-        fungible_asset_models::v2_fungible_asset_utils::V2FungibleAssetResource,
         object_models::v2_object_utils::{ObjectAggregatedDataMapping, ObjectWithMetadata},
         token_models::{token_utils::TokenWriteSet, tokens::TableHandleToOwner},
         token_v2_models::v2_token_utils::DEFAULT_OWNER_ADDRESS,
@@ -115,10 +113,6 @@ impl TokenOwnershipV2 {
         Vec<Self>,
         AHashMap<CurrentTokenOwnershipV2PK, CurrentTokenOwnershipV2>,
     )> {
-        // We should be indexing v1 token or v2 fungible token here
-        if token_data.is_fungible_v2 != Some(false) {
-            return Ok((vec![], AHashMap::new()));
-        }
         let mut ownerships = vec![];
         let mut current_ownerships = AHashMap::new();
 
@@ -408,90 +402,6 @@ impl TokenOwnershipV2 {
                     non_transferrable_by_owner: None, // default
                 },
             )));
-        }
-        Ok(None)
-    }
-
-    // Getting this from 0x1::fungible_asset::FungibleStore
-    pub async fn get_ft_v2_from_write_resource(
-        write_resource: &WriteResource,
-        txn_version: i64,
-        write_set_change_index: i64,
-        txn_timestamp: chrono::NaiveDateTime,
-        object_metadatas: &ObjectAggregatedDataMapping,
-        conn: &mut PgPoolConnection<'_>,
-    ) -> anyhow::Result<Option<(Self, CurrentTokenOwnershipV2)>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
-        if !V2FungibleAssetResource::is_resource_supported(type_str.as_str()) {
-            return Ok(None);
-        }
-        let resource = MoveResource::from_write_resource(
-            write_resource,
-            0, // Placeholder, this isn't used anyway
-            txn_version,
-            0, // Placeholder, this isn't used anyway
-        );
-
-        if let V2FungibleAssetResource::FungibleAssetStore(inner) =
-            V2FungibleAssetResource::from_resource(
-                &type_str,
-                resource.data.as_ref().unwrap(),
-                txn_version,
-            )?
-        {
-            if let Some(object_data) = object_metadatas.get(&resource.address) {
-                let object_core = &object_data.object.object_core;
-                let token_data_id = inner.metadata.get_reference_address();
-                // Exit early if it's not a token
-                if !TokenDataV2::is_address_token(
-                    conn,
-                    &token_data_id,
-                    object_metadatas,
-                    txn_version,
-                )
-                .await
-                {
-                    return Ok(None);
-                }
-                let storage_id = resource.address.clone();
-                let is_soulbound = inner.frozen;
-                let amount = inner.balance;
-                let owner_address = object_core.get_owner_address();
-
-                return Ok(Some((
-                    Self {
-                        transaction_version: txn_version,
-                        write_set_change_index,
-                        token_data_id: token_data_id.clone(),
-                        property_version_v1: BigDecimal::zero(),
-                        owner_address: Some(owner_address.clone()),
-                        storage_id: storage_id.clone(),
-                        amount: amount.clone(),
-                        table_type_v1: None,
-                        token_properties_mutated_v1: None,
-                        is_soulbound_v2: Some(is_soulbound),
-                        token_standard: TokenStandard::V2.to_string(),
-                        is_fungible_v2: Some(true),
-                        transaction_timestamp: txn_timestamp,
-                        non_transferrable_by_owner: Some(is_soulbound),
-                    },
-                    CurrentTokenOwnershipV2 {
-                        token_data_id,
-                        property_version_v1: BigDecimal::zero(),
-                        owner_address,
-                        storage_id,
-                        amount,
-                        table_type_v1: None,
-                        token_properties_mutated_v1: None,
-                        is_soulbound_v2: Some(is_soulbound),
-                        token_standard: TokenStandard::V2.to_string(),
-                        is_fungible_v2: Some(true),
-                        last_transaction_version: txn_version,
-                        last_transaction_timestamp: txn_timestamp,
-                        non_transferrable_by_owner: Some(is_soulbound),
-                    },
-                )));
-            }
         }
         Ok(None)
     }

--- a/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
@@ -137,7 +137,7 @@ impl TokenOwnershipV2 {
             token_properties_mutated_v1: None,
             is_soulbound_v2: Some(is_soulbound),
             token_standard: TokenStandard::V2.to_string(),
-            is_fungible_v2: token_data.is_fungible_v2,
+            is_fungible_v2: None,
             transaction_timestamp: token_data.transaction_timestamp,
             non_transferrable_by_owner: Some(is_soulbound),
         });
@@ -158,7 +158,7 @@ impl TokenOwnershipV2 {
                 token_properties_mutated_v1: None,
                 is_soulbound_v2: Some(is_soulbound),
                 token_standard: TokenStandard::V2.to_string(),
-                is_fungible_v2: token_data.is_fungible_v2,
+                is_fungible_v2: None,
                 last_transaction_version: token_data.transaction_version,
                 last_transaction_timestamp: token_data.transaction_timestamp,
                 non_transferrable_by_owner: Some(is_soulbound),
@@ -186,7 +186,7 @@ impl TokenOwnershipV2 {
                 token_properties_mutated_v1: None,
                 is_soulbound_v2: Some(is_soulbound),
                 token_standard: TokenStandard::V2.to_string(),
-                is_fungible_v2: token_data.is_fungible_v2,
+                is_fungible_v2: None,
                 transaction_timestamp: token_data.transaction_timestamp,
                 non_transferrable_by_owner: Some(is_soulbound),
             });

--- a/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_ownerships.rs
@@ -209,7 +209,7 @@ impl TokenOwnershipV2 {
                     token_properties_mutated_v1: None,
                     is_soulbound_v2: Some(is_soulbound),
                     token_standard: TokenStandard::V2.to_string(),
-                    is_fungible_v2: token_data.is_fungible_v2,
+                    is_fungible_v2: None,
                     last_transaction_version: token_data.transaction_version,
                     last_transaction_timestamp: token_data.transaction_timestamp,
                     non_transferrable_by_owner: Some(is_soulbound),

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -159,17 +159,9 @@ fn insert_fungible_asset_metadata_query(
             .do_update()
             .set(
                 (
-                    creator_address.eq(excluded(creator_address)),
-                    name.eq(excluded(name)),
-                    symbol.eq(excluded(symbol)),
+                    supply_v2.eq(excluded(supply_v2)),
+                    maximum_v2.eq(excluded(maximum_v2)),
                     decimals.eq(excluded(decimals)),
-                    icon_uri.eq(excluded(icon_uri)),
-                    project_uri.eq(excluded(project_uri)),
-                    last_transaction_version.eq(excluded(last_transaction_version)),
-                    last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
-                    supply_aggregator_table_handle_v1.eq(excluded(supply_aggregator_table_handle_v1)),
-                    supply_aggregator_table_key_v1.eq(excluded(supply_aggregator_table_key_v1)),
-                    token_standard.eq(excluded(token_standard)),
                     inserted_at.eq(excluded(inserted_at)),
                     is_token_v2.eq(excluded(is_token_v2)),
                 )
@@ -190,11 +182,7 @@ fn insert_fungible_asset_balances_query(
         diesel::insert_into(schema::fungible_asset_balances::table)
             .values(items_to_insert)
             .on_conflict((transaction_version, write_set_change_index))
-            .do_update()
-            .set((
-                is_frozen.eq(excluded(is_frozen)),
-                inserted_at.eq(excluded(inserted_at)),
-            )),
+            .do_nothing(),
         None,
     )
 }
@@ -211,21 +199,8 @@ fn insert_current_fungible_asset_balances_query(
         diesel::insert_into(schema::current_fungible_asset_balances::table)
             .values(items_to_insert)
             .on_conflict(storage_id)
-            .do_update()
-            .set(
-                (
-                    owner_address.eq(excluded(owner_address)),
-                    asset_type.eq(excluded(asset_type)),
-                    is_primary.eq(excluded(is_primary)),
-                    is_frozen.eq(excluded(is_frozen)),
-                    amount.eq(excluded(amount)),
-                    last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
-                    last_transaction_version.eq(excluded(last_transaction_version)),
-                    token_standard.eq(excluded(token_standard)),
-                    inserted_at.eq(excluded(inserted_at)),
-                )
-            ),
-        Some(" WHERE current_fungible_asset_balances.last_transaction_version <= excluded.last_transaction_version "),
+            .do_nothing(),
+        None,
     )
 }
 

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -242,7 +242,14 @@ fn insert_token_datas_v2_query(
         diesel::insert_into(schema::token_datas_v2::table)
             .values(items_to_insert)
             .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .do_update()
+            .set((
+                maximum.eq(excluded(maximum)),
+                supply.eq(excluded(supply)),
+                is_fungible_v2.eq(excluded(is_fungible_v2)),
+                inserted_at.eq(excluded(inserted_at)),
+                decimals.eq(excluded(decimals)),
+            )),
         None,
     )
 }
@@ -259,7 +266,11 @@ fn insert_token_ownerships_v2_query(
         diesel::insert_into(schema::token_ownerships_v2::table)
             .values(items_to_insert)
             .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .do_update()
+            .set((
+                is_fungible_v2.eq(excluded(is_fungible_v2)),
+                inserted_at.eq(excluded(inserted_at)),
+            )),
         None,
     )
 }
@@ -276,24 +287,8 @@ fn insert_current_collections_v2_query(
         diesel::insert_into(schema::current_collections_v2::table)
             .values(items_to_insert)
             .on_conflict(collection_id)
-            .do_update()
-            .set((
-                creator_address.eq(excluded(creator_address)),
-                collection_name.eq(excluded(collection_name)),
-                description.eq(excluded(description)),
-                uri.eq(excluded(uri)),
-                current_supply.eq(excluded(current_supply)),
-                max_supply.eq(excluded(max_supply)),
-                total_minted_v2.eq(excluded(total_minted_v2)),
-                mutable_description.eq(excluded(mutable_description)),
-                mutable_uri.eq(excluded(mutable_uri)),
-                table_handle_v1.eq(excluded(table_handle_v1)),
-                token_standard.eq(excluded(token_standard)),
-                last_transaction_version.eq(excluded(last_transaction_version)),
-                last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
-                inserted_at.eq(excluded(inserted_at)),
-            )),
-        Some(" WHERE current_collections_v2.last_transaction_version <= excluded.last_transaction_version "),
+            .do_nothing(),
+        None,
     )
 }
 
@@ -311,18 +306,9 @@ fn insert_current_token_datas_v2_query(
             .on_conflict(token_data_id)
             .do_update()
             .set((
-                collection_id.eq(excluded(collection_id)),
-                token_name.eq(excluded(token_name)),
                 maximum.eq(excluded(maximum)),
                 supply.eq(excluded(supply)),
-                largest_property_version_v1.eq(excluded(largest_property_version_v1)),
-                token_uri.eq(excluded(token_uri)),
-                description.eq(excluded(description)),
-                token_properties.eq(excluded(token_properties)),
-                token_standard.eq(excluded(token_standard)),
                 is_fungible_v2.eq(excluded(is_fungible_v2)),
-                last_transaction_version.eq(excluded(last_transaction_version)),
-                last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
                 inserted_at.eq(excluded(inserted_at)),
                 decimals.eq(excluded(decimals)),
             )),
@@ -344,16 +330,8 @@ fn insert_current_token_ownerships_v2_query(
             .on_conflict((token_data_id, property_version_v1, owner_address, storage_id))
             .do_update()
             .set((
-                amount.eq(excluded(amount)),
-                table_type_v1.eq(excluded(table_type_v1)),
-                token_properties_mutated_v1.eq(excluded(token_properties_mutated_v1)),
-                is_soulbound_v2.eq(excluded(is_soulbound_v2)),
-                token_standard.eq(excluded(token_standard)),
                 is_fungible_v2.eq(excluded(is_fungible_v2)),
-                last_transaction_version.eq(excluded(last_transaction_version)),
-                last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
                 inserted_at.eq(excluded(inserted_at)),
-                non_transferrable_by_owner.eq(excluded(non_transferrable_by_owner)),
             )),
         Some(" WHERE current_token_ownerships_v2.last_transaction_version <= excluded.last_transaction_version "),
     )
@@ -373,9 +351,7 @@ fn insert_current_deleted_token_ownerships_v2_query(
             .on_conflict((token_data_id, property_version_v1, owner_address, storage_id))
             .do_update()
             .set((
-                amount.eq(excluded(amount)),
-                last_transaction_version.eq(excluded(last_transaction_version)),
-                last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
+                is_fungible_v2.eq(excluded(is_fungible_v2)),
                 inserted_at.eq(excluded(inserted_at)),
             )),
         Some(" WHERE current_token_ownerships_v2.last_transaction_version <= excluded.last_transaction_version "),
@@ -396,7 +372,7 @@ fn insert_token_activities_v2_query(
             .on_conflict((transaction_version, event_index))
             .do_update()
             .set((
-                entry_function_id_str.eq(excluded(entry_function_id_str)),
+                is_fungible_v2.eq(excluded(is_fungible_v2)),
                 inserted_at.eq(excluded(inserted_at)),
             )),
         None,
@@ -415,14 +391,8 @@ fn insert_current_token_v2_metadatas_query(
         diesel::insert_into(schema::current_token_v2_metadata::table)
             .values(items_to_insert)
             .on_conflict((object_address, resource_type))
-            .do_update()
-            .set((
-                data.eq(excluded(data)),
-                state_key_hash.eq(excluded(state_key_hash)),
-                last_transaction_version.eq(excluded(last_transaction_version)),
-                inserted_at.eq(excluded(inserted_at)),
-            )),
-        Some(" WHERE current_token_v2_metadata.last_transaction_version <= excluded.last_transaction_version "),
+            .do_nothing(),
+        None,
     )
 }
 

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -4,9 +4,7 @@
 use super::{ProcessingResult, ProcessorName, ProcessorTrait};
 use crate::{
     models::{
-        fungible_asset_models::v2_fungible_asset_utils::{
-            FungibleAssetMetadata, FungibleAssetStore, FungibleAssetSupply,
-        },
+        fungible_asset_models::v2_fungible_asset_utils::FungibleAssetMetadata,
         object_models::v2_object_utils::{
             ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata,
         },
@@ -604,18 +602,8 @@ async fn parse_v2_token(
                         token_v2_metadata_helper.insert(
                             standardize_address(&wr.address.to_string()),
                             ObjectAggregatedData {
-                                aptos_collection: None,
-                                fixed_supply: None,
                                 object,
-                                unlimited_supply: None,
-                                concurrent_supply: None,
-                                property_map: None,
-                                transfer_events: vec![],
-                                token: None,
-                                fungible_asset_metadata: None,
-                                fungible_asset_supply: None,
-                                fungible_asset_store: None,
-                                token_identifier: None,
+                                ..ObjectAggregatedData::default()
                             },
                         );
                     }
@@ -660,16 +648,6 @@ async fn parse_v2_token(
                             FungibleAssetMetadata::from_write_resource(wr, txn_version).unwrap()
                         {
                             aggregated_data.fungible_asset_metadata = Some(fungible_asset_metadata);
-                        }
-                        if let Some(fungible_asset_supply) =
-                            FungibleAssetSupply::from_write_resource(wr, txn_version).unwrap()
-                        {
-                            aggregated_data.fungible_asset_supply = Some(fungible_asset_supply);
-                        }
-                        if let Some(fungible_asset_store) =
-                            FungibleAssetStore::from_write_resource(wr, txn_version).unwrap()
-                        {
-                            aggregated_data.fungible_asset_store = Some(fungible_asset_store);
                         }
                         if let Some(token_identifier) =
                             TokenIdentifiers::from_write_resource(wr, txn_version).unwrap()
@@ -731,21 +709,6 @@ async fn parse_v2_token(
                     index as i64,
                     &entry_function_id_str,
                     &token_v2_metadata_helper,
-                )
-                .await
-                .unwrap()
-                {
-                    token_activities_v2.push(event);
-                }
-                // handling all the token v2 events
-                if let Some(event) = TokenActivityV2::get_ft_v2_from_parsed_event(
-                    event,
-                    txn_version,
-                    txn_timestamp,
-                    index as i64,
-                    &entry_function_id_str,
-                    &token_v2_metadata_helper,
-                    conn,
                 )
                 .await
                 .unwrap()
@@ -951,31 +914,6 @@ async fn parse_v2_token(
                                     current_nft_ownership.storage_id.clone(),
                                 ),
                                 current_nft_ownership,
-                            );
-                        }
-
-                        // Add fungible token handling
-                        if let Some((ft_ownership, current_ft_ownership)) =
-                            TokenOwnershipV2::get_ft_v2_from_write_resource(
-                                resource,
-                                txn_version,
-                                wsc_index,
-                                txn_timestamp,
-                                &token_v2_metadata_helper,
-                                conn,
-                            )
-                            .await
-                            .unwrap()
-                        {
-                            token_ownerships_v2.push(ft_ownership);
-                            current_token_ownerships_v2.insert(
-                                (
-                                    current_ft_ownership.token_data_id.clone(),
-                                    current_ft_ownership.property_version_v1.clone(),
-                                    current_ft_ownership.owner_address.clone(),
-                                    current_ft_ownership.storage_id.clone(),
-                                ),
-                                current_ft_ownership,
                             );
                         }
 

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -525,7 +525,7 @@ diesel::table! {
         #[max_length = 128]
         token_name -> Varchar,
         maximum -> Nullable<Numeric>,
-        supply -> Numeric,
+        supply -> Nullable<Numeric>,
         largest_property_version_v1 -> Nullable<Numeric>,
         #[max_length = 512]
         token_uri -> Varchar,
@@ -537,7 +537,7 @@ diesel::table! {
         last_transaction_version -> Int8,
         last_transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
-        decimals -> Int8,
+        decimals -> Nullable<Int8>,
     }
 }
 
@@ -1064,7 +1064,7 @@ diesel::table! {
         #[max_length = 128]
         token_name -> Varchar,
         maximum -> Nullable<Numeric>,
-        supply -> Numeric,
+        supply -> Nullable<Numeric>,
         largest_property_version_v1 -> Nullable<Numeric>,
         #[max_length = 512]
         token_uri -> Varchar,
@@ -1075,7 +1075,7 @@ diesel::table! {
         is_fungible_v2 -> Nullable<Bool>,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
-        decimals -> Int8,
+        decimals -> Nullable<Int8>,
     }
 }
 

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -792,6 +792,8 @@ diesel::table! {
         token_standard -> Varchar,
         inserted_at -> Timestamp,
         is_token_v2 -> Nullable<Bool>,
+        supply_v2 -> Nullable<Numeric>,
+        maximum_v2 -> Nullable<Numeric>,
     }
 }
 

--- a/test_move_script/Move.toml
+++ b/test_move_script/Move.toml
@@ -2,6 +2,9 @@
 name = 'run_script'
 version = '1.0.0'
 
+[addresses]
+test_addr = "_"
+
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
 rev = 'mainnet'

--- a/test_move_script/README.md
+++ b/test_move_script/README.md
@@ -1,14 +1,18 @@
 ## Purpose
+
 Sometimes we might need to create move transactions that simulate edge cases. For example, we noticed that mint + burn the same token in a single transaction creates problems, and to repro we'd have to submit a blockchain transaction. This is an example of how to create a script.
 
 Checkout how scripts work in: https://stackoverflow.com/questions/74627977/how-do-i-execute-a-move-script-with-the-aptos-cli.
 
-This script attempts to get the signer of the resource account and deploy code to the resource account from the admin account. 
+This script attempts to get the signer of the resource account and deploy code to the resource account from the admin account.
 
 ## How to run this code?
-`aptos move compile && aptos move run-script --compiled-script-path build/run_script/bytecode_scripts/main.mv --profile blah`
-  * If you haven't created a profile before run `aptos init --profile blah`
+
+`aptos move compile && aptos move publish --named-addresses test_addr=default && aptos move run-script --compiled-script-path build/run_script/bytecode_scripts/main.mv --profile blah`
+
+- If you haven't created a profile before run `aptos init --profile blah`
 
 ## Notes
-  * This is meant to be a template. You should build your own script.
-  * In `Move.toml`, you can change the revision for the frameworks to test new code, from `main` for example.
+
+- This is meant to be a template. You should build your own script.
+- In `Move.toml`, you can change the revision for the frameworks to test new code, from `main` for example.

--- a/test_move_script/sources/modules/managed_fungible_asset.move
+++ b/test_move_script/sources/modules/managed_fungible_asset.move
@@ -1,0 +1,419 @@
+/// This module provides a managed fungible asset that allows the owner of the metadata object to
+/// mint, transfer and burn fungible assets.
+///
+/// The functionalities offered by this module are:
+/// 1. Mint fungible assets to fungible stores as the owner of metadata object.
+/// 2. Transfer fungible assets as the owner of metadata object ignoring `frozen` field between fungible stores.
+/// 3. Burn fungible assets from fungible stores as the owner of metadata object.
+/// 4. Withdraw the merged fungible assets from fungible stores as the owner of metadata object.
+/// 5. Deposit fungible assets to fungible stores.
+module test_addr::managed_fungible_asset {
+    use aptos_framework::fungible_asset::{Self, MintRef, TransferRef, BurnRef, Metadata, FungibleStore, FungibleAsset};
+    use aptos_framework::object::{Self, Object, ConstructorRef};
+    use aptos_framework::primary_fungible_store;
+    use std::error;
+    use std::signer;
+    use std::string::String;
+    use std::option;
+
+    /// Only fungible asset metadata owner can make changes.
+    const ERR_NOT_OWNER: u64 = 1;
+    /// The length of ref_flags is not 3.
+    const ERR_INVALID_REF_FLAGS_LENGTH: u64 = 2;
+    /// The lengths of two vector do not equal.
+    const ERR_VECTORS_LENGTH_MISMATCH: u64 = 3;
+    /// MintRef error.
+    const ERR_MINT_REF: u64 = 4;
+    /// TransferRef error.
+    const ERR_TRANSFER_REF: u64 = 5;
+    /// BurnRef error.
+    const ERR_BURN_REF: u64 = 6;
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Hold refs to control the minting, transfer and burning of fungible assets.
+    struct ManagingRefs has key {
+        mint_ref: Option<MintRef>,
+        transfer_ref: Option<TransferRef>,
+        burn_ref: Option<BurnRef>,
+    }
+
+    /// Initialize metadata object and store the refs specified by `ref_flags`.
+    public fun initialize(
+        constructor_ref: &ConstructorRef,
+        maximum_supply: u128,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        icon_uri: String,
+        project_uri: String,
+        ref_flags: vector<bool>,
+    ) {
+        assert!(vector::length(&ref_flags) == 3, error::invalid_argument(ERR_INVALID_REF_FLAGS_LENGTH));
+        let supply = if (maximum_supply != 0) {
+            option::some(maximum_supply)
+        } else {
+            option::none()
+        };
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            constructor_ref,
+            supply,
+            name,
+            symbol,
+            decimals,
+            icon_uri,
+            project_uri,
+        );
+
+        // Optionally create mint/burn/transfer refs to allow creator to manage the fungible asset.
+        let mint_ref = if (*vector::borrow(&ref_flags, 0)) {
+            option::some(fungible_asset::generate_mint_ref(constructor_ref))
+        } else {
+            option::none()
+        };
+        let transfer_ref = if (*vector::borrow(&ref_flags, 1)) {
+            option::some(fungible_asset::generate_transfer_ref(constructor_ref))
+        } else {
+            option::none()
+        };
+        let burn_ref = if (*vector::borrow(&ref_flags, 2)) {
+            option::some(fungible_asset::generate_burn_ref(constructor_ref))
+        } else {
+            option::none()
+        };
+        let metadata_object_signer = object::generate_signer(constructor_ref);
+        move_to(
+            &metadata_object_signer,
+            ManagingRefs { mint_ref, transfer_ref, burn_ref }
+        )
+    }
+
+    /// Mint as the owner of metadata object to the primary fungible stores of the accounts with amounts of FAs.
+    public entry fun mint_to_primary_stores(
+        admin: &signer,
+        asset: Object<Metadata>,
+        to: vector<address>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let receiver_primary_stores = vector::map(
+            to,
+            |addr| primary_fungible_store::ensure_primary_store_exists(addr, asset)
+        );
+        mint(admin, asset, receiver_primary_stores, amounts);
+    }
+
+
+    /// Mint as the owner of metadata object to multiple fungible stores with amounts of FAs.
+    public entry fun mint(
+        admin: &signer,
+        asset: Object<Metadata>,
+        stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>,
+    ) acquires ManagingRefs {
+        let length = vector::length(&stores);
+        assert!(length == vector::length(&amounts), error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH));
+        let mint_ref = authorized_borrow_mint_ref(admin, asset);
+        let i = 0;
+        while (i < length) {
+            fungible_asset::mint_to(mint_ref, *vector::borrow(&stores, i), *vector::borrow(&amounts, i));
+            i = i + 1;
+        }
+    }
+
+    /// Transfer as the owner of metadata object ignoring `frozen` field from primary stores to primary stores of
+    /// accounts.
+    public entry fun transfer_between_primary_stores(
+        admin: &signer,
+        asset: Object<Metadata>,
+        from: vector<address>,
+        to: vector<address>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let sender_primary_stores = vector::map(
+            from,
+            |addr| primary_fungible_store::primary_store(addr, asset)
+        );
+        let receiver_primary_stores = vector::map(
+            to,
+            |addr| primary_fungible_store::ensure_primary_store_exists(addr, asset)
+        );
+        transfer(admin, asset, sender_primary_stores, receiver_primary_stores, amounts);
+    }
+
+    /// Transfer as the owner of metadata object ignoring `frozen` field between fungible stores.
+    public entry fun transfer(
+        admin: &signer,
+        asset: Object<Metadata>,
+        sender_stores: vector<Object<FungibleStore>>,
+        receiver_stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>,
+    ) acquires ManagingRefs {
+        let length = vector::length(&sender_stores);
+        assert!(length == vector::length(&receiver_stores), error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH));
+        assert!(length == vector::length(&amounts), error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH));
+        let transfer_ref = authorized_borrow_transfer_ref(admin, asset);
+        let i = 0;
+        while (i < length) {
+            fungible_asset::transfer_with_ref(
+                transfer_ref,
+                *vector::borrow(&sender_stores, i),
+                *vector::borrow(&receiver_stores, i),
+                *vector::borrow(&amounts, i)
+            );
+            i = i + 1;
+        }
+    }
+
+    /// Burn fungible assets as the owner of metadata object from the primary stores of accounts.
+    public entry fun burn_from_primary_stores(
+        admin: &signer,
+        asset: Object<Metadata>,
+        from: vector<address>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let primary_stores = vector::map(
+            from,
+            |addr| primary_fungible_store::primary_store(addr, asset)
+        );
+        burn(admin, asset, primary_stores, amounts);
+    }
+
+    /// Burn fungible assets as the owner of metadata object from fungible stores.
+    public entry fun burn(
+        admin: &signer,
+        asset: Object<Metadata>,
+        stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let length = vector::length(&stores);
+        assert!(length == vector::length(&amounts), error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH));
+        let burn_ref = authorized_borrow_burn_ref(admin, asset);
+        let i = 0;
+        while (i < length) {
+            fungible_asset::burn_from(burn_ref, *vector::borrow(&stores, i), *vector::borrow(&amounts, i));
+            i = i + 1;
+        };
+    }
+
+
+    /// Freeze/unfreeze the primary stores of accounts so they cannot transfer or receive fungible assets.
+    public entry fun set_primary_stores_frozen_status(
+        admin: &signer,
+        asset: Object<Metadata>,
+        accounts: vector<address>,
+        frozen: bool
+    ) acquires ManagingRefs {
+        let primary_stores = vector::map(accounts, |acct| {
+            primary_fungible_store::ensure_primary_store_exists(acct, asset)
+        });
+        set_frozen_status(admin, asset, primary_stores, frozen);
+    }
+
+    /// Freeze/unfreeze the fungible stores so they cannot transfer or receive fungible assets.
+    public entry fun set_frozen_status(
+        admin: &signer,
+        asset: Object<Metadata>,
+        stores: vector<Object<FungibleStore>>,
+        frozen: bool
+    ) acquires ManagingRefs {
+        let transfer_ref = authorized_borrow_transfer_ref(admin, asset);
+        vector::for_each(stores, |store| {
+            fungible_asset::set_frozen_flag(transfer_ref, store, frozen);
+        });
+    }
+
+    /// Withdraw as the owner of metadata object ignoring `frozen` field from primary fungible stores of accounts.
+    public fun withdraw_from_primary_stores(
+        admin: &signer,
+        asset: Object<Metadata>,
+        from: vector<address>,
+        amounts: vector<u64>
+    ): FungibleAsset acquires ManagingRefs {
+        let primary_stores = vector::map(
+            from,
+            |addr| primary_fungible_store::primary_store(addr, asset)
+        );
+        withdraw(admin, asset, primary_stores, amounts)
+    }
+
+    /// Withdraw as the owner of metadata object ignoring `frozen` field from fungible stores.
+    /// return a fungible asset `fa` where `fa.amount = sum(amounts)`.
+    public fun withdraw(
+        admin: &signer,
+        asset: Object<Metadata>,
+        stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>
+    ): FungibleAsset acquires ManagingRefs {
+        let length = vector::length(&stores);
+        assert!(length == vector::length(&amounts), error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH));
+        let transfer_ref = authorized_borrow_transfer_ref(admin, asset);
+        let i = 0;
+        let sum = fungible_asset::zero(asset);
+        while (i < length) {
+            let fa = fungible_asset::withdraw_with_ref(
+                transfer_ref,
+                *vector::borrow(&stores, i),
+                *vector::borrow(&amounts, i)
+            );
+            fungible_asset::merge(&mut sum, fa);
+            i = i + 1;
+        };
+        sum
+    }
+
+    /// Deposit as the owner of metadata object ignoring `frozen` field to primary fungible stores of accounts from a
+    /// single source of fungible asset.
+    public fun deposit_to_primary_stores(
+        admin: &signer,
+        fa: &mut FungibleAsset,
+        from: vector<address>,
+        amounts: vector<u64>,
+    ) acquires ManagingRefs {
+        let primary_stores = vector::map(
+            from,
+            |addr| primary_fungible_store::ensure_primary_store_exists(addr, fungible_asset::asset_metadata(fa))
+        );
+        deposit(admin, fa, primary_stores, amounts);
+    }
+
+    /// Deposit as the owner of metadata object ignoring `frozen` field from fungible stores. The amount left in `fa`
+    /// is `fa.amount - sum(amounts)`.
+    public fun deposit(
+        admin: &signer,
+        fa: &mut FungibleAsset,
+        stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let length = vector::length(&stores);
+        assert!(length == vector::length(&amounts), error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH));
+        let transfer_ref = authorized_borrow_transfer_ref(admin, fungible_asset::asset_metadata(fa));
+        let i = 0;
+        while (i < length) {
+            let split_fa = fungible_asset::extract(fa, *vector::borrow(&amounts, i));
+            fungible_asset::deposit_with_ref(
+                transfer_ref,
+                *vector::borrow(&stores, i),
+                split_fa,
+            );
+            i = i + 1;
+        };
+    }
+
+    /// Borrow the immutable reference of the refs of `metadata`.
+    /// This validates that the signer is the metadata object's owner.
+    inline fun authorized_borrow_refs(
+        owner: &signer,
+        asset: Object<Metadata>,
+    ): &ManagingRefs acquires ManagingRefs {
+        assert!(object::is_owner(asset, signer::address_of(owner)), error::permission_denied(ERR_NOT_OWNER));
+        borrow_global<ManagingRefs>(object::object_address(&asset))
+    }
+
+    /// Check the existence and borrow `MintRef`.
+    inline fun authorized_borrow_mint_ref(
+        owner: &signer,
+        asset: Object<Metadata>,
+    ): &MintRef acquires ManagingRefs {
+        let refs = authorized_borrow_refs(owner, asset);
+        assert!(option::is_some(&refs.mint_ref), error::not_found(ERR_MINT_REF));
+        option::borrow(&refs.mint_ref)
+    }
+
+    /// Check the existence and borrow `TransferRef`.
+    inline fun authorized_borrow_transfer_ref(
+        owner: &signer,
+        asset: Object<Metadata>,
+    ): &TransferRef acquires ManagingRefs {
+        let refs = authorized_borrow_refs(owner, asset);
+        assert!(option::is_some(&refs.transfer_ref), error::not_found(ERR_TRANSFER_REF));
+        option::borrow(&refs.transfer_ref)
+    }
+
+    /// Check the existence and borrow `BurnRef`.
+    inline fun authorized_borrow_burn_ref(
+        owner: &signer,
+        asset: Object<Metadata>,
+    ): &BurnRef acquires ManagingRefs {
+        let refs = authorized_borrow_refs(owner, asset);
+        assert!(option::is_some(&refs.mint_ref), error::not_found(ERR_BURN_REF));
+        option::borrow(&refs.burn_ref)
+    }
+
+    #[test_only]
+    use aptos_framework::object::object_from_constructor_ref;
+    #[test_only]
+    use std::string::utf8;
+    use std::vector;
+    use std::option::Option;
+
+    #[test_only]
+    fun create_test_mfa(creator: &signer): Object<Metadata> {
+        let constructor_ref = &object::create_named_object(creator, b"APT");
+        initialize(
+            constructor_ref,
+            0,
+            utf8(b"Aptos Token"), /* name */
+            utf8(b"APT"), /* symbol */
+            8, /* decimals */
+            utf8(b"http://example.com/favicon.ico"), /* icon */
+            utf8(b"http://example.com"), /* project */
+            vector[true, true, true]
+        );
+        object_from_constructor_ref<Metadata>(constructor_ref)
+    }
+
+    #[test(creator = @example_addr)]
+    fun test_basic_flow(
+        creator: &signer,
+    ) acquires ManagingRefs {
+        let metadata = create_test_mfa(creator);
+        let creator_address = signer::address_of(creator);
+        let aaron_address = @0xface;
+
+        mint_to_primary_stores(creator, metadata, vector[creator_address, aaron_address], vector[100, 50]);
+        assert!(primary_fungible_store::balance(creator_address, metadata) == 100, 1);
+        assert!(primary_fungible_store::balance(aaron_address, metadata) == 50, 2);
+
+        set_primary_stores_frozen_status(creator, metadata, vector[creator_address, aaron_address], true);
+        assert!(primary_fungible_store::is_frozen(creator_address, metadata), 3);
+        assert!(primary_fungible_store::is_frozen(aaron_address, metadata), 4);
+
+        transfer_between_primary_stores(
+            creator,
+            metadata,
+            vector[creator_address, aaron_address],
+            vector[aaron_address, creator_address],
+            vector[10, 5]
+        );
+        assert!(primary_fungible_store::balance(creator_address, metadata) == 95, 5);
+        assert!(primary_fungible_store::balance(aaron_address, metadata) == 55, 6);
+
+        set_primary_stores_frozen_status(creator, metadata, vector[creator_address, aaron_address], false);
+        assert!(!primary_fungible_store::is_frozen(creator_address, metadata), 7);
+        assert!(!primary_fungible_store::is_frozen(aaron_address, metadata), 8);
+
+        let fa = withdraw_from_primary_stores(
+            creator,
+            metadata,
+            vector[creator_address, aaron_address],
+            vector[25, 15]
+        );
+        assert!(fungible_asset::amount(&fa) == 40, 9);
+        deposit_to_primary_stores(creator, &mut fa, vector[creator_address, aaron_address], vector[30, 10]);
+        fungible_asset::destroy_zero(fa);
+
+        burn_from_primary_stores(creator, metadata, vector[creator_address, aaron_address], vector[100, 50]);
+        assert!(primary_fungible_store::balance(creator_address, metadata) == 0, 10);
+        assert!(primary_fungible_store::balance(aaron_address, metadata) == 0, 11);
+    }
+
+    #[test(creator = @example_addr, aaron = @0xface)]
+    #[expected_failure(abort_code = 0x50001, location = Self)]
+    fun test_permission_denied(
+        creator: &signer,
+        aaron: &signer
+    ) acquires ManagingRefs {
+        let metadata = create_test_mfa(creator);
+        let creator_address = signer::address_of(creator);
+        mint_to_primary_stores(aaron, metadata, vector[creator_address], vector[100]);
+    }
+}

--- a/test_move_script/sources/run_script.move
+++ b/test_move_script/sources/run_script.move
@@ -13,30 +13,30 @@ script {
 
     const S: vector<u8> = b"TEST2";
 
-  fun main(deployer: &signer) {
-    collection::create_unlimited_collection(
-      deployer,
-      utf8(S),
-      utf8(S),
-      option::none(),
-      utf8(S),
-    );
-    let constructor_ref = token::create_named_token(
-        deployer,
-        utf8(S),
-        utf8(S),
-        utf8(S),
-        option::none(),
-        utf8(S),
-    );
-    let transfer_ref = object::generate_transfer_ref(&constructor_ref);
-    let linear_transfer_ref = object::generate_linear_transfer_ref(&transfer_ref);
-    object::transfer_with_ref(linear_transfer_ref, @0xcafe);
-    let linear_transfer_ref = object::generate_linear_transfer_ref(&transfer_ref);
-    object::transfer_with_ref(linear_transfer_ref, @0xcafe2);
-    // Disabling transfer ref after transferring
-    object::disable_ungated_transfer(&transfer_ref);
-    let burn_ref = token::generate_burn_ref(&constructor_ref);
-    token::burn(burn_ref);
-  }
+    fun main(deployer: &signer) {
+        collection::create_unlimited_collection(
+            deployer,
+            utf8(S),
+            utf8(S),
+            option::none(),
+            utf8(S),
+        );
+        let constructor_ref = token::create_named_token(
+            deployer,
+            utf8(S),
+            utf8(S),
+            utf8(S),
+            option::none(),
+            utf8(S),
+        );
+        let transfer_ref = object::generate_transfer_ref(&constructor_ref);
+        let linear_transfer_ref = object::generate_linear_transfer_ref(&transfer_ref);
+        object::transfer_with_ref(linear_transfer_ref, @0xcafe);
+        let linear_transfer_ref = object::generate_linear_transfer_ref(&transfer_ref);
+        object::transfer_with_ref(linear_transfer_ref, @0xcafe2);
+        // Disabling transfer ref after transferring
+        object::disable_ungated_transfer(&transfer_ref);
+        let burn_ref = token::generate_burn_ref(&constructor_ref);
+        token::burn(burn_ref);
+    }
 }

--- a/test_move_script/sources/scripts/burn_fungible_token.move
+++ b/test_move_script/sources/scripts/burn_fungible_token.move
@@ -1,0 +1,23 @@
+script {
+    use std::signer;
+    use std::string::utf8;
+
+    use aptos_framework::fungible_asset::{Metadata};
+    use aptos_framework::object::{Self};
+    use aptos_token_objects::token;
+    use test_addr::managed_fungible_asset::{Self};
+
+    const FT: vector<u8> = b"FT2";
+
+    fun burn_ft(deployer: &signer) {
+        let deployer_address = signer::address_of(deployer);
+        let token_address = token::create_token_address(&deployer_address, &utf8(FT), &utf8(FT));
+        let metadata = object::address_to_object<Metadata>(token_address);
+        managed_fungible_asset::burn_from_primary_stores(
+            deployer,
+            metadata,
+            vector[deployer_address],
+            vector[100],
+        );
+    }
+}

--- a/test_move_script/sources/scripts/fungible_token.move
+++ b/test_move_script/sources/scripts/fungible_token.move
@@ -1,0 +1,52 @@
+script {
+    use std::signer;
+    use std::string::utf8;
+    use std::option;
+
+    use aptos_framework::fungible_asset::{Metadata};
+    use aptos_framework::object::object_from_constructor_ref;
+    use aptos_token_objects::collection;
+    use aptos_token_objects::token;
+    use test_addr::managed_fungible_asset::{Self};
+
+    const FT: vector<u8> = b"FT2";
+
+    fun create_ft(deployer: &signer) {
+        // Create token part
+        collection::create_unlimited_collection(
+            deployer,
+            utf8(FT),
+            utf8(FT),
+            option::none(),
+            utf8(FT),
+        );
+        let constructor_ref = &token::create_named_token(
+            deployer,
+            utf8(FT),
+            utf8(FT),
+            utf8(FT),
+            option::none(),
+            utf8(FT),
+        );
+
+        // Create fungible asset part
+        managed_fungible_asset::initialize(
+            constructor_ref,
+            0, /* maximum_supply */
+            utf8(FT),
+            utf8(FT),
+            8, /* decimals */
+            utf8(b"http://example.com/favicon.ico"), /* icon */
+            utf8(b"http://example.com"), /* project */
+            vector[true, true, true], /* ref_flags */
+        );
+        let metadata = object_from_constructor_ref<Metadata>(constructor_ref);
+        let deployer_addr = signer::address_of(deployer);
+        managed_fungible_asset::mint_to_primary_stores(
+            deployer,
+            metadata,
+            vector[deployer_addr, @0xcafe],
+            vector[200000000, 100000000],
+        );
+    }
+}

--- a/test_move_script/sources/scripts/transfer_fungible_token.move
+++ b/test_move_script/sources/scripts/transfer_fungible_token.move
@@ -1,0 +1,24 @@
+script {
+    use std::signer;
+    use std::string::utf8;
+
+    use aptos_framework::fungible_asset::{Metadata};
+    use aptos_framework::object::{Self};
+    use aptos_token_objects::token;
+    use test_addr::managed_fungible_asset::{Self};
+
+    const FT: vector<u8> = b"FT2";
+
+    fun transfer_ft(deployer: &signer) {
+        let deployer_address = signer::address_of(deployer);
+        let token_address = token::create_token_address(&deployer_address, &utf8(FT), &utf8(FT));
+        let metadata = object::address_to_object<Metadata>(token_address);
+        managed_fungible_asset::transfer_between_primary_stores(
+            deployer, 
+            metadata, 
+            vector[deployer_address],
+            vector[@0xdead],
+            vector[100000000],
+        );
+    }
+}


### PR DESCRIPTION
## Description
Index fungible assets and tokens independently, to better reflect the composable nature of the object model on chain
1. Add fungible-related columns `maximum_v2` and `supply_v2` to `fungible_asset_metadata` (copied from `current_token_datas_v2` )
    1. For coins, these fields will be null
2. Set to null fungible-related columns `maximum`, `supply`, `decimals` from `token_datas_v2`
    1. The only place that tracks fungibility of a token will be in `current_token_datas_v2.is_fungible_v2`
3. Set to null these columns since we can use a join to get the same information. 
    - `fungible_asset_metadata.is_token_v2`
    - `token_activities_v2.is_fungible_v2`
    - `current_token_ownerships_v2.is_fungible_v2`
    - `token_ownerships_v2.is_fungible_v2`

Proposal: https://www.notion.so/aptoslabs/Indexer-Remove-DB-Lookups-16b8fc8c19fb4c79900e7dc35b0da9ef?d=210b8f48ab3c45fcbc971440836096fd#8dd1c16eebd440a6809b795a8041b1a8

## Test plan
Run move scripts to create token mint, transfer, burn txn's. Run token_v2_processor and fungile_asset_processor on the txn's.

### Mint fungible token 
https://explorer.aptoslabs.com/txn/1033408820/userTxnOverview?network=testnet
#### Token tables 
<img width="1327" alt="Screenshot 2024-04-25 at 11 10 40 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/2afa543b-38a6-4ef1-b202-b4c217df139e">
<img width="1242" alt="Screenshot 2024-04-25 at 11 10 05 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/d3c1d0e1-d4d3-4b37-a520-5e6ef36b2815">
<img width="1328" alt="Screenshot 2024-04-25 at 10 59 58 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/c5b3adb4-1988-448e-9d9f-a35a35ec7d42">
<img width="1333" alt="Screenshot 2024-04-25 at 10 59 37 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/44d1dd97-0a21-452d-8919-bafd14f64c4a">

#### Fungible asset tables 
<img width="1324" alt="Screenshot 2024-04-25 at 11 14 51 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/644740ad-1894-472d-8c63-6d29981391f6">
<img width="1197" alt="Screenshot 2024-04-25 at 11 14 19 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/df59a335-ed8d-4659-92ea-0a8305c21435">
<img width="1330" alt="Screenshot 2024-04-25 at 11 13 07 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/b94d3195-dab8-40cb-8bca-f624f066091f">

#### Joins
<img width="1250" alt="Screenshot 2024-04-25 at 11 21 11 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/5eab6d84-94d0-4323-9a68-a93325ab42d5">


### Transfer fungible token 
https://explorer.aptoslabs.com/txn/1033409449?network=testnet
Token tables had no change. 

#### Fungible asset tables
FA balance changed. 
<img width="1331" alt="Screenshot 2024-04-25 at 11 25 29 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/e910bd83-62f4-4981-9a8f-a40b2a2cacb9">
<img width="1334" alt="Screenshot 2024-04-25 at 11 25 23 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/4f5c28ad-54f3-47ef-afef-e31039b07c0e">

#### Joins
<img width="1260" alt="Screenshot 2024-04-25 at 11 26 02 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/fdf715cb-d8b3-4138-92e2-3f2bfe5346aa">


### Burn fungible asset
https://explorer.aptoslabs.com/txn/1033409890?network=testnet
Token tables had no change. 

#### Fungible asset tables
FA balance changed. 
<img width="1327" alt="Screenshot 2024-04-25 at 11 28 28 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/3521c174-c273-4c60-bc00-178ba17cee3d">
<img width="1326" alt="Screenshot 2024-04-25 at 11 28 16 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/ea1f1f80-87f9-4526-a839-890acef420c3">


#### Joins
<img width="1257" alt="Screenshot 2024-04-25 at 11 29 05 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/2f41a27e-18fb-477e-ab67-62528a336b3f">
