### PR TITLE
[EI-370] Timeout if grpc request takes too long

### DIFF
--- a/rust/processor/src/config.rs
+++ b/rust/processor/src/config.rs
@@ -114,6 +114,9 @@ pub struct IndexerGrpcHttp2Config {
 
     /// Indexer GRPC http2 ping timeout in seconds. Defaults to 10.
     indexer_grpc_http2_ping_timeout_in_secs: u64,
+
+    /// Seconds before timeout for grpc connection.
+    indexer_grpc_connection_timeout_secs: u64,
 }
 
 impl IndexerGrpcHttp2Config {
@@ -124,6 +127,10 @@ impl IndexerGrpcHttp2Config {
     pub fn grpc_http2_ping_timeout_in_secs(&self) -> Duration {
         Duration::from_secs(self.indexer_grpc_http2_ping_timeout_in_secs)
     }
+
+    pub fn grpc_connection_timeout_secs(&self) -> Duration {
+        Duration::from_secs(self.indexer_grpc_connection_timeout_secs)
+    }
 }
 
 impl Default for IndexerGrpcHttp2Config {
@@ -131,6 +138,7 @@ impl Default for IndexerGrpcHttp2Config {
         Self {
             indexer_grpc_http2_ping_interval_in_secs: 30,
             indexer_grpc_http2_ping_timeout_in_secs: 10,
+            indexer_grpc_connection_timeout_secs: 5,
         }
     }
 }

--- a/rust/processor/src/grpc_stream.rs
+++ b/rust/processor/src/grpc_stream.rs
@@ -74,6 +74,7 @@ pub async fn get_stream(
     indexer_grpc_data_service_address: Url,
     indexer_grpc_http2_ping_interval: Duration,
     indexer_grpc_http2_ping_timeout: Duration,
+    indexer_grpc_reconnection_timeout_secs: Duration,
     starting_version: u64,
     ending_version: Option<u64>,
     auth_token: String,
@@ -121,7 +122,7 @@ pub async fn get_stream(
     let mut connect_retries = 0;
     let connect_res = loop {
         let res = timeout(
-            Duration::from_secs(5),
+            indexer_grpc_reconnection_timeout_secs,
             RawDataClient::connect(channel.clone()),
         )
         .await;
@@ -182,7 +183,7 @@ pub async fn get_stream(
     // Retry this connection a few times before giving up
     let mut connect_retries = 0;
     let stream_res = loop {
-        let timeout_res = timeout(Duration::from_secs(5), async {
+        let timeout_res = timeout(indexer_grpc_reconnection_timeout_secs, async {
             let request = grpc_request_builder(
                 starting_version,
                 count,
@@ -235,6 +236,7 @@ pub async fn get_chain_id(
     indexer_grpc_data_service_address: Url,
     indexer_grpc_http2_ping_interval: Duration,
     indexer_grpc_http2_ping_timeout: Duration,
+    indexer_grpc_reconnection_timeout_secs: Duration,
     auth_token: String,
     processor_name: String,
 ) -> u64 {
@@ -248,6 +250,7 @@ pub async fn get_chain_id(
         indexer_grpc_data_service_address.clone(),
         indexer_grpc_http2_ping_interval,
         indexer_grpc_http2_ping_timeout,
+        indexer_grpc_reconnection_timeout_secs,
         1,
         Some(2),
         auth_token.clone(),
@@ -304,6 +307,7 @@ pub async fn create_fetcher_loop(
     indexer_grpc_data_service_address: Url,
     indexer_grpc_http2_ping_interval: Duration,
     indexer_grpc_http2_ping_timeout: Duration,
+    indexer_grpc_reconnection_timeout_secs: Duration,
     starting_version: u64,
     request_ending_version: Option<u64>,
     auth_token: String,
@@ -324,6 +328,7 @@ pub async fn create_fetcher_loop(
         indexer_grpc_data_service_address.clone(),
         indexer_grpc_http2_ping_interval,
         indexer_grpc_http2_ping_timeout,
+        indexer_grpc_reconnection_timeout_secs,
         starting_version,
         request_ending_version,
         auth_token.clone(),
@@ -634,6 +639,7 @@ pub async fn create_fetcher_loop(
                 indexer_grpc_data_service_address.clone(),
                 indexer_grpc_http2_ping_interval,
                 indexer_grpc_http2_ping_timeout,
+                indexer_grpc_reconnection_timeout_secs,
                 next_version_to_fetch,
                 request_ending_version,
                 auth_token.clone(),

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -66,6 +66,7 @@ pub struct Worker {
 }
 
 impl Worker {
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         processor_config: ProcessorConfig,
         postgres_connection_string: String,
@@ -173,6 +174,7 @@ impl Worker {
             self.indexer_grpc_data_service_address.clone(),
             self.grpc_http2_config.grpc_http2_ping_interval_in_secs(),
             self.grpc_http2_config.grpc_http2_ping_timeout_in_secs(),
+            self.grpc_http2_config.grpc_connection_timeout_secs(),
             self.auth_token.clone(),
             processor_name.to_string(),
         )
@@ -189,6 +191,8 @@ impl Worker {
             self.grpc_http2_config.grpc_http2_ping_interval_in_secs();
         let indexer_grpc_http2_ping_timeout =
             self.grpc_http2_config.grpc_http2_ping_timeout_in_secs();
+        let indexer_grpc_reconnection_timeout_secs =
+            self.grpc_http2_config.grpc_connection_timeout_secs();
         let pb_channel_txn_chunk_size = self.pb_channel_txn_chunk_size;
 
         // Create a transaction fetcher thread that will continuously fetch transactions from the GRPC stream
@@ -212,6 +216,7 @@ impl Worker {
                 indexer_grpc_data_service_address.clone(),
                 indexer_grpc_http2_ping_interval,
                 indexer_grpc_http2_ping_timeout,
+                indexer_grpc_reconnection_timeout_secs,
                 starting_version,
                 request_ending_version,
                 auth_token.clone(),


### PR DESCRIPTION
## Description
When updating grpc image, we observe some processor reconnection hangs when making the grpc request. Example where processor hangs for 2 mins ([link](https://cloud.us.humio.com/k8s/search?columns=%5B%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22%40timestamp%22%2C%22format%22%3A%22datetime%22%2C%22width%22%3A180%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22level%22%2C%22format%22%3A%22text%22%2C%22width%22%3A54%7D%2C%7B%22type%22%3A%22link%22%2C%22openInNewBrowserTab%22%3Atrue%2C%22style%22%3A%22button%22%2C%22hrefTemplate%22%3A%22https%3A%2F%2Fgithub.com%2Faptos-labs%2Faptos-core%2Fpull%2F%7B%7Bfields%5B%5C%22github_pr%5C%22%5D%7D%7D%22%2C%22textTemplate%22%3A%22%7B%7Bfields%5B%5C%22github_pr%5C%22%5D%7D%7D%22%2C%22header%22%3A%22Forge%20PR%22%2C%22width%22%3A79%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.namespace%22%2C%22format%22%3A%22text%22%2C%22width%22%3A104%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.pod_name%22%2C%22format%22%3A%22text%22%2C%22width%22%3A126%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.container_name%22%2C%22format%22%3A%22text%22%2C%22width%22%3A85%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22message%22%2C%22format%22%3A%22text%22%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22fields.message%22%2C%22format%22%3A%22text%22%2C%22width%22%3A587%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22fields.connection_id%22%2C%22format%22%3A%22text%22%2C%22width%22%3A302%7D%5D&end=1714522122043&live=false&newestAtBottom=true&query=k8s.namespace%20%3D%20%22indexer-v2-devnet%22%0A%7C%20k8s.container_name%20%3D%20%22stake-processor%22&showOnlyFirstLine=false&start=1714521961807&tz=America%2FNew_York&widgetType=list-view)). 

This adds a 5s timeout to the grpc request. If it takes too long it will retry up to 5 times. 

## Testing
Restart 3/4 of the data service pods and monitor the processors reconnection 

### Before
Some processors taking > 1.5 min to reconnect
<img width="412" alt="Screenshot 2024-05-01 at 5 37 23 PM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/48a55fda-bc83-4fdb-8e1d-a56c16d06547">

### After
Processors that time out making the grpc request, try to reconnect faster. All processors reconnect faster 
<img width="408" alt="Screenshot 2024-05-01 at 5 43 26 PM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/03784abc-90b6-4c71-9154-12af60b47e26">
