### PR TITLE
maintain backward compatibility

### DIFF
--- a/rust/processor/src/config.rs
+++ b/rust/processor/src/config.rs
@@ -50,6 +50,7 @@ pub struct IndexerGrpcProcessorConfig {
     #[serde(default)]
     pub transaction_filter: TransactionFilter,
     // String vector for deprecated tables to skip db writes
+    #[serde(default)]
     pub deprecated_tables: HashSet<String>,
 }
 


### PR DESCRIPTION
Add default to value. Confirmed that this doesn't break even when config is missing. 