### PR TITLE
Fix TPS calculation

### DIFF
--- a/rust/moving-average/src/lib.rs
+++ b/rust/moving-average/src/lib.rs
@@ -64,11 +64,10 @@ impl MovingAverage {
     }
 }
 
-
+#[cfg(test)]
 mod test {
-    use std::thread::sleep;
-
     use super::*;
+
     #[test]
     fn test_moving_average() {
         // 10 Second window.
@@ -76,11 +75,10 @@ mod test {
         // 9 seconds spent at 100 TPS.
         for _ in 0..9 {
             ma.tick_now(100);
-            sleep(std::time::Duration::from_secs(1));
+            std::thread::sleep(std::time::Duration::from_secs(1));
         }
         // No matter what algorithm we use, the average should be 99 at least.
         let avg = ma.avg();
         assert!(avg >= 99.0, "Average is too low: {}", avg);
     }
-
 }

--- a/rust/moving-average/src/lib.rs
+++ b/rust/moving-average/src/lib.rs
@@ -62,3 +62,24 @@ impl MovingAverage {
         self.sum
     }
 }
+
+
+mod test {
+    use std::thread::sleep;
+
+    use super::*;
+    #[test]
+    fn test_moving_average() {
+        // 10 Second window.
+        let mut ma = MovingAverage::new(10_000);
+        // 9 seconds spent at 100 TPS.
+        for _ in 0..9 {
+            ma.tick_now(100);
+            sleep(std::time::Duration::from_secs(1));
+        }
+        // No matter what algorithm we use, the average should be 100 at least.
+        let avg = ma.avg();
+        assert!(avg >= 90.0, "Average is too low: {}", avg);
+    }
+
+}

--- a/rust/moving-average/src/lib.rs
+++ b/rust/moving-average/src/lib.rs
@@ -78,9 +78,9 @@ mod test {
             ma.tick_now(100);
             sleep(std::time::Duration::from_secs(1));
         }
-        // No matter what algorithm we use, the average should be 100 at least.
+        // No matter what algorithm we use, the average should be 99 at least.
         let avg = ma.avg();
-        assert!(avg >= 90.0, "Average is too low: {}", avg);
+        assert!(avg >= 99.0, "Average is too low: {}", avg);
     }
 
 }

--- a/rust/moving-average/src/lib.rs
+++ b/rust/moving-average/src/lib.rs
@@ -49,7 +49,7 @@ impl MovingAverage {
         self.avg()
     }
 
-    // This is required to called after tick_now/tick is called.
+    // Only be called after tick_now/tick is called.
     pub fn avg(&self) -> f64 {
         if self.values.len() < 2 {
             0.0

--- a/rust/moving-average/src/lib.rs
+++ b/rust/moving-average/src/lib.rs
@@ -49,12 +49,13 @@ impl MovingAverage {
         self.avg()
     }
 
+    // This is required to called after tick_now/tick is called.
     pub fn avg(&self) -> f64 {
         if self.values.len() < 2 {
             0.0
         } else {
             let elapsed = self.values.back().unwrap().0 - self.values.front().unwrap().0;
-            self.sum as f64 / elapsed as f64
+            (self.sum * 1000) as f64 / elapsed as f64
         }
     }
 

--- a/rust/processor/src/grpc_stream.rs
+++ b/rust/processor/src/grpc_stream.rs
@@ -405,7 +405,7 @@ pub async fn create_fetcher_loop(
                     channel_size = txn_sender.len(),
                     size_in_bytes,
                     duration_in_secs,
-                    tps = fetch_ma.avg() as u64,
+                    tps = fetch_ma.avg().ceil() as u64,
                     bytes_per_sec = size_in_bytes as f64 / duration_in_secs,
                     step,
                     "{}",
@@ -511,7 +511,7 @@ pub async fn create_fetcher_loop(
 
                 let duration_in_secs = txn_channel_send_latency.elapsed().as_secs_f64();
                 send_ma.tick_now(num_txns as u64);
-                let tps = send_ma.avg() as u64;
+                let tps = send_ma.avg().ceil() as u64;
                 let bytes_per_sec = size_in_bytes as f64 / duration_in_secs;
 
                 let channel_size = txn_sender.len();

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -432,7 +432,7 @@ impl Worker {
                 // We've processed things: do some data and metrics
 
                 ma.tick_now((last_txn_version - first_txn_version) + 1);
-                let tps = (ma.avg() * 1000.0) as u64;
+                let tps = ma.avg().ceil() as u64;
 
                 let num_processed = (last_txn_version - first_txn_version) + 1;
 


### PR DESCRIPTION
* Fix the TPS calculation

1. GRPC TPS is off by 1000.
2. use ceiling to avoid loss of accuracy because of truncate. 