### PR TITLE
[EI-461] Index royalty in royalty tables

### DIFF
--- a/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/down.sql
+++ b/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/down.sql
@@ -1,3 +1,2 @@
 -- This file should undo anything in `up.sql`
-DROP TABLE IF EXISTS token_royalty;
-DROP TABLE IF EXISTS current_token_royalty;
+DROP TABLE IF EXISTS current_token_royalty_v1;

--- a/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/down.sql
+++ b/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS token_royalty;
+DROP TABLE IF EXISTS current_token_royalty;

--- a/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/up.sql
+++ b/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/up.sql
@@ -1,19 +1,23 @@
 -- Your SQL goes here
 CREATE TABLE token_royalty (
     transaction_version BIGINT NOT NULL,
-    token_data_id VARCHAR(64) NOT NULL,
-    payee_address VARCHAR(64) NOT NULL,
-    royalty_points_numerator_v1 INT NOT NULL,
-    royalty_points_denominator_v1 INT NOT NULL,
+    token_data_id VARCHAR(66) NOT NULL,
+    payee_address VARCHAR(66) NOT NULL,
+    royalty_points_numerator NUMERIC NOT NULL,
+    royalty_points_denominator NUMERIC NOT NULL,
     token_standard TEXT NOT NULL,
-    (transaction_version, token_data_id) PRIMARY KEY
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (transaction_version, token_data_id) 
 );
 
 CREATE TABLE current_token_royalty (
-    token_data_id VARCHAR(64) NOT NULL,
-    payee_address VARCHAR(64) NOT NULL,
-    royalty_points_numerator_v1 INT NOT NULL,
-    royalty_points_denominator_v1 INT NOT NULL,
+    token_data_id VARCHAR(66) NOT NULL,
+    payee_address VARCHAR(66) NOT NULL,
+    royalty_points_numerator NUMERIC NOT NULL,
+    royalty_points_denominator NUMERIC NOT NULL,
     token_standard TEXT NOT NULL,
-    token_data_id PRIMARY KEY
+    last_transaction_version BIGINT NOT NULL,
+    last_transaction_timestamp TIMESTAMP NOT NULL,
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (token_data_id)
 );

--- a/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/up.sql
+++ b/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/up.sql
@@ -1,24 +1,11 @@
 -- Your SQL goes here
