### PR TITLE
[EI-428] Auto reconnect grpc if txn stream times out waiting for response

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -614,6 +614,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "diesel"
 version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +1845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2125,12 @@ dependencies = [
  "fallible-iterator",
  "postgres-protocol",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
@@ -3155,11 +3176,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
+ "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -3167,16 +3191,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/rust/processor/src/grpc_stream.rs
+++ b/rust/processor/src/grpc_stream.rs
@@ -365,212 +365,221 @@ pub async fn create_fetcher_loop(
         )
         .await
         {
-            Ok(Some(Ok(mut r))) => {
-                reconnection_retries = 0;
-                let start_version = r.transactions.as_slice().first().unwrap().version;
-                let start_txn_timestamp =
-                    r.transactions.as_slice().first().unwrap().timestamp.clone();
-                let end_version = r.transactions.as_slice().last().unwrap().version;
-                let end_txn_timestamp = r.transactions.as_slice().last().unwrap().timestamp.clone();
+            // Received datastream response
+            Ok(response) => {
+                match response {
+                    Some(Ok(mut r)) => {
+                        reconnection_retries = 0;
+                        let start_version = r.transactions.as_slice().first().unwrap().version;
+                        let start_txn_timestamp =
+                            r.transactions.as_slice().first().unwrap().timestamp.clone();
+                        let end_version = r.transactions.as_slice().last().unwrap().version;
+                        let end_txn_timestamp =
+                            r.transactions.as_slice().last().unwrap().timestamp.clone();
 
-                next_version_to_fetch = end_version + 1;
+                        next_version_to_fetch = end_version + 1;
 
-                let size_in_bytes = r.encoded_len() as u64;
-                let chain_id: u64 = r.chain_id.expect("[Parser] Chain Id doesn't exist.");
-                let num_txns = r.transactions.len();
-                let duration_in_secs = grpc_channel_recv_latency.elapsed().as_secs_f64();
-                fetch_ma.tick_now(num_txns as u64);
+                        let size_in_bytes = r.encoded_len() as u64;
+                        let chain_id: u64 = r.chain_id.expect("[Parser] Chain Id doesn't exist.");
+                        let num_txns = r.transactions.len();
+                        let duration_in_secs = grpc_channel_recv_latency.elapsed().as_secs_f64();
+                        fetch_ma.tick_now(num_txns as u64);
 
-                let num_txns = r.transactions.len();
+                        let num_txns = r.transactions.len();
 
-                // Filter out the txns we don't care about
-                r.transactions.retain(|txn| transaction_filter.include(txn));
+                        // Filter out the txns we don't care about
+                        r.transactions.retain(|txn| transaction_filter.include(txn));
 
-                let num_txn_post_filter = r.transactions.len();
-                let num_filtered_txns = num_txns - num_txn_post_filter;
-                let step = ProcessorStep::ReceivedTxnsFromGrpc.get_step();
-                let label = ProcessorStep::ReceivedTxnsFromGrpc.get_label();
+                        let num_txn_post_filter = r.transactions.len();
+                        let num_filtered_txns = num_txns - num_txn_post_filter;
+                        let step = ProcessorStep::ReceivedTxnsFromGrpc.get_step();
+                        let label = ProcessorStep::ReceivedTxnsFromGrpc.get_label();
 
-                info!(
-                    processor_name = processor_name,
-                    service_type = crate::worker::PROCESSOR_SERVICE_TYPE,
-                    stream_address = indexer_grpc_data_service_address.to_string(),
-                    connection_id,
-                    start_version,
-                    end_version,
-                    start_txn_timestamp_iso = start_txn_timestamp
-                        .as_ref()
-                        .map(timestamp_to_iso)
-                        .unwrap_or_default(),
-                    end_txn_timestamp_iso = end_txn_timestamp
-                        .as_ref()
-                        .map(timestamp_to_iso)
-                        .unwrap_or_default(),
-                    num_of_transactions = end_version - start_version + 1,
-                    num_filtered_txns,
-                    channel_size = txn_sender.len(),
-                    size_in_bytes,
-                    duration_in_secs,
-                    tps = fetch_ma.avg().ceil() as u64,
-                    bytes_per_sec = size_in_bytes as f64 / duration_in_secs,
-                    step,
-                    "{}",
-                    label,
-                );
-
-                if last_fetched_version + 1 != start_version as i64 {
-                    error!(
-                        batch_start_version = last_fetched_version + 1,
-                        last_fetched_version,
-                        current_fetched_version = start_version,
-                        "[Parser] Received batch with gap from GRPC stream"
-                    );
-                    panic!("[Parser] Received batch with gap from GRPC stream");
-                }
-                last_fetched_version = end_version as i64;
-
-                LATEST_PROCESSED_VERSION
-                    .with_label_values(&[&processor_name, step, label, "-"])
-                    .set(end_version as i64);
-                TRANSACTION_UNIX_TIMESTAMP
-                    .with_label_values(&[&processor_name, step, label, "-"])
-                    .set(
-                        start_txn_timestamp
-                            .as_ref()
-                            .map(timestamp_to_unixtime)
-                            .unwrap_or_default(),
-                    );
-                PROCESSED_BYTES_COUNT
-                    .with_label_values(&[&processor_name, step, label, "-"])
-                    .inc_by(size_in_bytes);
-                NUM_TRANSACTIONS_PROCESSED_COUNT
-                    .with_label_values(&[&processor_name, step, label, "-"])
-                    .inc_by(end_version - start_version + 1);
-
-                let txn_channel_send_latency = std::time::Instant::now();
-
-                //potentially break txn_pb into many `TransactionsPBResponse` that are each `pb_channel_txn_chunk_size` txns max in size
-                if num_txn_post_filter < pb_channel_txn_chunk_size {
-                    // We only need to send one; avoid the chunk/clone
-                    let txn_pb = TransactionsPBResponse {
-                        transactions: r.transactions,
-                        chain_id,
-                        start_version,
-                        end_version,
-                        start_txn_timestamp,
-                        end_txn_timestamp,
-                        size_in_bytes,
-                    };
-
-                    match txn_sender.send(txn_pb).await {
-                        Ok(()) => {},
-                        Err(e) => {
-                            error!(
-                                processor_name = processor_name,
-                                stream_address = indexer_grpc_data_service_address.to_string(),
-                                connection_id,
-                                error = ?e,
-                                "[Parser] Error sending GRPC response to channel."
-                            );
-                            panic!("[Parser] Error sending GRPC response to channel.")
-                        },
-                    }
-                } else {
-                    // We are breaking down a big batch into small batches; this involves an iterator
-                    let average_size_in_bytes = size_in_bytes / num_txns as u64;
-
-                    let pb_txn_chunks: Vec<Vec<Transaction>> = r
-                        .transactions
-                        .into_iter()
-                        .chunks(pb_channel_txn_chunk_size)
-                        .into_iter()
-                        .map(|chunk| chunk.collect())
-                        .collect();
-                    for txns in pb_txn_chunks {
-                        let size_in_bytes = average_size_in_bytes * txns.len() as u64;
-                        let txn_pb = TransactionsPBResponse {
-                            transactions: txns,
-                            chain_id,
+                        info!(
+                            processor_name = processor_name,
+                            service_type = crate::worker::PROCESSOR_SERVICE_TYPE,
+                            stream_address = indexer_grpc_data_service_address.to_string(),
+                            connection_id,
                             start_version,
                             end_version,
-                            // TODO: this is only for gap checker + filtered txns, but this is wrong
-                            start_txn_timestamp: start_txn_timestamp.clone(),
-                            end_txn_timestamp: end_txn_timestamp.clone(),
+                            start_txn_timestamp_iso = start_txn_timestamp
+                                .as_ref()
+                                .map(timestamp_to_iso)
+                                .unwrap_or_default(),
+                            end_txn_timestamp_iso = end_txn_timestamp
+                                .as_ref()
+                                .map(timestamp_to_iso)
+                                .unwrap_or_default(),
+                            num_of_transactions = end_version - start_version + 1,
+                            num_filtered_txns,
+                            channel_size = txn_sender.len(),
                             size_in_bytes,
-                        };
+                            duration_in_secs,
+                            tps = fetch_ma.avg().ceil() as u64,
+                            bytes_per_sec = size_in_bytes as f64 / duration_in_secs,
+                            step,
+                            "{}",
+                            label,
+                        );
 
-                        match txn_sender.send(txn_pb).await {
-                            Ok(()) => {},
-                            Err(e) => {
-                                error!(
-                                    processor_name = processor_name,
-                                    stream_address = indexer_grpc_data_service_address.to_string(),
-                                    connection_id,
-                                    error = ?e,
-                                    "[Parser] Error sending GRPC response to channel."
-                                );
-                                panic!("[Parser] Error sending GRPC response to channel.")
-                            },
+                        if last_fetched_version + 1 != start_version as i64 {
+                            error!(
+                                batch_start_version = last_fetched_version + 1,
+                                last_fetched_version,
+                                current_fetched_version = start_version,
+                                "[Parser] Received batch with gap from GRPC stream"
+                            );
+                            panic!("[Parser] Received batch with gap from GRPC stream");
                         }
-                    }
+                        last_fetched_version = end_version as i64;
+
+                        LATEST_PROCESSED_VERSION
+                            .with_label_values(&[&processor_name, step, label, "-"])
+                            .set(end_version as i64);
+                        TRANSACTION_UNIX_TIMESTAMP
+                            .with_label_values(&[&processor_name, step, label, "-"])
+                            .set(
+                                start_txn_timestamp
+                                    .as_ref()
+                                    .map(timestamp_to_unixtime)
+                                    .unwrap_or_default(),
+                            );
+                        PROCESSED_BYTES_COUNT
+                            .with_label_values(&[&processor_name, step, label, "-"])
+                            .inc_by(size_in_bytes);
+                        NUM_TRANSACTIONS_PROCESSED_COUNT
+                            .with_label_values(&[&processor_name, step, label, "-"])
+                            .inc_by(end_version - start_version + 1);
+
+                        let txn_channel_send_latency = std::time::Instant::now();
+
+                        //potentially break txn_pb into many `TransactionsPBResponse` that are each `pb_channel_txn_chunk_size` txns max in size
+                        if num_txn_post_filter < pb_channel_txn_chunk_size {
+                            // We only need to send one; avoid the chunk/clone
+                            let txn_pb = TransactionsPBResponse {
+                                transactions: r.transactions,
+                                chain_id,
+                                start_version,
+                                end_version,
+                                start_txn_timestamp,
+                                end_txn_timestamp,
+                                size_in_bytes,
+                            };
+
+                            match txn_sender.send(txn_pb).await {
+                                Ok(()) => {},
+                                Err(e) => {
+                                    error!(
+                                        processor_name = processor_name,
+                                        stream_address = indexer_grpc_data_service_address.to_string(),
+                                        connection_id,
+                                        error = ?e,
+                                        "[Parser] Error sending GRPC response to channel."
+                                    );
+                                    panic!("[Parser] Error sending GRPC response to channel.")
+                                },
+                            }
+                        } else {
+                            // We are breaking down a big batch into small batches; this involves an iterator
+                            let average_size_in_bytes = size_in_bytes / num_txns as u64;
+
+                            let pb_txn_chunks: Vec<Vec<Transaction>> = r
+                                .transactions
+                                .into_iter()
+                                .chunks(pb_channel_txn_chunk_size)
+                                .into_iter()
+                                .map(|chunk| chunk.collect())
+                                .collect();
+                            for txns in pb_txn_chunks {
+                                let size_in_bytes = average_size_in_bytes * txns.len() as u64;
+                                let txn_pb = TransactionsPBResponse {
+                                    transactions: txns,
+                                    chain_id,
+                                    start_version,
+                                    end_version,
+                                    // TODO: this is only for gap checker + filtered txns, but this is wrong
+                                    start_txn_timestamp: start_txn_timestamp.clone(),
+                                    end_txn_timestamp: end_txn_timestamp.clone(),
+                                    size_in_bytes,
+                                };
+
+                                match txn_sender.send(txn_pb).await {
+                                    Ok(()) => {},
+                                    Err(e) => {
+                                        error!(
+                                            processor_name = processor_name,
+                                            stream_address = indexer_grpc_data_service_address.to_string(),
+                                            connection_id,
+                                            error = ?e,
+                                            "[Parser] Error sending GRPC response to channel."
+                                        );
+                                        panic!("[Parser] Error sending GRPC response to channel.")
+                                    },
+                                }
+                            }
+                        }
+
+                        let duration_in_secs = txn_channel_send_latency.elapsed().as_secs_f64();
+                        send_ma.tick_now(num_txns as u64);
+                        let tps = send_ma.avg().ceil() as u64;
+                        let bytes_per_sec = size_in_bytes as f64 / duration_in_secs;
+
+                        let channel_size = txn_sender.len();
+                        debug!(
+                            processor_name = processor_name,
+                            service_type = crate::worker::PROCESSOR_SERVICE_TYPE,
+                            stream_address = indexer_grpc_data_service_address.to_string(),
+                            connection_id,
+                            start_version,
+                            end_version,
+                            channel_size,
+                            size_in_bytes,
+                            duration_in_secs,
+                            bytes_per_sec,
+                            tps,
+                            num_filtered_txns,
+                            "[Parser] Successfully sent transactions to channel."
+                        );
+                        FETCHER_THREAD_CHANNEL_SIZE
+                            .with_label_values(&[&processor_name])
+                            .set(channel_size as i64);
+                        grpc_channel_recv_latency = std::time::Instant::now();
+
+                        NUM_TRANSACTIONS_FILTERED_OUT_COUNT
+                            .with_label_values(&[&processor_name])
+                            .inc_by(num_filtered_txns as u64);
+                        true
+                    },
+                    // Error receiving datastream response
+                    Some(Err(rpc_error)) => {
+                        tracing::warn!(
+                            processor_name = processor_name,
+                            service_type = crate::worker::PROCESSOR_SERVICE_TYPE,
+                            stream_address = indexer_grpc_data_service_address.to_string(),
+                            connection_id,
+                            start_version = starting_version,
+                            end_version = request_ending_version,
+                            error = ?rpc_error,
+                            "[Parser] Error receiving datastream response."
+                        );
+                        false
+                    },
+                    // Stream is finished
+                    None => {
+                        tracing::warn!(
+                            processor_name = processor_name,
+                            service_type = crate::worker::PROCESSOR_SERVICE_TYPE,
+                            stream_address = indexer_grpc_data_service_address.to_string(),
+                            connection_id,
+                            start_version = starting_version,
+                            end_version = request_ending_version,
+                            "[Parser] Stream ended."
+                        );
+                        false
+                    },
                 }
-
-                let duration_in_secs = txn_channel_send_latency.elapsed().as_secs_f64();
-                send_ma.tick_now(num_txns as u64);
-                let tps = send_ma.avg().ceil() as u64;
-                let bytes_per_sec = size_in_bytes as f64 / duration_in_secs;
-
-                let channel_size = txn_sender.len();
-                debug!(
-                    processor_name = processor_name,
-                    service_type = crate::worker::PROCESSOR_SERVICE_TYPE,
-                    stream_address = indexer_grpc_data_service_address.to_string(),
-                    connection_id,
-                    start_version,
-                    end_version,
-                    channel_size,
-                    size_in_bytes,
-                    duration_in_secs,
-                    bytes_per_sec,
-                    tps,
-                    num_filtered_txns,
-                    "[Parser] Successfully sent transactions to channel."
-                );
-                FETCHER_THREAD_CHANNEL_SIZE
-                    .with_label_values(&[&processor_name])
-                    .set(channel_size as i64);
-                grpc_channel_recv_latency = std::time::Instant::now();
-
-                NUM_TRANSACTIONS_FILTERED_OUT_COUNT
-                    .with_label_values(&[&processor_name])
-                    .inc_by(num_filtered_txns as u64);
-                true
             },
-            Ok(Some(Err(rpc_error))) => {
-                tracing::warn!(
-                    processor_name = processor_name,
-                    service_type = crate::worker::PROCESSOR_SERVICE_TYPE,
-                    stream_address = indexer_grpc_data_service_address.to_string(),
-                    connection_id,
-                    start_version = starting_version,
-                    end_version = request_ending_version,
-                    error = ?rpc_error,
-                    "[Parser] Error receiving datastream response."
-                );
-                false
-            },
-            Ok(None) => {
-                tracing::warn!(
-                    processor_name = processor_name,
-                    service_type = crate::worker::PROCESSOR_SERVICE_TYPE,
-                    stream_address = indexer_grpc_data_service_address.to_string(),
-                    connection_id,
-                    start_version = starting_version,
-                    end_version = request_ending_version,
-                    "[Parser] Stream ended."
-                );
-                false
-            },
+            // Timeout receiving datastream response
             Err(e) => {
                 tracing::warn!(
                     processor_name = processor_name,

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -327,6 +327,7 @@ impl Worker {
                 )
                 .await
                 {
+                    // Fetched transactions from channel
                     Ok(transactions_pb) => {
                         let size_in_bytes = transactions_pb.size_in_bytes as f64;
                         let first_txn_version = transactions_pb
@@ -502,13 +503,15 @@ impl Worker {
                             .await
                             .expect("[Parser] Failed to send versions to gap detector");
                     },
+                    // Could not fetch transactions from channel. This happens when there are
+                    // no more transactions to fetch and the channel is closed.
                     Err(e) => {
                         error!(
                             processor_name = processor_name,
                             stream_address = stream_address.as_str(),
                             error = ?e,
                             task_index,
-                            "[Parser][T#{}] Consumer thread error fetching transactions from channel", task_index
+                            "[Parser][T#{}] Consumer thread exiting fetching loop", task_index
                         );
                         break;
                     },

--- a/rust/server-framework/src/lib.rs
+++ b/rust/server-framework/src/lib.rs
@@ -55,8 +55,8 @@ where
             bail!("Probes and metrics handler unexpectedly exited");
         },
         _ = main_task_handler => {
-            error!("Main task unexpectedly exited");
-            bail!("Main task unexpectedly exited");
+            eprintln!("Main task exited");
+            anyhow::Ok(())
         },
     }
 }

--- a/rust/server-framework/src/lib.rs
+++ b/rust/server-framework/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright © Aptos Foundation
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 #[cfg(target_os = "linux")]
 use aptos_system_utils::profiling::start_cpu_profiling;
 use backtrace::Backtrace;
@@ -50,13 +50,11 @@ where
     });
     let main_task_handler = handle.spawn(async move { config.run().await });
     tokio::select! {
-        _ = task_handler => {
-            error!("Probes and metrics handler unexpectedly exited");
-            bail!("Probes and metrics handler unexpectedly exited");
+        res = task_handler => {
+            res.expect("Probes and metrics handler unexpectedly exited")
         },
-        _ = main_task_handler => {
-            eprintln!("Main task exited");
-            anyhow::Ok(())
+        res = main_task_handler => {
+            res.expect("Main task handler unexpectedly exited")
         },
     }
 }


### PR DESCRIPTION
## Description 
Two changes:
1. Auto reconnect to grpc if it times out waiting for txn's from channel. Moving the timeout out of the processor thread to the fetcher loop thread.
2. When processor reaches ending version, it stops gracefully instead of panic

## Testing 
Happy path still works. 

Processor with auto-reconnection
<img width="1314" alt="Screenshot 2024-05-15 at 12 15 47 PM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/1ed185f4-8dd7-4648-9cb5-b7cd2b0aef33">

Processor with ending version
<img width="1314" alt="Screenshot 2024-05-15 at 11 47 47 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/4dd79b62-0c13-409b-97e1-80b51aa3bbbb">

Panics in the fetcher thread works.
<img width="1426" alt="Screenshot 2024-05-17 at 11 09 42 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/21f6a683-3c97-47ee-9267-d7bba06302b3">

Panic in processor thread works. 
<img width="1426" alt="Screenshot 2024-05-17 at 11 19 37 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/340cf7d3-7c77-49d9-86f3-48ef958bbe6b">
