### PR TITLE
Modify current_unified_fungible_asset_balances for smoother migration later

### DIFF
--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -15,7 +15,7 @@ use crate::{
         token_v2_models::v2_token_utils::{TokenStandard, V2_STANDARD},
     },
     schema::{
-        current_fungible_asset_balances, current_unified_fungible_asset_balances,
+        current_fungible_asset_balances, current_unified_fungible_asset_balances_to_be_renamed,
         fungible_asset_balances,
     },
     utils::util::{
@@ -68,14 +68,14 @@ pub struct CurrentFungibleAssetBalance {
 
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Default)]
 #[diesel(primary_key(storage_id))]
-#[diesel(table_name = current_unified_fungible_asset_balances)]
+#[diesel(table_name = current_unified_fungible_asset_balances_to_be_renamed)]
 #[diesel(treat_none_as_null = true)]
 pub struct CurrentUnifiedFungibleAssetBalance {
     pub storage_id: String,
     pub owner_address: String,
     // metadata address for (paired) Fungible Asset
-    pub asset_type: String,
-    pub coin_type: Option<String>,
+    pub asset_type_v1: Option<String>,
+    pub asset_type_v2: Option<String>,
     pub is_primary: Option<bool>,
     pub is_frozen: bool,
     pub amount_v1: Option<BigDecimal>,
@@ -113,8 +113,8 @@ impl From<&CurrentFungibleAssetBalance> for CurrentUnifiedFungibleAssetBalance {
             Self {
                 storage_id: cfab.storage_id.clone(),
                 owner_address: cfab.owner_address.clone(),
-                asset_type: cfab.asset_type.clone(),
-                coin_type: None,
+                asset_type_v2: Some(cfab.asset_type.clone()),
+                asset_type_v1: None,
                 is_primary: Some(cfab.is_primary),
                 is_frozen: cfab.is_frozen,
                 amount_v1: None,
@@ -131,8 +131,8 @@ impl From<&CurrentFungibleAssetBalance> for CurrentUnifiedFungibleAssetBalance {
             Self {
                 storage_id: pfs_addr,
                 owner_address: cfab.owner_address.clone(),
-                asset_type: metadata_addr,
-                coin_type: Some(cfab.asset_type.clone()),
+                asset_type_v2: None,
+                asset_type_v1: Some(cfab.asset_type.clone()),
                 is_primary: None,
                 is_frozen: cfab.is_frozen,
                 amount_v1: Some(cfab.amount.clone()),

--- a/rust/processor/src/db/postgres/migrations/2024-06-13-065302_current_unified_fungible_asset_balance_edit/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-13-065302_current_unified_fungible_asset_balance_edit/down.sql
@@ -1,0 +1,13 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
+  RENAME TO current_unified_fungible_asset_balances;
+DROP INDEX IF EXISTS cufab_owner_at_index;
+ALTER TABLE current_unified_fungible_asset_balances DROP COLUMN asset_type;
+ALTER TABLE current_unified_fungible_asset_balances
+  RENAME COLUMN asset_type_v2 TO asset_type;
+ALTER TABLE current_unified_fungible_asset_balances
+  RENAME COLUMN asset_type_v1 TO coin_type;
+ALTER TABLE current_unified_fungible_asset_balances
+ALTER COLUMN asset_type
+SET NOT NULL;
+CREATE INDEX IF NOT EXISTS cufab_owner_at_index ON current_unified_fungible_asset_balances (owner_address, asset_type);

--- a/rust/processor/src/db/postgres/migrations/2024-06-13-065302_current_unified_fungible_asset_balance_edit/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-13-065302_current_unified_fungible_asset_balance_edit/up.sql
@@ -1,0 +1,15 @@
+-- Your SQL goes here
+-- Rename asset_type and coin_type to v1 and v2, and make a generated asset_type to be v2 if exists, else v1.
+DROP INDEX IF EXISTS cufab_owner_at_index;
+ALTER TABLE current_unified_fungible_asset_balances
+ALTER COLUMN asset_type DROP NOT NULL;
+ALTER TABLE current_unified_fungible_asset_balances
+  RENAME COLUMN asset_type TO asset_type_v2;
+ALTER TABLE current_unified_fungible_asset_balances
+  RENAME COLUMN coin_type TO asset_type_v1;
+ALTER TABLE current_unified_fungible_asset_balances
+ADD COLUMN asset_type VARCHAR(1000) GENERATED ALWAYS AS (COALESCE(asset_type_v2, asset_type_v1)) STORED;
+CREATE INDEX IF NOT EXISTS cufab_owner_at_index ON current_unified_fungible_asset_balances (owner_address, asset_type);
+-- Rename table to set expectation that we'll rename this table to current_fungible_asset_balances after testing
+ALTER TABLE current_unified_fungible_asset_balances
+  RENAME TO current_unified_fungible_asset_balances_to_be_renamed;

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -650,15 +650,15 @@ diesel::table! {
 }
 
 diesel::table! {
-    current_unified_fungible_asset_balances (storage_id) {
+    current_unified_fungible_asset_balances_to_be_renamed (storage_id) {
         #[max_length = 66]
         storage_id -> Varchar,
         #[max_length = 66]
         owner_address -> Varchar,
         #[max_length = 66]
-        asset_type -> Varchar,
+        asset_type_v2 -> Nullable<Varchar>,
         #[max_length = 1000]
-        coin_type -> Nullable<Varchar>,
+        asset_type_v1 -> Nullable<Varchar>,
         is_primary -> Nullable<Bool>,
         is_frozen -> Bool,
         amount_v1 -> Nullable<Numeric>,
@@ -671,6 +671,8 @@ diesel::table! {
         last_transaction_timestamp_v2 -> Nullable<Timestamp>,
         last_transaction_timestamp -> Nullable<Timestamp>,
         inserted_at -> Timestamp,
+        #[max_length = 1000]
+        asset_type -> Nullable<Varchar>,
     }
 }
 
@@ -1001,14 +1003,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    test (token_data_id) {
-        #[max_length = 66]
-        token_data_id -> Varchar,
-        inserted_at -> Timestamp,
-    }
-}
-
-diesel::table! {
     token_activities (transaction_version, event_account_address, event_creation_number, event_sequence_number) {
         transaction_version -> Int8,
         #[max_length = 66]
@@ -1316,7 +1310,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_token_pending_claims,
     current_token_royalty_v1,
     current_token_v2_metadata,
-    current_unified_fungible_asset_balances,
+    current_unified_fungible_asset_balances_to_be_renamed,
     delegated_staking_activities,
     delegated_staking_pool_balances,
     delegated_staking_pools,
@@ -1338,7 +1332,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     spam_assets,
     table_items,
     table_metadatas,
-    test,
     token_activities,
     token_activities_v2,
     token_datas,

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -266,18 +266,17 @@ fn insert_current_unified_fungible_asset_balances_v1_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::current_unified_fungible_asset_balances::dsl::*;
+    use schema::current_unified_fungible_asset_balances_to_be_renamed::dsl::*;
 
     (
-        diesel::insert_into(schema::current_unified_fungible_asset_balances::table)
+        diesel::insert_into(schema::current_unified_fungible_asset_balances_to_be_renamed::table)
             .values(items_to_insert)
             .on_conflict(storage_id)
             .do_update()
             .set(
                 (
                     owner_address.eq(excluded(owner_address)),
-                    asset_type.eq(excluded(asset_type)),
-                    coin_type.eq(excluded(coin_type)),
+                    asset_type_v1.eq(excluded(asset_type_v1)),
                     is_frozen.eq(excluded(is_frozen)),
                     amount_v1.eq(excluded(amount_v1)),
                     last_transaction_timestamp_v1.eq(excluded(last_transaction_timestamp_v1)),
@@ -285,7 +284,7 @@ fn insert_current_unified_fungible_asset_balances_v1_query(
                     inserted_at.eq(excluded(inserted_at)),
                 )
             ),
-        Some(" WHERE current_unified_fungible_asset_balances.last_transaction_version_v1 IS NULL OR current_unified_fungible_asset_balances.last_transaction_version_v1 <= excluded.last_transaction_version_v1"),
+        Some(" WHERE current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v1 IS NULL OR current_unified_fungible_asset_balances.last_transaction_version_v1 <= excluded.last_transaction_version_v1"),
     )
 }
 
@@ -295,16 +294,16 @@ fn insert_current_unified_fungible_asset_balances_v2_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::current_unified_fungible_asset_balances::dsl::*;
+    use schema::current_unified_fungible_asset_balances_to_be_renamed::dsl::*;
     (
-        diesel::insert_into(schema::current_unified_fungible_asset_balances::table)
+        diesel::insert_into(schema::current_unified_fungible_asset_balances_to_be_renamed::table)
             .values(items_to_insert)
             .on_conflict(storage_id)
             .do_update()
             .set(
                 (
                     owner_address.eq(excluded(owner_address)),
-                    asset_type.eq(excluded(asset_type)),
+                    asset_type_v2.eq(excluded(asset_type_v2)),
                     is_primary.eq(excluded(is_primary)),
                     is_frozen.eq(excluded(is_frozen)),
                     amount_v2.eq(excluded(amount_v2)),
@@ -313,7 +312,7 @@ fn insert_current_unified_fungible_asset_balances_v2_query(
                     inserted_at.eq(excluded(inserted_at)),
                 )
             ),
-        Some(" WHERE current_unified_fungible_asset_balances.last_transaction_version_v2 IS NULL OR current_unified_fungible_asset_balances.last_transaction_version_v2 <= excluded.last_transaction_version_v2 "),
+        Some(" WHERE current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v2 IS NULL OR current_unified_fungible_asset_balances.last_transaction_version_v2 <= excluded.last_transaction_version_v2 "),
     )
 }
 

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -284,7 +284,8 @@ fn insert_current_unified_fungible_asset_balances_v1_query(
                     inserted_at.eq(excluded(inserted_at)),
                 )
             ),
-        Some(" WHERE current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v1 IS NULL OR current_unified_fungible_asset_balances.last_transaction_version_v1 <= excluded.last_transaction_version_v1"),
+        Some(" WHERE current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v1 IS NULL \
+        OR current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v1 <= excluded.last_transaction_version_v1"),
     )
 }
 
@@ -312,7 +313,8 @@ fn insert_current_unified_fungible_asset_balances_v2_query(
                     inserted_at.eq(excluded(inserted_at)),
                 )
             ),
-        Some(" WHERE current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v2 IS NULL OR current_unified_fungible_asset_balances.last_transaction_version_v2 <= excluded.last_transaction_version_v2 "),
+        Some(" WHERE current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v2 IS NULL \
+        OR current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v2 <= excluded.last_transaction_version_v2 "),
     )
 }
 


### PR DESCRIPTION
## Summary
* Rename current_unified_fungible_asset_balances -> current_unified_fungible_asset_balances_to_be_renamed
* Set asset_type -> asset_type_v2 (and make it nullable), coin_type -> asset_type_v1
* Create a new asset_type generated from coalesce(asset_type_v2, asset_type_v1). This way all 3 options are covered
  * asset not migrated yet: asset_type = asset_type_v1
    * before, this would break because the new asset doesn't exist yet so the joins would not work.
  * asset migrated: asset_type = asset_type_v2
  * asset created with v2: asset_type = asset_type_v2

## Backfill
fungible_asset_processor only
* Testnet: 553151941
* Mainnet: 199271122

## Testing
Need to test all 3 cases and try to join with fungible_asset_metadata: 
* asset not migrated yet:
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/fd0e697a-a523-4a8b-a819-2d992d58ee99)

* asset migrated:


* asset created with v2:
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/9abf5fb5-f7a3-4ef1-9304-d2e13926904c)