-CREATE TABLE token_royalty (
-    transaction_version BIGINT NOT NULL,
-    token_data_id VARCHAR(66) NOT NULL,
+-- This'll only work with royalty v1 because royalty_v2 requires collection id
+CREATE TABLE IF NOT EXISTS current_token_royalty_v1 (
+    token_data_id VARCHAR(66) UNIQUE PRIMARY KEY NOT NULL,
     payee_address VARCHAR(66) NOT NULL,
     royalty_points_numerator NUMERIC NOT NULL,
     royalty_points_denominator NUMERIC NOT NULL,
-    token_standard TEXT NOT NULL,
-    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (transaction_version, token_data_id) 
-);
-
-CREATE TABLE current_token_royalty (
-    token_data_id VARCHAR(66) NOT NULL,
-    creator_address VARCHAR(66) NOT NULL,
-    payee_address VARCHAR(66) NOT NULL,
-    royalty_points_numerator NUMERIC NOT NULL,
-    royalty_points_denominator NUMERIC NOT NULL,
-    token_standard TEXT NOT NULL,
     last_transaction_version BIGINT NOT NULL,
     last_transaction_timestamp TIMESTAMP NOT NULL,
-    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (token_data_id, creator_address)
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
 );

--- a/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/up.sql
+++ b/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/up.sql
@@ -12,6 +12,7 @@ CREATE TABLE token_royalty (
 
 CREATE TABLE current_token_royalty (
     token_data_id VARCHAR(66) NOT NULL,
+    creator_address VARCHAR(66) NOT NULL,
     payee_address VARCHAR(66) NOT NULL,
     royalty_points_numerator NUMERIC NOT NULL,
     royalty_points_denominator NUMERIC NOT NULL,
@@ -19,5 +20,5 @@ CREATE TABLE current_token_royalty (
     last_transaction_version BIGINT NOT NULL,
     last_transaction_timestamp TIMESTAMP NOT NULL,
     inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (token_data_id)
+    PRIMARY KEY (token_data_id, creator_address)
 );

--- a/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/up.sql
+++ b/rust/processor/migrations/2024-05-21-221101_add_royalty_v1/up.sql
@@ -1,0 +1,19 @@
+-- Your SQL goes here
+CREATE TABLE token_royalty (
+    transaction_version BIGINT NOT NULL,
+    token_data_id VARCHAR(64) NOT NULL,
+    payee_address VARCHAR(64) NOT NULL,
+    royalty_points_numerator_v1 INT NOT NULL,
+    royalty_points_denominator_v1 INT NOT NULL,
+    token_standard TEXT NOT NULL,
+    (transaction_version, token_data_id) PRIMARY KEY
+);
+
+CREATE TABLE current_token_royalty (
+    token_data_id VARCHAR(64) NOT NULL,
+    payee_address VARCHAR(64) NOT NULL,
+    royalty_points_numerator_v1 INT NOT NULL,
+    royalty_points_denominator_v1 INT NOT NULL,
+    token_standard TEXT NOT NULL,
+    token_data_id PRIMARY KEY
+);

--- a/rust/processor/src/models/token_v2_models/mod.rs
+++ b/rust/processor/src/models/token_v2_models/mod.rs
@@ -6,5 +6,5 @@ pub mod v2_token_activities;
 pub mod v2_token_datas;
 pub mod v2_token_metadata;
 pub mod v2_token_ownerships;
-pub mod v2_token_royalty;
+pub mod v1_token_royalty;
 pub mod v2_token_utils;

--- a/rust/processor/src/models/token_v2_models/mod.rs
+++ b/rust/processor/src/models/token_v2_models/mod.rs
@@ -1,10 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod v1_token_royalty;
 pub mod v2_collections;
 pub mod v2_token_activities;
 pub mod v2_token_datas;
 pub mod v2_token_metadata;
 pub mod v2_token_ownerships;
-pub mod v1_token_royalty;
 pub mod v2_token_utils;

--- a/rust/processor/src/models/token_v2_models/mod.rs
+++ b/rust/processor/src/models/token_v2_models/mod.rs
@@ -6,4 +6,5 @@ pub mod v2_token_activities;
 pub mod v2_token_datas;
 pub mod v2_token_metadata;
 pub mod v2_token_ownerships;
+pub mod v2_token_royalty;
 pub mod v2_token_utils;

--- a/rust/processor/src/models/token_v2_models/v1_token_royalty.rs
+++ b/rust/processor/src/models/token_v2_models/v1_token_royalty.rs
@@ -5,50 +5,49 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::v2_token_utils::TokenStandard;
-use crate::{
-    models::token_models::token_utils::TokenWriteSet,
-    schema::{current_token_royalty, token_royalty},
-};
+use crate::{models::token_models::token_utils::TokenWriteSet, schema::current_token_royalty_v1};
 use aptos_protos::transaction::v1::WriteTableItem;
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
-#[diesel(primary_key(token_data_id, transaction_version))]
-#[diesel(table_name = token_royalty)]
-pub struct TokenRoyalty {
-    pub transaction_version: i64,
+#[derive(
+    Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, PartialEq, Eq,
+)]
+#[diesel(primary_key(token_data_id))]
+#[diesel(table_name = current_token_royalty_v1)]
+pub struct CurrentTokenRoyaltyV1 {
     pub token_data_id: String,
     pub payee_address: String,
     pub royalty_points_numerator: BigDecimal,
     pub royalty_points_denominator: BigDecimal,
-    pub token_standard: String,
-}
-
-#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
-#[diesel(primary_key(token_data_id, creator_address))]
-#[diesel(table_name = current_token_royalty)]
-pub struct CurrentTokenRoyalty {
-    pub token_data_id: String,
-    pub creator_address: String,
-    pub payee_address: String,
-    pub royalty_points_numerator: BigDecimal,
-    pub royalty_points_denominator: BigDecimal,
-    pub token_standard: String,
     pub last_transaction_version: i64,
     pub last_transaction_timestamp: chrono::NaiveDateTime,
 }
 
-impl TokenRoyalty {
+impl Ord for CurrentTokenRoyaltyV1 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id.cmp(&other.token_data_id)
+    }
+}
+impl PartialOrd for CurrentTokenRoyaltyV1 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl CurrentTokenRoyaltyV1 {
+    pub fn pk(&self) -> String {
+        self.token_data_id.clone()
+    }
+
     // Royalty for v2 token is more complicated and not supported yet. For token v2, royalty can be on the collection (default) or on
     // the token (override).
     pub fn get_v1_from_write_table_item(
         write_table_item: &WriteTableItem,
         transaction_version: i64,
         transaction_timestamp: chrono::NaiveDateTime,
-    ) -> anyhow::Result<Option<(Self, CurrentTokenRoyalty)>> {
+    ) -> anyhow::Result<Option<Self>> {
         let table_item_data = write_table_item.data.as_ref().unwrap();
 
         let maybe_token_data = match TokenWriteSet::from_table_item_type(
@@ -70,33 +69,21 @@ impl TokenRoyalty {
                 _ => None,
             };
             if let Some(token_data_id_struct) = maybe_token_data_id {
-                let token_data_id = token_data_id_struct.to_hash();
-                let creator_address = token_data_id_struct.get_creator_address();
+                // token data id is the 0x{hash} version of the creator, collection name, and token name
+                let token_data_id = token_data_id_struct.to_id();
                 let payee_address = token_data.royalty.get_payee_address();
                 let royalty_points_numerator = token_data.royalty.royalty_points_numerator.clone();
                 let royalty_points_denominator =
                     token_data.royalty.royalty_points_denominator.clone();
 
-                return Ok(Some((
-                    TokenRoyalty {
-                        transaction_version,
-                        token_data_id: token_data_id.clone(),
-                        payee_address: payee_address.clone(),
-                        royalty_points_numerator: royalty_points_numerator.clone(),
-                        royalty_points_denominator: royalty_points_denominator.clone(),
-                        token_standard: TokenStandard::V1.to_string(),
-                    },
-                    CurrentTokenRoyalty {
-                        token_data_id,
-                        creator_address,
-                        payee_address,
-                        royalty_points_numerator,
-                        royalty_points_denominator,
-                        token_standard: TokenStandard::V1.to_string(),
-                        last_transaction_version: transaction_version,
-                        last_transaction_timestamp: transaction_timestamp,
-                    },
-                )));
+                return Ok(Some(Self {
+                    token_data_id,
+                    payee_address,
+                    royalty_points_numerator,
+                    royalty_points_denominator,
+                    last_transaction_version: transaction_version,
+                    last_transaction_timestamp: transaction_timestamp,
+                }));
             } else {
                 tracing::warn!(
                     transaction_version,

--- a/rust/processor/src/models/token_v2_models/v2_token_royalty.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_royalty.rs
@@ -28,10 +28,11 @@ pub struct TokenRoyalty {
 }
 
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
-#[diesel(primary_key(token_data_id))]
+#[diesel(primary_key(token_data_id, creator_address))]
 #[diesel(table_name = current_token_royalty)]
 pub struct CurrentTokenRoyalty {
     pub token_data_id: String,
+    pub creator_address: String,
     pub payee_address: String,
     pub royalty_points_numerator: BigDecimal,
     pub royalty_points_denominator: BigDecimal,
@@ -70,6 +71,7 @@ impl TokenRoyalty {
             };
             if let Some(token_data_id_struct) = maybe_token_data_id {
                 let token_data_id = token_data_id_struct.to_hash();
+                let creator_address = token_data_id_struct.get_creator_address();
                 let payee_address = token_data.royalty.get_payee_address();
                 let royalty_points_numerator = token_data.royalty.royalty_points_numerator.clone();
                 let royalty_points_denominator =
@@ -86,6 +88,7 @@ impl TokenRoyalty {
                     },
                     CurrentTokenRoyalty {
                         token_data_id,
+                        creator_address,
                         payee_address,
                         royalty_points_numerator,
                         royalty_points_denominator,

--- a/rust/processor/src/models/token_v2_models/v2_token_royalty.rs
+++ b/rust/processor/src/models/token_v2_models/v2_token_royalty.rs
@@ -1,0 +1,108 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::v2_token_utils::TokenStandard;
+use crate::{
+    models::token_models::token_utils::TokenWriteSet,
+    schema::{current_token_royalty, token_royalty},
+};
+use aptos_protos::transaction::v1::WriteTableItem;
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(token_data_id, transaction_version))]
+#[diesel(table_name = token_royalty)]
+pub struct TokenRoyalty {
+    pub transaction_version: i64,
+    pub token_data_id: String,
+    pub payee_address: String,
+    pub royalty_points_numerator: BigDecimal,
+    pub royalty_points_denominator: BigDecimal,
+    pub token_standard: String,
+}
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(token_data_id))]
+#[diesel(table_name = current_token_royalty)]
+pub struct CurrentTokenRoyalty {
+    pub token_data_id: String,
+    pub payee_address: String,
+    pub royalty_points_numerator: BigDecimal,
+    pub royalty_points_denominator: BigDecimal,
+    pub token_standard: String,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl TokenRoyalty {
+    // Royalty for v2 token is more complicated and not supported yet. For token v2, royalty can be on the collection (default) or on
+    // the token (override).
+    pub fn get_v1_from_write_table_item(
+        write_table_item: &WriteTableItem,
+        transaction_version: i64,
+        transaction_timestamp: chrono::NaiveDateTime,
+    ) -> anyhow::Result<Option<(Self, CurrentTokenRoyalty)>> {
+        let table_item_data = write_table_item.data.as_ref().unwrap();
+
+        let maybe_token_data = match TokenWriteSet::from_table_item_type(
+            table_item_data.value_type.as_str(),
+            &table_item_data.value,
+            transaction_version,
+        )? {
+            Some(TokenWriteSet::TokenData(inner)) => Some(inner),
+            _ => None,
+        };
+
+        if let Some(token_data) = maybe_token_data {
+            let maybe_token_data_id = match TokenWriteSet::from_table_item_type(
+                table_item_data.key_type.as_str(),
+                &table_item_data.key,
+                transaction_version,
+            )? {
+                Some(TokenWriteSet::TokenDataId(inner)) => Some(inner),
+                _ => None,
+            };
+            if let Some(token_data_id_struct) = maybe_token_data_id {
+                let token_data_id = token_data_id_struct.to_hash();
+                let payee_address = token_data.royalty.get_payee_address();
+                let royalty_points_numerator = token_data.royalty.royalty_points_numerator.clone();
+                let royalty_points_denominator =
+                    token_data.royalty.royalty_points_denominator.clone();
+
+                return Ok(Some((
+                    TokenRoyalty {
+                        transaction_version,
+                        token_data_id: token_data_id.clone(),
+                        payee_address: payee_address.clone(),
+                        royalty_points_numerator: royalty_points_numerator.clone(),
+                        royalty_points_denominator: royalty_points_denominator.clone(),
+                        token_standard: TokenStandard::V1.to_string(),
+                    },
+                    CurrentTokenRoyalty {
+                        token_data_id,
+                        payee_address,
+                        royalty_points_numerator,
+                        royalty_points_denominator,
+                        token_standard: TokenStandard::V1.to_string(),
+                        last_transaction_version: transaction_version,
+                        last_transaction_timestamp: transaction_timestamp,
+                    },
+                )));
+            } else {
+                tracing::warn!(
+                    transaction_version,
+                    key_type = table_item_data.key_type,
+                    key = table_item_data.key,
+                    "Expecting token_data_id as key for value = token_data"
+                );
+            }
+        }
+        Ok(None)
+    }
+}

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -10,6 +10,7 @@ use crate::{
         },
         token_models::tokens::{TableHandleToOwner, TableMetadataForToken},
         token_v2_models::{
+            v1_token_royalty::CurrentTokenRoyaltyV1,
             v2_collections::{CollectionV2, CurrentCollectionV2, CurrentCollectionV2PK},
             v2_token_activities::TokenActivityV2,
             v2_token_datas::{CurrentTokenDataV2, CurrentTokenDataV2PK, TokenDataV2},
@@ -18,7 +19,6 @@ use crate::{
                 CurrentTokenOwnershipV2, CurrentTokenOwnershipV2PK, NFTOwnershipV2,
                 TokenOwnershipV2,
             },
-            v2_token_royalty::{CurrentTokenRoyalty, TokenRoyalty},
             v2_token_utils::{
                 AptosCollection, Burn, BurnEvent, ConcurrentSupply, FixedSupply, MintEvent,
                 PropertyMapModel, TokenIdentifiers, TokenV2, TokenV2Burned, TokenV2Minted,
@@ -106,7 +106,7 @@ async fn insert_to_db(
     ),
     token_activities_v2: &[TokenActivityV2],
     current_token_v2_metadata: &[CurrentTokenV2Metadata],
-    (token_royalties_v2, current_token_royalties_v2): (&[TokenRoyalty], &[CurrentTokenRoyalty]),
+    current_token_royalties_v1: &[CurrentTokenRoyaltyV1],
     per_table_chunk_sizes: &AHashMap<String, usize>,
 ) -> Result<(), diesel::result::Error> {
     tracing::trace!(
@@ -200,18 +200,12 @@ async fn insert_to_db(
             per_table_chunk_sizes,
         ),
     );
-    let tr_v2 = execute_in_chunks(
-        conn.clone(),
-        insert_token_royalties_query,
-        token_royalties_v2,
-        get_config_table_chunk_size::<TokenRoyalty>("token_royalty", per_table_chunk_sizes),
-    );
-    let ctr_v2 = execute_in_chunks(
+    let ctr_v1 = execute_in_chunks(
         conn,
-        insert_current_token_royalties_query,
-        current_token_royalties_v2,
-        get_config_table_chunk_size::<CurrentTokenRoyalty>(
-            "current_token_royalty",
+        insert_current_token_royalties_v1_query,
+        current_token_royalties_v1,
+        get_config_table_chunk_size::<CurrentTokenRoyaltyV1>(
+            "current_token_royalty_v1",
             per_table_chunk_sizes,
         ),
     );
@@ -227,10 +221,9 @@ async fn insert_to_db(
         cdto_v2_res,
         ta_v2_res,
         ct_v2_res,
-        tr_v2_res,
-        ctr_v2_res,
+        ctr_v1_res,
     ) = tokio::join!(
-        coll_v2, td_v2, to_v2, cc_v2, ctd_v2, cdtd_v2, cto_v2, cdto_v2, ta_v2, ct_v2, tr_v2, ctr_v2
+        coll_v2, td_v2, to_v2, cc_v2, ctd_v2, cdtd_v2, cto_v2, cdto_v2, ta_v2, ct_v2, ctr_v1
     );
 
     for res in [
@@ -244,8 +237,7 @@ async fn insert_to_db(
         cdto_v2_res,
         ta_v2_res,
         ct_v2_res,
-        tr_v2_res,
-        ctr_v2_res,
+        ctr_v1_res,
     ] {
         res?;
     }
@@ -502,45 +494,27 @@ fn insert_current_token_v2_metadatas_query(
     )
 }
 
-fn insert_token_royalties_query(
-    items_to_insert: Vec<TokenRoyalty>,
+fn insert_current_token_royalties_v1_query(
+    items_to_insert: Vec<CurrentTokenRoyaltyV1>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::token_royalty::dsl::*;
+    use schema::current_token_royalty_v1::dsl::*;
 
     (
-        diesel::insert_into(schema::token_royalty::table)
+        diesel::insert_into(schema::current_token_royalty_v1::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, token_data_id))
-            .do_nothing(),
-        None,
-    )
-}
-
-fn insert_current_token_royalties_query(
-    items_to_insert: Vec<CurrentTokenRoyalty>,
-) -> (
-    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
-    Option<&'static str>,
-) {
-    use schema::current_token_royalty::dsl::*;
-
-    (
-        diesel::insert_into(schema::current_token_royalty::table)
-            .values(items_to_insert)
-            .on_conflict((token_data_id, creator_address))
+            .on_conflict(token_data_id)
             .do_update()
             .set((
                 payee_address.eq(excluded(payee_address)),
                 royalty_points_numerator.eq(excluded(royalty_points_numerator)),
                 royalty_points_denominator.eq(excluded(royalty_points_denominator)),
-                token_standard.eq(excluded(token_standard)),
                 last_transaction_version.eq(excluded(last_transaction_version)),
                 last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
             )),
-        Some(" WHERE current_token_royalty.last_transaction_version <= excluded.last_transaction_version "),
+        Some(" WHERE current_token_royalty_v1.last_transaction_version <= excluded.last_transaction_version "),
     )
 }
 
@@ -581,8 +555,7 @@ impl ProcessorTrait for TokenV2Processor {
             current_deleted_token_ownerships_v2,
             token_activities_v2,
             current_token_v2_metadata,
-            token_royalties,
-            current_token_royalties,
+            current_token_royalties_v1,
         ) = parse_v2_token(
             &transactions,
             &table_handle_to_owner,
@@ -611,7 +584,7 @@ impl ProcessorTrait for TokenV2Processor {
             ),
             &token_activities_v2,
             &current_token_v2_metadata,
-            (&token_royalties, &current_token_royalties),
+            &current_token_royalties_v1,
             &self.per_table_chunk_sizes,
         )
         .await;
@@ -660,15 +633,13 @@ async fn parse_v2_token(
     Vec<CurrentTokenOwnershipV2>, // deleted token ownerships
     Vec<TokenActivityV2>,
     Vec<CurrentTokenV2Metadata>,
-    Vec<TokenRoyalty>,
-    Vec<CurrentTokenRoyalty>,
+    Vec<CurrentTokenRoyaltyV1>,
 ) {
     // Token V2 and V1 combined
     let mut collections_v2 = vec![];
     let mut token_datas_v2 = vec![];
     let mut token_ownerships_v2 = vec![];
     let mut token_activities_v2 = vec![];
-    let mut token_royalties = vec![];
 
     let mut current_collections_v2: AHashMap<CurrentCollectionV2PK, CurrentCollectionV2> =
         AHashMap::new();
@@ -690,7 +661,7 @@ async fn parse_v2_token(
     // Basically token properties
     let mut current_token_v2_metadata: AHashMap<CurrentTokenV2MetadataPK, CurrentTokenV2Metadata> =
         AHashMap::new();
-    let mut current_token_royalties: AHashMap<CurrentTokenDataV2PK, CurrentTokenRoyalty> =
+    let mut current_token_royalties_v1: AHashMap<CurrentTokenDataV2PK, CurrentTokenRoyaltyV1> =
         AHashMap::new();
 
     // Code above is inefficient (multiple passthroughs) so I'm approaching TokenV2 with a cleaner code structure
@@ -894,16 +865,15 @@ async fn parse_v2_token(
                                 current_token_data,
                             );
                         }
-                        if let Some((token_royalty, current_token_royalty)) =
-                            TokenRoyalty::get_v1_from_write_table_item(
+                        if let Some(current_token_royalty) =
+                            CurrentTokenRoyaltyV1::get_v1_from_write_table_item(
                                 table_item,
                                 txn_version,
                                 txn_timestamp,
                             )
                             .unwrap()
                         {
-                            token_royalties.push(token_royalty);
-                            current_token_royalties.insert(
+                            current_token_royalties_v1.insert(
                                 current_token_royalty.token_data_id.clone(),
                                 current_token_royalty,
                             );
@@ -1159,8 +1129,6 @@ async fn parse_v2_token(
             }
         }
     }
-    tracing::info!("token royalties {}", token_royalties.len());
-    tracing::info!("current token royalties {}", current_token_royalties.len());
 
     // Getting list of values and sorting by pk in order to avoid postgres deadlock since we're doing multi threaded db writes
     let mut current_collections_v2 = current_collections_v2
@@ -1181,9 +1149,9 @@ async fn parse_v2_token(
     let mut current_deleted_token_ownerships_v2 = current_deleted_token_ownerships_v2
         .into_values()
         .collect::<Vec<CurrentTokenOwnershipV2>>();
-    let mut current_token_royalties = current_token_royalties
+    let mut current_token_royalties_v1 = current_token_royalties_v1
         .into_values()
-        .collect::<Vec<CurrentTokenRoyalty>>();
+        .collect::<Vec<CurrentTokenRoyaltyV1>>();
 
     // Sort by PK
     current_collections_v2.sort_by(|a, b| a.collection_id.cmp(&b.collection_id));
@@ -1220,7 +1188,7 @@ async fn parse_v2_token(
                 &b.storage_id,
             ))
     });
-    current_token_royalties.sort_by(|a, b| a.token_data_id.cmp(&b.token_data_id));
+    current_token_royalties_v1.sort();
 
     (
         collections_v2,
@@ -1233,7 +1201,6 @@ async fn parse_v2_token(
         current_deleted_token_ownerships_v2,
         token_activities_v2,
         current_token_v2_metadata,
-        token_royalties,
-        current_token_royalties,
+        current_token_royalties_v1,
     )
 }

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -530,7 +530,7 @@ fn insert_current_token_royalties_query(
     (
         diesel::insert_into(schema::current_token_royalty::table)
             .values(items_to_insert)
-            .on_conflict(token_data_id)
+            .on_conflict((token_data_id, creator_address))
             .do_update()
             .set((
                 payee_address.eq(excluded(payee_address)),

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -621,9 +621,11 @@ diesel::table! {
 }
 
 diesel::table! {
-    current_token_royalty (token_data_id) {
+    current_token_royalty (token_data_id, creator_address) {
         #[max_length = 66]
         token_data_id -> Varchar,
+        #[max_length = 66]
+        creator_address -> Varchar,
         #[max_length = 66]
         payee_address -> Varchar,
         royalty_points_numerator -> Numeric,

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -621,16 +621,13 @@ diesel::table! {
 }
 
 diesel::table! {
-    current_token_royalty (token_data_id, creator_address) {
+    current_token_royalty_v1 (token_data_id) {
         #[max_length = 66]
         token_data_id -> Varchar,
-        #[max_length = 66]
-        creator_address -> Varchar,
         #[max_length = 66]
         payee_address -> Varchar,
         royalty_points_numerator -> Numeric,
         royalty_points_denominator -> Numeric,
-        token_standard -> Text,
         last_transaction_version -> Int8,
         last_transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
@@ -1174,20 +1171,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    token_royalty (transaction_version, token_data_id) {
-        transaction_version -> Int8,
-        #[max_length = 66]
-        token_data_id -> Varchar,
-        #[max_length = 66]
-        payee_address -> Varchar,
-        royalty_points_numerator -> Numeric,
-        royalty_points_denominator -> Numeric,
-        token_standard -> Text,
-        inserted_at -> Timestamp,
-    }
-}
-
-diesel::table! {
     tokens (token_data_id_hash, property_version, transaction_version) {
         #[max_length = 64]
         token_data_id_hash -> Varchar,
@@ -1321,7 +1304,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_token_ownerships,
     current_token_ownerships_v2,
     current_token_pending_claims,
-    current_token_royalty,
+    current_token_royalty_v1,
     current_token_v2_metadata,
     current_unified_fungible_asset_balances,
     delegated_staking_activities,
@@ -1351,7 +1334,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     token_datas_v2,
     token_ownerships,
     token_ownerships_v2,
-    token_royalty,
     tokens,
     transaction_size_info,
     transactions,

--- a/rust/processor/src/schema.rs
+++ b/rust/processor/src/schema.rs
@@ -621,6 +621,21 @@ diesel::table! {
 }
 
 diesel::table! {
+    current_token_royalty (token_data_id) {
+        #[max_length = 66]
+        token_data_id -> Varchar,
+        #[max_length = 66]
+        payee_address -> Varchar,
+        royalty_points_numerator -> Numeric,
+        royalty_points_denominator -> Numeric,
+        token_standard -> Text,
+        last_transaction_version -> Int8,
+        last_transaction_timestamp -> Timestamp,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     current_token_v2_metadata (object_address, resource_type) {
         #[max_length = 66]
         object_address -> Varchar,
@@ -1157,6 +1172,20 @@ diesel::table! {
 }
 
 diesel::table! {
+    token_royalty (transaction_version, token_data_id) {
+        transaction_version -> Int8,
+        #[max_length = 66]
+        token_data_id -> Varchar,
+        #[max_length = 66]
+        payee_address -> Varchar,
+        royalty_points_numerator -> Numeric,
+        royalty_points_denominator -> Numeric,
+        token_standard -> Text,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     tokens (token_data_id_hash, property_version, transaction_version) {
         #[max_length = 64]
         token_data_id_hash -> Varchar,
@@ -1290,6 +1319,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_token_ownerships,
     current_token_ownerships_v2,
     current_token_pending_claims,
+    current_token_royalty,
     current_token_v2_metadata,
     current_unified_fungible_asset_balances,
     delegated_staking_activities,
@@ -1319,6 +1349,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     token_datas_v2,
     token_ownerships,
     token_ownerships_v2,
+    token_royalty,
     tokens,
     transaction_size_info,
     transactions,


### PR DESCRIPTION
## Description 
* Separate royalty to`current_token_royalty_v1` table (note that v2 royalty requires collection id which isn't currently supported in this PR)
* Move the indexing to `token_v2_processor`

## Backfill
Testnet: 0
Mainnet: 0

## Test Plan
Mainnet transaction 613858541
<img width="824" alt="Screenshot 2024-05-21 at 5 48 17 PM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/44b211a5-b7de-4c33-b84f-4213b860f356">

<img width="1537" alt="Screenshot 2024-05-21 at 5 48 06 PM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/d624f8a8-3ab0-4c59-bc6b-e5f381ea9208">
<img width="1245" alt="Screenshot 2024-05-21 at 5 47 34 PM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/b277ddf9-da0a-4c81-a5e8-25c83af6466e">
