### PR TITLE
[release][aip-83][1.13] Add untransferable handling for FA and token

### DIFF
--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -165,6 +165,12 @@ impl FungibleAssetBalance {
                 let asset_type = inner.metadata.get_reference_address();
                 let is_primary = Self::is_primary(&owner_address, &asset_type, &storage_id);
 
+                // If store has the untransferable field then it must be frozen
+                let is_frozen = if object_data.untransferable.as_ref().is_some() {
+                    true
+                } else {
+                    inner.frozen
+                };
                 let concurrent_balance = object_data
                     .concurrent_fungible_asset_balance
                     .as_ref()
@@ -179,7 +185,7 @@ impl FungibleAssetBalance {
                     owner_address: owner_address.clone(),
                     asset_type: asset_type.clone(),
                     is_primary,
-                    is_frozen: inner.frozen,
+                    is_frozen,
                     amount: concurrent_balance
                         .clone()
                         .unwrap_or_else(|| inner.balance.clone()),
@@ -191,7 +197,7 @@ impl FungibleAssetBalance {
                     owner_address,
                     asset_type: asset_type.clone(),
                     is_primary,
-                    is_frozen: inner.frozen,
+                    is_frozen,
                     amount: concurrent_balance.unwrap_or_else(|| inner.balance.clone()),
                     last_transaction_version: txn_version,
                     last_transaction_timestamp: txn_timestamp,

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -165,12 +165,6 @@ impl FungibleAssetBalance {
                 let asset_type = inner.metadata.get_reference_address();
                 let is_primary = Self::is_primary(&owner_address, &asset_type, &storage_id);
 
-                // If store has the untransferable field then it must be frozen
-                let is_frozen = if object_data.untransferable.as_ref().is_some() {
-                    true
-                } else {
-                    inner.frozen
-                };
                 let concurrent_balance = object_data
                     .concurrent_fungible_asset_balance
                     .as_ref()
@@ -185,7 +179,7 @@ impl FungibleAssetBalance {
                     owner_address: owner_address.clone(),
                     asset_type: asset_type.clone(),
                     is_primary,
-                    is_frozen,
+                    is_frozen: inner.frozen,
                     amount: concurrent_balance
                         .clone()
                         .unwrap_or_else(|| inner.balance.clone()),
@@ -197,7 +191,7 @@ impl FungibleAssetBalance {
                     owner_address,
                     asset_type: asset_type.clone(),
                     is_primary,
-                    is_frozen,
+                    is_frozen: inner.frozen,
                     amount: concurrent_balance.unwrap_or_else(|| inner.balance.clone()),
                     last_transaction_version: txn_version,
                     last_transaction_timestamp: txn_timestamp,

--- a/rust/processor/src/db/common/models/token_v2_models/v2_token_utils.rs
+++ b/rust/processor/src/db/common/models/token_v2_models/v2_token_utils.rs
@@ -530,6 +530,9 @@ impl V2TokenResource {
             x if x == format!("{}::object::ObjectCore", COIN_ADDR) => {
                 serde_json::from_value(data.clone()).map(|inner| Some(Self::ObjectCore(inner)))
             },
+            x if x == format!("{}::object::Untransferable", COIN_ADDR) => {
+                serde_json::from_value(data.clone()).map(|inner| Some(Self::Untransferable(inner)))
+            },
             x if x == format!("{}::collection::Collection", TOKEN_V2_ADDR) => {
                 serde_json::from_value(data.clone()).map(|inner| Some(Self::Collection(inner)))
             },

--- a/rust/processor/src/db/common/models/token_v2_models/v2_token_utils.rs
+++ b/rust/processor/src/db/common/models/token_v2_models/v2_token_utils.rs
@@ -8,7 +8,7 @@ use crate::{
     db::common::models::{
         coin_models::coin_utils::COIN_ADDR,
         default_models::move_resources::MoveResource,
-        object_models::v2_object_utils::{CurrentObjectPK, ObjectCore},
+        object_models::v2_object_utils::{CurrentObjectPK, ObjectCore, Untransferable},
         token_models::token_utils::{NAME_LENGTH, URI_LENGTH},
     },
     utils::util::{
@@ -498,6 +498,7 @@ pub enum V2TokenResource {
     FixedSupply(FixedSupply),
     ObjectCore(ObjectCore),
     UnlimitedSupply(UnlimitedSupply),
+    Untransferable(Untransferable),
     TokenV2(TokenV2),
     PropertyMapModel(PropertyMapModel),
     TokenIdentifiers(TokenIdentifiers),
@@ -507,6 +508,7 @@ impl V2TokenResource {
     pub fn is_resource_supported(data_type: &str) -> bool {
         [
             format!("{}::object::ObjectCore", COIN_ADDR),
+            format!("{}::object::Untransferable", COIN_ADDR),
             format!("{}::collection::Collection", TOKEN_V2_ADDR),
             format!("{}::collection::ConcurrentSupply", TOKEN_V2_ADDR),
             format!("{}::collection::FixedSupply", TOKEN_V2_ADDR),

--- a/rust/processor/src/db/postgres/migrations/2024-06-13-061711_untransferrable/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-13-061711_untransferrable/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE public.current_objects DROP COLUMN IF EXISTS untransferrable;
+ALTER TABLE public.objects DROP COLUMN IF EXISTS untransferrable;

--- a/rust/processor/src/db/postgres/migrations/2024-06-13-061711_untransferrable/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-13-061711_untransferrable/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE public.current_objects
+ADD COLUMN IF NOT EXISTS untransferrable BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE public.objects
+ADD COLUMN IF NOT EXISTS untransferrable BOOLEAN NOT NULL DEFAULT FALSE;

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -451,6 +451,7 @@ diesel::table! {
         last_transaction_version -> Int8,
         is_deleted -> Bool,
         inserted_at -> Timestamp,
+        untransferrable -> Bool,
     }
 }
 
@@ -916,6 +917,7 @@ diesel::table! {
         allow_ungated_transfer -> Bool,
         is_deleted -> Bool,
         inserted_at -> Timestamp,
+        untransferrable -> Bool,
     }
 }
 
@@ -994,6 +996,14 @@ diesel::table! {
         handle -> Varchar,
         key_type -> Text,
         value_type -> Text,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    test (token_data_id) {
+        #[max_length = 66]
+        token_data_id -> Varchar,
         inserted_at -> Timestamp,
     }
 }
@@ -1328,6 +1338,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     spam_assets,
     table_items,
     table_metadatas,
+    test,
     token_activities,
     token_activities_v2,
     token_datas,

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -18,7 +18,7 @@ use crate::{
             v2_fungible_metadata::{FungibleAssetMetadataMapping, FungibleAssetMetadataModel},
         },
         object_models::v2_object_utils::{
-            ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata,
+            ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata, Untransferable,
         },
     },
     schema,
@@ -546,6 +546,11 @@ async fn parse_v2_coin(
                     {
                         aggregated_data.concurrent_fungible_asset_balance =
                             Some(concurrent_fungible_asset_balance);
+                    }
+                    if let Some(untransferable) =
+                        Untransferable::from_write_resource(write_resource, txn_version).unwrap()
+                    {
+                        aggregated_data.untransferable = Some(untransferable);
                     }
                 }
             } else if let Change::DeleteResource(delete_resource) = wsc.change.as_ref().unwrap() {

--- a/rust/processor/src/processors/nft_metadata_processor.rs
+++ b/rust/processor/src/processors/nft_metadata_processor.rs
@@ -247,6 +247,7 @@ async fn parse_v2_token(
                             unlimited_supply: None,
                             property_map: None,
                             transfer_events: vec![],
+                            untransferable: None,
                             token: None,
                             fungible_asset_metadata: None,
                             fungible_asset_supply: None,

--- a/rust/processor/src/processors/objects_processor.rs
+++ b/rust/processor/src/processors/objects_processor.rs
@@ -204,6 +204,7 @@ impl ProcessorTrait for ObjectsProcessor {
                             concurrent_supply: None,
                             property_map: None,
                             transfer_events: vec![],
+                            untransferable: None,
                             fungible_asset_supply: None,
                             concurrent_fungible_asset_supply: None,
                             concurrent_fungible_asset_balance: None,

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -6,7 +6,7 @@ use crate::{
     db::common::models::{
         fungible_asset_models::v2_fungible_asset_utils::FungibleAssetMetadata,
         object_models::v2_object_utils::{
-            ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata,
+            ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata, Untransferable,
         },
         token_models::tokens::{TableHandleToOwner, TableMetadataForToken},
         token_v2_models::{
@@ -758,6 +758,11 @@ async fn parse_v2_token(
                         {
                             aggregated_data.token_identifier = Some(token_identifier);
                         }
+                        if let Some(untransferable) =
+                            Untransferable::from_write_resource(wr, txn_version).unwrap()
+                        {
+                            aggregated_data.untransferable = Some(untransferable);
+                        }
                     }
                 }
             }
@@ -1028,6 +1033,7 @@ async fn parse_v2_token(
                                 txn_timestamp,
                                 &prior_nft_ownership,
                                 &tokens_burned,
+                                &token_v2_metadata_helper,
                                 conn,
                                 query_retries,
                                 query_retry_delay_ms,


### PR DESCRIPTION
## Summary
Handling this AIP https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-83.md

Basically if an object is created with Untransferable resource then it cannot be transferred by anyone including the creator/admin. This PR addresses 3 changes in the indexer
1. Objects -> untransferrable got added
1. Token ownerships v2 -> is_soulbound is true if we see this object. non_transferrable_by_owner is still the old logic (!object_core.allow_ungated_transfer)

Note, we're not doing anything on the fungible asset front since is_frozen is not affected and there's nothing on store level transferrability currently. 

## Backfill
Not actually required if upgrading on time. Otherwise, need to upgrade objects_processor, and token_v2_processor
* Testnet: 1231301072
* Mainnet: 979865558

## Testing
Obj: https://explorer.aptoslabs.com/txn/1231307643?network=testnet
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/0eedb0ef-2d37-433f-aeec-be4629d83d49)

Token: https://explorer.aptoslabs.com/txn/1231310601?network=testnet
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/bb7f47db-8762-4b60-af45-1544a8670b35)
