### PR TITLE
[index] current unified balances

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -595,6 +595,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,6 +2214,7 @@ dependencies = [
  "itertools 0.12.1",
  "jemallocator",
  "kanal",
+ "lazy_static",
  "native-tls",
  "num_cpus",
  "once_cell",
@@ -2222,6 +2229,7 @@ dependencies = [
  "sha2 0.9.9",
  "sha3",
  "strum",
+ "tiny-keccak",
  "tokio",
  "tokio-postgres",
  "tonic 0.11.0",
@@ -3203,6 +3211,15 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -61,6 +61,7 @@ google-cloud-googleapis = "0.10.0"
 google-cloud-pubsub = "0.18.0"
 hex = "0.4.3"
 itertools = "0.12.1"
+lazy_static = "1.4.0"
 jemallocator = { version = "0.5.0", features = [
     "profiling",
     "unprefixed_malloc_on_supported_platforms",
@@ -88,6 +89,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 tempfile = "3.3.0"
 toml = "0.7.4"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
+tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 tokio = { version = "1.35.1", features = ["full"] }
 tonic = { version = "0.11.0", features = [
     "tls",

--- a/rust/processor/Cargo.toml
+++ b/rust/processor/Cargo.toml
@@ -37,6 +37,7 @@ google-cloud-pubsub = { workspace = true }
 hex = { workspace = true }
 itertools = { workspace = true }
 kanal = { workspace = true }
+lazy_static = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }
 prometheus = { workspace = true }
@@ -58,6 +59,7 @@ url = { workspace = true }
 # Postgres SSL support
 native-tls = { workspace = true }
 postgres-native-tls = { workspace = true }
+tiny-keccak = { workspace = true }
 tokio-postgres = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/rust/processor/migrations/2024-05-04-025823_current_unified_fungible_asset_balance/down.sql
+++ b/rust/processor/migrations/2024-05-04-025823_current_unified_fungible_asset_balance/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS current_unified_fungible_asset_balances;
+DROP INDEX IF EXISTS cufab_owner_at_index;
+DROP INDEX IF EXISTS cufab_insat_index;

--- a/rust/processor/migrations/2024-05-04-025823_current_unified_fungible_asset_balance/up.sql
+++ b/rust/processor/migrations/2024-05-04-025823_current_unified_fungible_asset_balance/up.sql
@@ -1,0 +1,21 @@
+-- current fungible asset balances
+CREATE TABLE IF NOT EXISTS current_unified_fungible_asset_balances (
+    storage_id VARCHAR(66) PRIMARY KEY NOT NULL,
+    owner_address VARCHAR(66) NOT NULL,
+    asset_type VARCHAR(66) NOT NULL,
+    coin_type VARCHAR(1000),
+    is_primary BOOLEAN,
+    is_frozen BOOLEAN NOT NULL,
+    amount_v1 NUMERIC,
+    amount_v2 NUMERIC,
+    amount NUMERIC GENERATED ALWAYS AS (COALESCE(amount_v1, 0) + COALESCE(amount_v2, 0)) STORED,
+    last_transaction_version_v1 BIGINT,
+    last_transaction_version_v2 BIGINT,
+    last_transaction_version BIGINT GENERATED ALWAYS AS (GREATEST(last_transaction_version_v1, last_transaction_version_v2)) STORED,
+    last_transaction_timestamp_v1 TIMESTAMP,
+    last_transaction_timestamp_v2 TIMESTAMP,
+    last_transaction_timestamp TIMESTAMP GENERATED ALWAYS AS (GREATEST(last_transaction_timestamp_v1, last_transaction_timestamp_v2)) STORED,
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS cufab_owner_at_index ON current_unified_fungible_asset_balances (owner_address, asset_type);
+CREATE INDEX IF NOT EXISTS cufab_insat_index ON current_unified_fungible_asset_balances (inserted_at);

--- a/rust/processor/src/models/ans_models/ans_utils.rs
+++ b/rust/processor/src/models/ans_models/ans_utils.rs
@@ -220,7 +220,7 @@ impl AnsWriteResource {
         ans_v2_contract_address: &str,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         let data = write_resource.data.as_str();
 
         match type_str.clone() {

--- a/rust/processor/src/models/coin_models/coin_activities.rs
+++ b/rust/processor/src/models/coin_models/coin_activities.rs
@@ -22,11 +22,13 @@ use crate::{
         },
         user_transactions_models::signatures::Signature,
     },
-    processors::coin_processor::APTOS_COIN_TYPE_STR,
     schema::coin_activities,
     utils::{
         counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
-        util::{get_entry_function_from_user_request, standardize_address, u64_to_bigdecimal},
+        util::{
+            get_entry_function_from_user_request, standardize_address, u64_to_bigdecimal,
+            APTOS_COIN_TYPE_STR,
+        },
     },
 };
 use ahash::AHashMap;

--- a/rust/processor/src/models/coin_models/coin_supply.rs
+++ b/rust/processor/src/models/coin_models/coin_supply.rs
@@ -7,7 +7,8 @@
 
 use crate::{
     models::default_models::move_tables::TableItem,
-    processors::coin_processor::APTOS_COIN_TYPE_STR, schema::coin_supply, utils::util::hash_str,
+    schema::coin_supply,
+    utils::util::{hash_str, APTOS_COIN_TYPE_STR},
 };
 use anyhow::Context;
 use aptos_protos::transaction::v1::WriteTableItem;

--- a/rust/processor/src/models/default_models/move_resources.rs
+++ b/rust/processor/src/models/default_models/move_resources.rs
@@ -116,9 +116,21 @@ impl MoveResource {
         }
     }
 
-    pub fn get_outer_type_from_resource(write_resource: &WriteResource) -> String {
+    pub fn get_outer_type_from_write_resource(write_resource: &WriteResource) -> String {
         let move_struct_tag =
             Self::convert_move_struct_tag(write_resource.r#type.as_ref().unwrap());
+
+        format!(
+            "{}::{}::{}",
+            move_struct_tag.get_address(),
+            move_struct_tag.module,
+            move_struct_tag.name,
+        )
+    }
+
+    pub fn get_outer_type_from_delete_resource(delete_resource: &DeleteResource) -> String {
+        let move_struct_tag =
+            Self::convert_move_struct_tag(delete_resource.r#type.as_ref().unwrap());
 
         format!(
             "{}::{}::{}",

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -12,19 +12,23 @@ use crate::{
     models::{
         coin_models::coin_utils::{CoinInfoType, CoinResource},
         object_models::v2_object_utils::ObjectAggregatedDataMapping,
-        token_v2_models::v2_token_utils::TokenStandard,
+        token_v2_models::v2_token_utils::{TokenStandard, V2_STANDARD},
     },
-    schema::{current_fungible_asset_balances, fungible_asset_balances},
-    utils::util::standardize_address,
+    schema::{
+        current_fungible_asset_balances, current_unified_fungible_asset_balances,
+        fungible_asset_balances,
+    },
+    utils::util::{
+        hex_to_raw_bytes, sha3_256, standardize_address, APTOS_COIN_TYPE_STR,
+        APT_METADATA_ADDRESS_HEX, APT_METADATA_ADDRESS_RAW,
+    },
 };
 use ahash::AHashMap;
-use aptos_protos::transaction::v1::WriteResource;
-use bigdecimal::BigDecimal;
+use aptos_protos::transaction::v1::{DeleteResource, WriteResource};
+use bigdecimal::{BigDecimal, Zero};
 use field_count::FieldCount;
-use hex::FromHex;
 use serde::{Deserialize, Serialize};
-use sha2::Digest;
-use sha3::Sha3_256;
+use std::borrow::Borrow;
 
 // Storage id
 pub type CurrentFungibleAssetBalancePK = String;
@@ -60,6 +64,86 @@ pub struct CurrentFungibleAssetBalance {
     pub last_transaction_version: i64,
     pub last_transaction_timestamp: chrono::NaiveDateTime,
     pub token_standard: String,
+}
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Default)]
+#[diesel(primary_key(storage_id))]
+#[diesel(table_name = current_unified_fungible_asset_balances)]
+#[diesel(treat_none_as_null = true)]
+pub struct CurrentUnifiedFungibleAssetBalance {
+    pub storage_id: String,
+    pub owner_address: String,
+    // metadata address for (paired) Fungible Asset
+    pub asset_type: String,
+    pub coin_type: Option<String>,
+    pub is_primary: Option<bool>,
+    pub is_frozen: bool,
+    pub amount_v1: Option<BigDecimal>,
+    pub amount_v2: Option<BigDecimal>,
+    pub last_transaction_version_v1: Option<i64>,
+    pub last_transaction_version_v2: Option<i64>,
+    pub last_transaction_timestamp_v1: Option<chrono::NaiveDateTime>,
+    pub last_transaction_timestamp_v2: Option<chrono::NaiveDateTime>,
+}
+
+fn get_paired_metadata_address(coin_type_name: &str) -> String {
+    if coin_type_name == APTOS_COIN_TYPE_STR {
+        APT_METADATA_ADDRESS_HEX.clone()
+    } else {
+        let mut preimage = APT_METADATA_ADDRESS_RAW.to_vec();
+        preimage.extend(coin_type_name.as_bytes());
+        preimage.push(0xFE);
+        format!("0x{}", hex::encode(sha3_256(&preimage)))
+    }
+}
+
+fn get_primary_fungible_store_address(
+    owner_address: &str,
+    metadata_address: &str,
+) -> anyhow::Result<String> {
+    let mut preimage = hex_to_raw_bytes(owner_address)?;
+    preimage.append(&mut hex_to_raw_bytes(metadata_address)?);
+    preimage.push(0xFC);
+    Ok(format!("0x{}", hex::encode(sha3_256(&preimage))))
+}
+
+impl From<&CurrentFungibleAssetBalance> for CurrentUnifiedFungibleAssetBalance {
+    fn from(cfab: &CurrentFungibleAssetBalance) -> Self {
+        if cfab.token_standard.as_str() == V2_STANDARD.borrow().as_str() {
+            Self {
+                storage_id: cfab.storage_id.clone(),
+                owner_address: cfab.owner_address.clone(),
+                asset_type: cfab.asset_type.clone(),
+                coin_type: None,
+                is_primary: Some(cfab.is_primary),
+                is_frozen: cfab.is_frozen,
+                amount_v1: None,
+                amount_v2: Some(cfab.amount.clone()),
+                last_transaction_version_v1: None,
+                last_transaction_version_v2: Some(cfab.last_transaction_version),
+                last_transaction_timestamp_v1: None,
+                last_transaction_timestamp_v2: Some(cfab.last_transaction_timestamp),
+            }
+        } else {
+            let metadata_addr = get_paired_metadata_address(&cfab.asset_type);
+            let pfs_addr = get_primary_fungible_store_address(&cfab.owner_address, &metadata_addr)
+                .expect("calculate pfs_address failed");
+            Self {
+                storage_id: pfs_addr,
+                owner_address: cfab.owner_address.clone(),
+                asset_type: metadata_addr,
+                coin_type: Some(cfab.asset_type.clone()),
+                is_primary: None,
+                is_frozen: cfab.is_frozen,
+                amount_v1: Some(cfab.amount.clone()),
+                amount_v2: None,
+                last_transaction_version_v1: Some(cfab.last_transaction_version),
+                last_transaction_version_v2: None,
+                last_transaction_timestamp_v1: Some(cfab.last_transaction_timestamp),
+                last_transaction_timestamp_v2: None,
+            }
+        }
+    }
 }
 
 impl FungibleAssetBalance {
@@ -108,6 +192,57 @@ impl FungibleAssetBalance {
             }
         }
 
+        Ok(None)
+    }
+
+    pub fn get_v1_from_delete_resource(
+        delete_resource: &DeleteResource,
+        write_set_change_index: i64,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+    ) -> anyhow::Result<Option<(Self, CurrentFungibleAssetBalance, EventToCoinType)>> {
+        if let Some(CoinResource::CoinStoreDeletion) =
+            &CoinResource::from_delete_resource(delete_resource, txn_version)?
+        {
+            let coin_info_type = &CoinInfoType::from_move_type(
+                &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
+                delete_resource.type_str.as_ref(),
+                txn_version,
+            );
+            if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
+                let owner_address = standardize_address(delete_resource.address.as_str());
+                let storage_id =
+                    CoinInfoType::get_storage_id(coin_type.as_str(), owner_address.as_str());
+                let coin_balance = Self {
+                    transaction_version: txn_version,
+                    write_set_change_index,
+                    storage_id: storage_id.clone(),
+                    owner_address: owner_address.clone(),
+                    asset_type: coin_type.clone(),
+                    is_primary: true,
+                    is_frozen: false,
+                    amount: BigDecimal::zero(),
+                    transaction_timestamp: txn_timestamp,
+                    token_standard: TokenStandard::V1.to_string(),
+                };
+                let current_coin_balance = CurrentFungibleAssetBalance {
+                    storage_id,
+                    owner_address,
+                    asset_type: coin_type.clone(),
+                    is_primary: true,
+                    is_frozen: false,
+                    amount: BigDecimal::zero(),
+                    last_transaction_version: txn_version,
+                    last_transaction_timestamp: txn_timestamp,
+                    token_standard: TokenStandard::V1.to_string(),
+                };
+                return Ok(Some((
+                    coin_balance,
+                    current_coin_balance,
+                    AHashMap::default(),
+                )));
+            }
+        }
         Ok(None)
     }
 
@@ -178,17 +313,8 @@ impl FungibleAssetBalance {
         metadata_address: &str,
         fungible_store_address: &str,
     ) -> bool {
-        let owner_address_bytes = <[u8; 32]>::from_hex(&owner_address[2..]).unwrap();
-        let metadata_address_bytes = <[u8; 32]>::from_hex(&metadata_address[2..]).unwrap();
-
-        // construct the expected metadata address
-        let mut hasher = Sha3_256::new();
-        hasher.update(owner_address_bytes);
-        hasher.update(metadata_address_bytes);
-        hasher.update([0xFC]);
-        let hash_result = hasher.finalize();
-        // compare address to actual metadata address
-        hex::encode(hash_result) == fungible_store_address[2..]
+        fungible_store_address
+            == get_primary_fungible_store_address(owner_address, metadata_address).unwrap()
     }
 }
 

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -104,7 +104,7 @@ fn get_primary_fungible_store_address(
     let mut preimage = hex_to_raw_bytes(owner_address)?;
     preimage.append(&mut hex_to_raw_bytes(metadata_address)?);
     preimage.push(0xFC);
-    Ok(format!("0x{}", hex::encode(sha3_256(&preimage))))
+    Ok(standardize_address(&hex::encode(sha3_256(&preimage))))
 }
 
 impl From<&CurrentFungibleAssetBalance> for CurrentUnifiedFungibleAssetBalance {
@@ -361,5 +361,14 @@ mod tests {
             metadata_address,
             fungible_store_address,
         ));
+    }
+
+    #[test]
+    fn test_paired_metadata_address() {
+        assert_eq!(
+            get_paired_metadata_address("0x1::aptos_coin::AptosCoin"),
+            *APT_METADATA_ADDRESS_HEX
+        );
+        assert_eq!(get_paired_metadata_address("0x66c34778730acbb120cefa57a3d98fd21e0c8b3a51e9baee530088b2e444e94c::moon_coin::MoonCoin"), "0xf772c28c069aa7e4417d85d771957eb3c5c11b5bf90b1965cda23b899ebc0384");
     }
 }

--- a/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_utils.rs
+++ b/rust/processor/src/models/fungible_asset_models/v2_fungible_asset_utils.rs
@@ -59,7 +59,7 @@ impl FungibleAssetMetadata {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2FungibleAssetResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }
@@ -113,7 +113,7 @@ impl FungibleAssetStore {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2FungibleAssetResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }
@@ -158,7 +158,7 @@ impl FungibleAssetSupply {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str: String = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str: String = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2FungibleAssetResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }

--- a/rust/processor/src/models/object_models/v2_object_utils.rs
+++ b/rust/processor/src/models/object_models/v2_object_utils.rs
@@ -103,7 +103,7 @@ impl ObjectWithMetadata {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }

--- a/rust/processor/src/models/stake_models/stake_utils.rs
+++ b/rust/processor/src/models/stake_models/stake_utils.rs
@@ -167,7 +167,7 @@ impl StakeResource {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !Self::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }
@@ -323,7 +323,7 @@ impl DelegationVoteGovernanceRecordsResource {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         let resource = MoveResource::from_write_resource(
             write_resource,
             0, // Placeholder, this isn't used anyway

--- a/rust/processor/src/models/token_models/tokens.rs
+++ b/rust/processor/src/models/token_models/tokens.rs
@@ -419,7 +419,7 @@ impl TableMetadataForToken {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<TableHandleToOwner>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }

--- a/rust/processor/src/models/token_v2_models/v2_collections.rs
+++ b/rust/processor/src/models/token_v2_models/v2_collections.rs
@@ -85,7 +85,7 @@ impl CollectionV2 {
         txn_timestamp: chrono::NaiveDateTime,
         object_metadatas: &ObjectAggregatedDataMapping,
     ) -> anyhow::Result<Option<(Self, CurrentCollectionV2)>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }

--- a/rust/processor/src/models/token_v2_models/v2_token_utils.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_utils.rs
@@ -21,6 +21,7 @@ use ahash::{AHashMap, AHashSet};
 use anyhow::{Context, Result};
 use aptos_protos::transaction::v1::{Event, WriteResource};
 use bigdecimal::BigDecimal;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Formatter};
 
@@ -28,6 +29,10 @@ pub const TOKEN_V2_ADDR: &str =
     "0x0000000000000000000000000000000000000000000000000000000000000004";
 
 pub const DEFAULT_OWNER_ADDRESS: &str = "unknown";
+
+lazy_static! {
+    pub static ref V2_STANDARD: String = TokenStandard::V2.to_string();
+}
 
 /// Tracks all token related data in a hashmap for quick access (keyed on address of the object core)
 /// Maps address to burn event. If it's an old event previous_owner will be empty
@@ -87,7 +92,7 @@ impl AptosCollection {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }
@@ -134,7 +139,7 @@ impl TokenV2 {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }
@@ -191,7 +196,7 @@ impl FixedSupply {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }
@@ -225,7 +230,7 @@ impl UnlimitedSupply {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }
@@ -257,7 +262,7 @@ impl ConcurrentSupply {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }
@@ -431,7 +436,7 @@ impl PropertyMapModel {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }
@@ -462,7 +467,7 @@ impl TokenIdentifiers {
         write_resource: &WriteResource,
         txn_version: i64,
     ) -> anyhow::Result<Option<Self>> {
-        let type_str = MoveResource::get_outer_type_from_resource(write_resource);
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
         if !V2TokenResource::is_resource_supported(type_str.as_str()) {
             return Ok(None);
         }

--- a/rust/processor/src/processors/coin_processor.rs
+++ b/rust/processor/src/processors/coin_processor.rs
@@ -27,8 +27,6 @@ use diesel::{
 use std::fmt::Debug;
 use tracing::error;
 
-pub const APTOS_COIN_TYPE_STR: &str = "0x1::aptos_coin::AptosCoin";
-
 pub struct CoinProcessor {
     connection_pool: PgDbPool,
     per_table_chunk_sizes: AHashMap<String, usize>,

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -635,6 +635,31 @@ diesel::table! {
 }
 
 diesel::table! {
+    current_unified_fungible_asset_balances (storage_id) {
+        #[max_length = 66]
+        storage_id -> Varchar,
+        #[max_length = 66]
+        owner_address -> Varchar,
+        #[max_length = 66]
+        asset_type -> Varchar,
+        #[max_length = 1000]
+        coin_type -> Nullable<Varchar>,
+        is_primary -> Nullable<Bool>,
+        is_frozen -> Bool,
+        amount_v1 -> Nullable<Numeric>,
+        amount_v2 -> Nullable<Numeric>,
+        amount -> Nullable<Numeric>,
+        last_transaction_version_v1 -> Nullable<Int8>,
+        last_transaction_version_v2 -> Nullable<Int8>,
+        last_transaction_version -> Nullable<Int8>,
+        last_transaction_timestamp_v1 -> Nullable<Timestamp>,
+        last_transaction_timestamp_v2 -> Nullable<Timestamp>,
+        last_transaction_timestamp -> Nullable<Timestamp>,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     delegated_staking_activities (transaction_version, event_index) {
         transaction_version -> Int8,
         event_index -> Int8,
@@ -1266,6 +1291,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_token_ownerships_v2,
     current_token_pending_claims,
     current_token_v2_metadata,
+    current_unified_fungible_asset_balances,
     delegated_staking_activities,
     delegated_staking_pool_balances,
     delegated_staking_pools,


### PR DESCRIPTION
Add a new table `current_unified_fungible_asset_balances` to reflect the total balance of a coin.

tested locally with devnet data:
## Indexer Testing

Just make sure for every step in  [[Correctness Testing](https://www.notion.so/aptoslabs/Testing-Plan-f3f66e05e7e244258a292ad95a80b6e7#3f60ed580c9346dbad35522bbb72ce1a)  the `current_unifed_fungible_asset_balances` table shows the correct number at the correct row&col, which matches `current_coin_balances` and `current_fungible_asset_balances`.

This is the final state on devnet with running fungible asset processor locally.

Row #1 (Shows as column here for better layout) is the default profile APT balance

Row #2 (Shows as column here for better layout) is the test profile APT balance

Row #3 (Shows as column here for better layout) is the default profile MoonCoin balance

Row#4 (Shows as column here for better layout) is the default profile a Pure FA balance
<img width="1510" alt="image" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/1549573/2c3d318b-4b91-451d-a34e-9d5e453d192c">

sent another [txn](https://explorer.aptoslabs.com/txn/0xe183f1c6533d97260a6c4bd7878847fefe5d6d514b0f181dd87f8c856100bc7d?network=devnet) to send 20000 octa to 0x1 who already has 1+ apt, then we get:
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/1549573/c27fedfc-4104-4a83-90fd-843c83e448df)
