### PR TITLE
[event_v2] indexer logic update to handle migration 

### DIFF
--- a/python/processors/nft_orderbooks/parsers/okx_parser.py
+++ b/python/processors/nft_orderbooks/parsers/okx_parser.py
@@ -19,6 +19,8 @@ OKX_MARKETPLACE_EVENT_TYPES = set(
         "okx_listing_utils::CancelListingEvent",
     ]
 )
+DEPOSITE_EVENT_V1 = "0x3::token::DepositEvent"
+DEPOSITE_EVENT_V2 = "0x3::token::Deposit"
 
 
 def parse_marketplace_events(
@@ -141,8 +143,15 @@ def parse_marketplace_events(
 def get_token_data_from_deposit_events(user_transaction) -> Dict[str, TokenDataIdType]:
     # Extract deposit events, which contain token metadata
     deposit_events: Dict[str, TokenDataIdType] = {}
-    for event in user_transaction.events:
-        if event.type_str != "0x3::token::DepositEvent":
+    for idx, event in enumerate(user_transaction.events):
+        if event.type_str != DEPOSITE_EVENT_V1 and event.type_str != DEPOSITE_EVENT_V2:
+            continue
+        # Current event is either DEPOSITE_EVENT_V1 or DEPOSITE_EVENT_V2.
+        if (
+            idx > 0
+            # skip if prior event is V2 deposit event.
+            and user_transaction.events[idx - 1].type_str == DEPOSITE_EVENT_V2
+        ):
             continue
         account_address = standardize_address(event_utils.get_account_address(event))
         data = json.loads(event.data)

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
@@ -72,7 +72,38 @@ impl FungibleAssetActivity {
         if let Some(fa_event) =
             &FungibleAssetEvent::from_event(event_type.as_str(), &event.data, txn_version)?
         {
-            let storage_id = standardize_address(&event.key.as_ref().unwrap().account_address);
+            let (storage_id, is_frozen, amount) = match fa_event {
+                FungibleAssetEvent::WithdrawEvent(inner) => (
+                    standardize_address(&event.key.as_ref().unwrap().account_address),
+                    None,
+                    Some(inner.amount.clone()),
+                ),
+                FungibleAssetEvent::DepositEvent(inner) => (
+                    standardize_address(&event.key.as_ref().unwrap().account_address),
+                    None,
+                    Some(inner.amount.clone()),
+                ),
+                FungibleAssetEvent::FrozenEvent(inner) => (
+                    standardize_address(&event.key.as_ref().unwrap().account_address),
+                    Some(inner.frozen),
+                    None,
+                ),
+                FungibleAssetEvent::WithdrawEventV2(inner) => (
+                    inner.store.get_reference_address(),
+                    None,
+                    Some(inner.amount.clone()),
+                ),
+                FungibleAssetEvent::DepositEventV2(inner) => (
+                    inner.store.get_reference_address(),
+                    None,
+                    Some(inner.amount.clone()),
+                ),
+                FungibleAssetEvent::FrozenEventV2(inner) => (
+                    inner.store.get_reference_address(),
+                    Some(inner.frozen),
+                    None,
+                ),
+            };
 
             // The event account address will also help us find fungible store which tells us where to find
             // the metadata
@@ -80,12 +111,6 @@ impl FungibleAssetActivity {
                 let object_core = &object_metadata.object.object_core;
                 let fungible_asset = object_metadata.fungible_asset_store.as_ref().unwrap();
                 let asset_type = fungible_asset.metadata.get_reference_address();
-
-                let (is_frozen, amount) = match fa_event {
-                    FungibleAssetEvent::WithdrawEvent(inner) => (None, Some(inner.amount.clone())),
-                    FungibleAssetEvent::DepositEvent(inner) => (None, Some(inner.amount.clone())),
-                    FungibleAssetEvent::FrozenEvent(inner) => (Some(inner.frozen), None),
-                };
 
                 return Ok(Some(Self {
                     transaction_version: txn_version,
@@ -119,36 +144,54 @@ impl FungibleAssetActivity {
         event_to_coin_type: &EventToCoinType,
         event_index: i64,
     ) -> anyhow::Result<Option<Self>> {
-        if let Some(inner) =
+        if let Some((inner, coin_type_option)) =
             CoinEvent::from_event(event.type_str.as_str(), &event.data, txn_version)?
         {
-            let amount = match inner {
-                CoinEvent::WithdrawCoinEvent(inner) => inner.amount,
-                CoinEvent::DepositCoinEvent(inner) => inner.amount,
+            let (owner_address, amount) = match inner {
+                CoinEvent::WithdrawCoinEvent(inner) => (
+                    standardize_address(&event.key.as_ref().unwrap().account_address),
+                    inner.amount.clone(),
+                ),
+                CoinEvent::DepositCoinEvent(inner) => (
+                    standardize_address(&event.key.as_ref().unwrap().account_address),
+                    inner.amount.clone(),
+                ),
+                CoinEvent::WithdrawCoinEventV2(inner) => {
+                    (standardize_address(&inner.account), inner.amount.clone())
+                },
+                CoinEvent::DepositCoinEventV2(inner) => {
+                    (standardize_address(&inner.account), inner.amount.clone())
+                },
             };
-            let event_key = event.key.as_ref().context("event must have a key")?;
-            let event_move_guid = EventGuidResource {
-                addr: standardize_address(event_key.account_address.as_str()),
-                creation_num: event_key.creation_number as i64,
-            };
-            // Given this mapping only contains coin type < 1000 length, we should not assume that the mapping exists.
-            // If it doesn't exist, skip.
-            let coin_type = match event_to_coin_type.get(&event_move_guid) {
-                Some(coin_type) => coin_type.clone(),
-                None => {
-                    tracing::warn!(
+            let coin_type = if let Some(coin_type) = coin_type_option {
+                coin_type
+            } else {
+                let event_key = event.key.as_ref().context("event must have a key")?;
+                let event_move_guid = EventGuidResource {
+                    addr: standardize_address(event_key.account_address.as_str()),
+                    creation_num: event_key.creation_number as i64,
+                };
+                // Given this mapping only contains coin type < 1000 length, we should not assume that the mapping exists.
+                // If it doesn't exist, skip.
+                match event_to_coin_type.get(&event_move_guid) {
+                    Some(coin_type) => coin_type.clone(),
+                    None => {
+                        tracing::warn!(
                         "Could not find event in resources (CoinStore), version: {}, event guid: {:?}, mapping: {:?}",
                         txn_version, event_move_guid, event_to_coin_type
                     );
-                    return Ok(None);
-                },
+                        return Ok(None);
+                    },
+                }
             };
+
             let storage_id =
-                CoinInfoType::get_storage_id(coin_type.as_str(), event_move_guid.addr.as_str());
+                CoinInfoType::get_storage_id(coin_type.as_str(), owner_address.as_str());
+
             Ok(Some(Self {
                 transaction_version: txn_version,
                 event_index,
-                owner_address: event_move_guid.addr,
+                owner_address,
                 storage_id,
                 asset_type: coin_type,
                 is_frozen: None,

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_activities.rs
@@ -89,20 +89,18 @@ impl FungibleAssetActivity {
                     None,
                 ),
                 FungibleAssetEvent::WithdrawEventV2(inner) => (
-                    inner.store.get_reference_address(),
+                    standardize_address(&inner.store),
                     None,
                     Some(inner.amount.clone()),
                 ),
                 FungibleAssetEvent::DepositEventV2(inner) => (
-                    inner.store.get_reference_address(),
+                    standardize_address(&inner.store),
                     None,
                     Some(inner.amount.clone()),
                 ),
-                FungibleAssetEvent::FrozenEventV2(inner) => (
-                    inner.store.get_reference_address(),
-                    Some(inner.frozen),
-                    None,
-                ),
+                FungibleAssetEvent::FrozenEventV2(inner) => {
+                    (standardize_address(&inner.store), Some(inner.frozen), None)
+                },
             };
 
             // The event account address will also help us find fungible store which tells us where to find

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_utils.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_utils.rs
@@ -206,21 +206,21 @@ pub struct FrozenEvent {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DepositEventV2 {
-    pub store: ResourceReference,
+    pub store: String,
     #[serde(deserialize_with = "deserialize_from_string")]
     pub amount: BigDecimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct WithdrawEventV2 {
-    pub store: ResourceReference,
+    pub store: String,
     #[serde(deserialize_with = "deserialize_from_string")]
     pub amount: BigDecimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FrozenEventV2 {
-    pub store: ResourceReference,
+    pub store: String,
     pub frozen: bool,
 }
 

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_utils.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_utils.rs
@@ -205,6 +205,26 @@ pub struct FrozenEvent {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DepositEventV2 {
+    pub store: ResourceReference,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WithdrawEventV2 {
+    pub store: ResourceReference,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FrozenEventV2 {
+    pub store: ResourceReference,
+    pub frozen: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum V2FungibleAssetResource {
     FungibleAssetMetadata(FungibleAssetMetadata),
     FungibleAssetStore(FungibleAssetStore),
@@ -256,6 +276,9 @@ pub enum FungibleAssetEvent {
     DepositEvent(DepositEvent),
     WithdrawEvent(WithdrawEvent),
     FrozenEvent(FrozenEvent),
+    DepositEventV2(DepositEventV2),
+    WithdrawEventV2(WithdrawEventV2),
+    FrozenEventV2(FrozenEventV2),
 }
 
 impl FungibleAssetEvent {
@@ -269,6 +292,15 @@ impl FungibleAssetEvent {
             },
             "0x1::fungible_asset::FrozenEvent" => {
                 serde_json::from_str(data).map(|inner| Some(Self::FrozenEvent(inner)))
+            },
+            "0x1::fungible_asset::Deposit" => {
+                serde_json::from_str(data).map(|inner| Some(Self::DepositEventV2(inner)))
+            },
+            "0x1::fungible_asset::Withdraw" => {
+                serde_json::from_str(data).map(|inner| Some(Self::WithdrawEventV2(inner)))
+            },
+            "0x1::fungible_asset::Frozen" => {
+                serde_json::from_str(data).map(|inner| Some(Self::FrozenEventV2(inner)))
             },
             _ => Ok(None),
         }

--- a/rust/processor/src/models/mod.rs
+++ b/rust/processor/src/models/mod.rs
@@ -23,5 +23,51 @@ pub(crate) fn should_skip(index: usize, event: &Event, events: &[Event]) -> bool
     let len = event.type_str.len();
     index > 0
         && event.type_str.ends_with("Event")
-        && events[index - 1].type_str[..len - 5] == event.type_str[..len - 5]
+        && events[index - 1]
+            .type_str
+            .starts_with(&event.type_str[..len - 5])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Tests are to make sure
+    // - only when previous processed event is event v2, current event v1 can be skipped
+
+    #[test]
+    fn test_should_skip_intended() {
+        let event1 = Event {
+            type_str: "0x1::coin::Deposit<0x1::aptos_coin::AptosCoin>".to_string(),
+            ..Event::default()
+        };
+        let event2 = Event {
+            type_str: "0x1::coin::DepositEvent".to_string(),
+            ..Event::default()
+        };
+        let events = vec![event1, event2];
+        assert!(!should_skip(0, &events[0], &events));
+        assert!(should_skip(1, &events[1], &events));
+    }
+
+    #[test]
+    fn test_should_not_break_for_length() {
+        let events = [
+            Event {
+                type_str: "Test0000000000000000000000000000000Event".to_string(),
+                ..Event::default()
+            },
+            Event {
+                type_str: "TEvent".to_string(),
+                ..Event::default()
+            },
+            Event {
+                type_str: "Test0000000000000000000000000000000Event".to_string(),
+                ..Event::default()
+            },
+        ];
+        assert!(!should_skip(0, &events[0], &events));
+        // Note, it is intentional that the second event is skipped.
+        assert!(should_skip(1, &events[1], &events));
+        assert!(!should_skip(2, &events[2], &events));
+    }
 }

--- a/rust/processor/src/models/mod.rs
+++ b/rust/processor/src/models/mod.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_protos::transaction::v1::Event;
+
 pub mod account_transaction_models;
 pub mod ans_models;
 pub mod coin_models;
@@ -16,3 +18,10 @@ pub mod token_models;
 pub mod token_v2_models;
 pub mod transaction_metadata_model;
 pub mod user_transactions_models;
+
+pub(crate) fn should_skip(index: usize, event: &Event, events: &[Event]) -> bool {
+    let len = event.type_str.len();
+    index > 0
+        && event.type_str.ends_with("Event")
+        && events[index - 1].type_str[..len - 5] == event.type_str[..len - 5]
+}

--- a/rust/processor/src/models/stake_models/delegator_activities.rs
+++ b/rust/processor/src/models/stake_models/delegator_activities.rs
@@ -5,6 +5,7 @@
 
 use super::stake_utils::StakeEvent;
 use crate::{
+    models::should_skip,
     schema::delegated_staking_activities,
     utils::{
         counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
@@ -57,6 +58,9 @@ impl DelegatedStakingActivity {
             if let Some(staking_event) =
                 StakeEvent::from_event(event.type_str.as_str(), &event.data, txn_version)?
             {
+                if should_skip(index, event, events) {
+                    continue;
+                }
                 let activity = match staking_event {
                     StakeEvent::AddStakeEvent(inner) => DelegatedStakingActivity {
                         transaction_version: txn_version,

--- a/rust/processor/src/models/stake_models/proposal_votes.rs
+++ b/rust/processor/src/models/stake_models/proposal_votes.rs
@@ -6,6 +6,7 @@
 
 use super::stake_utils::StakeEvent;
 use crate::{
+    models::should_skip,
     schema::proposal_votes,
     utils::{
         counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
@@ -49,7 +50,10 @@ impl ProposalVote {
         let txn_version = transaction.version as i64;
 
         if let TxnData::User(user_txn) = txn_data {
-            for event in &user_txn.events {
+            for (index, event) in user_txn.events.iter().enumerate() {
+                if should_skip(index, event, &user_txn.events) {
+                    continue;
+                };
                 if let Some(StakeEvent::GovernanceVoteEvent(ev)) =
                     StakeEvent::from_event(event.type_str.as_str(), &event.data, txn_version)?
                 {

--- a/rust/processor/src/models/stake_models/proposal_votes.rs
+++ b/rust/processor/src/models/stake_models/proposal_votes.rs
@@ -51,12 +51,12 @@ impl ProposalVote {
 
         if let TxnData::User(user_txn) = txn_data {
             for (index, event) in user_txn.events.iter().enumerate() {
-                if should_skip(index, event, &user_txn.events) {
-                    continue;
-                };
                 if let Some(StakeEvent::GovernanceVoteEvent(ev)) =
                     StakeEvent::from_event(event.type_str.as_str(), &event.data, txn_version)?
                 {
+                    if should_skip(index, event, &user_txn.events) {
+                        continue;
+                    };
                     proposal_votes.push(Self {
                         transaction_version: txn_version,
                         proposal_id: ev.proposal_id as i64,

--- a/rust/processor/src/models/stake_models/stake_utils.rs
+++ b/rust/processor/src/models/stake_models/stake_utils.rs
@@ -198,21 +198,24 @@ pub enum StakeEvent {
 impl StakeEvent {
     pub fn from_event(data_type: &str, data: &str, txn_version: i64) -> Result<Option<Self>> {
         match data_type {
-            "0x1::aptos_governance::VoteEvent" => {
+            "0x1::aptos_governance::VoteEvent" | "0x1::aptos_governance::Vote" => {
                 serde_json::from_str(data).map(|inner| Some(StakeEvent::GovernanceVoteEvent(inner)))
             },
-            "0x1::stake::DistributeRewardsEvent" => serde_json::from_str(data)
-                .map(|inner| Some(StakeEvent::DistributeRewardsEvent(inner))),
-            "0x1::delegation_pool::AddStakeEvent" => {
+            "0x1::stake::DistributeRewardsEvent" | "0x1::stake::DistributeRewards" => {
+                serde_json::from_str(data)
+                    .map(|inner| Some(StakeEvent::DistributeRewardsEvent(inner)))
+            },
+            "0x1::delegation_pool::AddStakeEvent" | "0x1::delegation_pool::AddStake" => {
                 serde_json::from_str(data).map(|inner| Some(StakeEvent::AddStakeEvent(inner)))
             },
-            "0x1::delegation_pool::UnlockStakeEvent" => {
+            "0x1::delegation_pool::UnlockStakeEvent" | "0x1::delegation_pool::UnlockStake" => {
                 serde_json::from_str(data).map(|inner| Some(StakeEvent::UnlockStakeEvent(inner)))
             },
-            "0x1::delegation_pool::WithdrawStakeEvent" => {
+            "0x1::delegation_pool::WithdrawStakeEvent" | "0x1::delegation_pool::WithdrawStake" => {
                 serde_json::from_str(data).map(|inner| Some(StakeEvent::WithdrawStakeEvent(inner)))
             },
-            "0x1::delegation_pool::ReactivateStakeEvent" => serde_json::from_str(data)
+            "0x1::delegation_pool::ReactivateStakeEvent"
+            | "0x1::delegation_pool::ReactivateStake" => serde_json::from_str(data)
                 .map(|inner| Some(StakeEvent::ReactivateStakeEvent(inner))),
             _ => Ok(None),
         }

--- a/rust/processor/src/models/token_models/token_utils.rs
+++ b/rust/processor/src/models/token_models/token_utils.rs
@@ -403,26 +403,29 @@ pub enum TokenEvent {
 impl TokenEvent {
     pub fn from_event(data_type: &str, data: &str, txn_version: i64) -> Result<Option<TokenEvent>> {
         match data_type {
-            "0x3::token::MintTokenEvent" => {
+            "0x3::token::MintTokenEvent" | "0x3::token::MintToken" => {
                 serde_json::from_str(data).map(|inner| Some(TokenEvent::MintTokenEvent(inner)))
             },
-            "0x3::token::BurnTokenEvent" => {
+            "0x3::token::BurnTokenEvent" | "0x3::token::BurnToken" => {
                 serde_json::from_str(data).map(|inner| Some(TokenEvent::BurnTokenEvent(inner)))
             },
-            "0x3::token::MutateTokenPropertyMapEvent" => serde_json::from_str(data)
-                .map(|inner| Some(TokenEvent::MutateTokenPropertyMapEvent(inner))),
-            "0x3::token::WithdrawEvent" => {
+            "0x3::token::MutateTokenPropertyMapEvent" | "0x3::token::MutateTokenPropertyMap" => {
+                serde_json::from_str(data)
+                    .map(|inner| Some(TokenEvent::MutateTokenPropertyMapEvent(inner)))
+            },
+            "0x3::token::WithdrawEvent" | "0x3::token::Withdraw" => {
                 serde_json::from_str(data).map(|inner| Some(TokenEvent::WithdrawTokenEvent(inner)))
             },
-            "0x3::token::DepositEvent" => {
+            "0x3::token::DepositEvent" | "0x3::token::Deposit" => {
                 serde_json::from_str(data).map(|inner| Some(TokenEvent::DepositTokenEvent(inner)))
             },
-            "0x3::token_transfers::TokenOfferEvent" => {
+            "0x3::token_transfers::TokenOfferEvent" | "0x3::token_transfers::TokenOffer" => {
                 serde_json::from_str(data).map(|inner| Some(TokenEvent::OfferTokenEvent(inner)))
             },
-            "0x3::token_transfers::TokenCancelOfferEvent" => serde_json::from_str(data)
+            "0x3::token_transfers::TokenCancelOfferEvent"
+            | "0x3::token_transfers::TokenCancelOffer" => serde_json::from_str(data)
                 .map(|inner| Some(TokenEvent::CancelTokenOfferEvent(inner))),
-            "0x3::token_transfers::TokenClaimEvent" => {
+            "0x3::token_transfers::TokenClaimEvent" | "0x3::token_transfers::TokenClaim" => {
                 serde_json::from_str(data).map(|inner| Some(TokenEvent::ClaimTokenEvent(inner)))
             },
             _ => Ok(None),

--- a/rust/processor/src/models/token_v2_models/v2_token_utils.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_utils.rs
@@ -584,7 +584,7 @@ impl V2TokenEvent {
             "0x4::collection::MintEvent" => {
                 serde_json::from_str(data).map(|inner| Some(Self::MintEvent(inner)))
             },
-            "0x4::token::MutationEvent" => {
+            "0x4::token::MutationEvent" | "0x4::token::Mutation" => {
                 serde_json::from_str(data).map(|inner| Some(Self::TokenMutationEvent(inner)))
             },
             "0x4::collection::Burn" => {
@@ -593,7 +593,7 @@ impl V2TokenEvent {
             "0x4::collection::BurnEvent" => {
                 serde_json::from_str(data).map(|inner| Some(Self::BurnEvent(inner)))
             },
-            "0x1::object::TransferEvent" => {
+            "0x1::object::TransferEvent" | "0x1::object::Transfer" => {
                 serde_json::from_str(data).map(|inner| Some(Self::TransferEvent(inner)))
             },
             _ => Ok(None),

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -17,6 +17,8 @@ use crate::{
         object_models::v2_object_utils::{
             ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata,
         },
+        should_skip,
+        token_v2_models::v2_token_utils::TokenV2,
     },
     schema,
     utils::{
@@ -433,6 +435,9 @@ async fn parse_v2_coin(
 
         // Loop to handle events and collect additional metadata from events for v2
         for (index, event) in events.iter().enumerate() {
+            if should_skip(index, event, events) {
+                continue;
+            };
             if let Some(v1_activity) = FungibleAssetActivity::get_v1_from_event(
                 event,
                 txn_version,

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -18,7 +18,6 @@ use crate::{
             ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata,
         },
         should_skip,
-        token_v2_models::v2_token_utils::TokenV2,
     },
     schema,
     utils::{

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -8,6 +8,7 @@ use crate::{
         object_models::v2_object_utils::{
             ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata,
         },
+        should_skip,
         token_models::tokens::{TableHandleToOwner, TableMetadataForToken},
         token_v2_models::{
             v2_collections::{CollectionV2, CurrentCollectionV2, CurrentCollectionV2PK},
@@ -721,6 +722,9 @@ async fn parse_v2_token(
             // This needs to be here because we need the metadata above for token activities
             // and burn / transfer events need to come before the next section
             for (index, event) in user_txn.events.iter().enumerate() {
+                if should_skip(index, event, user_txn.events.as_slice()) {
+                    continue;
+                }
                 if let Some(burn_event) = Burn::from_event(event, txn_version).unwrap() {
                     tokens_burned.insert(burn_event.get_token_address(), burn_event);
                 }


### PR DESCRIPTION
# PR description

In this PR we add event v2 migration indexing support.

PRs to handle:

1. https://github.com/aptos-labs/aptos-core/pull/10532
2. https://github.com/aptos-labs/aptos-core/pull/11688
3. https://github.com/aptos-labs/aptos-core/pull/13147

## Events to migrate

* V1 + V2: means dedupe is required
* only V1 or V2: means no dedupe is required due to no double emission.

| Module            | Event Name                        | Migration Note          |
| ----------------- | --------------------------------- | ----------------------- |
| account           | KeyRotation                       | not indexed             |
| aptos_account     | DirectCoinTransferConfigUpdated   | not indexed             |
| coin              | Deposit                           | only V1 or V2; not both |
|                   | Withdraw                          | only V1 or V2; not both |
| fungible_asset    | Deposit                           | only V1 or V2; not both |
|                   | Withdraw                          | only V1 or V2; not both |
|                   | Frozen                            | only V1 or V2; not both |
| object            | Transfer                     | V1 + V2                 |
| aptos_governance  | CreateProposal                    | not indexed             |
|                   | Vote                              | V1 + V2                 |
|                   | UpdateConfig                      | not indexed             |
| block             | NewBlock                          | not indexed             |
|                   | UpdateEpochInterval               | not indexed             |
| multisig_account  | \-- all events --                 | not indexed             |
| reconfiguration   | NewEpoch                          | not indexed             |
| stake             | RegisterValidatorCandidate        | not indexed             |
|                   | SetOperator                       | not indexed             |
|                   | AddStake                          | V1 + V2                 |
|                   | ReactivateStakeEvent              | not indexed             |
|                   | RotateConsensusKey                | not indexed             |
|                   | UpdateNetworkAndFullnodeAddresses | not indexed             |
|                   | IncreaseLockup                    | not indexed             |
|                   | JoinValidatorSet                  | not indexed             |
|                   | DistributeRewards                 | V1 + V2                 |
|                   | UnlockStake                       | not indexed             |
|                   | WithdrawStake                     | not indexed             |
|                   | LeaveValidatorSet                 | not indexed             |
| staking_contract  | \-- all events --                 | not indexed             |
| vesting           | \-- all events --                 | not indexed             |
| voting            | \-- all events --                 | not indexed             |
| token             | Mutation                          | V1 + V2                 |
| token_event_store | \-- all events --                 | not indexed             |
| token_transfers   | \-- all events --                 | not indexed             |


### Notes

An example for event v2 migration.


whether a new field would be added can be seen here:
https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-71.md
But the ground truth is in the code. Please verify.