### PR TITLE
processor proto update.

### DIFF
--- a/.github/actions/protobuf-compatibility-check/action.yaml
+++ b/.github/actions/protobuf-compatibility-check/action.yaml
@@ -34,7 +34,7 @@ runs:
         curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
         mv ./dasel /usr/local/bin/dasel
         cd aptos-indexer-processors
-        tag_output=$(dasel -r toml  -f rust/Cargo.toml workspace.dependencies.aptos-protos.tag -w - )
+        tag_output=$(dasel -r toml  -f rust/Cargo.toml workspace.dependencies.aptos-protos.rev -w - )
         echo "::set-output name=tag_output::$tag_output"
 
     - name: Checkout aptos-core

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?tag=aptos-node-v1.12.1#4b9a2593facaee92b28df2e99b2773a7e4f930f5"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=d76b5bb423b78b2b9affc72d3853f0d973d3f11f#d76b5bb423b78b2b9affc72d3853f0d973d3f11f"
 dependencies = [
  "futures-core",
  "pbjson",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ aptos-moving-average = { path = "moving-average" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.62"
-aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", tag = "d76b5bb423b78b2b9affc72d3853f0d973d3f11f" }
+aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "d76b5bb423b78b2b9affc72d3853f0d973d3f11f" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "4541add3fd29826ec57f22658ca286d2d6134b93" }
 async-trait = "0.1.53"
 backtrace = "0.3.58"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ aptos-moving-average = { path = "moving-average" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.62"
-aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", tag = "aptos-node-v1.12.1" }
+aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", tag = "d76b5bb423b78b2b9affc72d3853f0d973d3f11f" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "4541add3fd29826ec57f22658ca286d2d6134b93" }
 async-trait = "0.1.53"
 backtrace = "0.3.58"

--- a/rust/processor/src/db/common/models/default_models/transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/transactions.rs
@@ -292,7 +292,7 @@ impl Transaction {
                 vec![],
                 vec![],
             ),
-            Txn::BlockEpilogue(_) => (
+            TxnData::BlockEpilogue(_) => (
                 Self::from_transaction_info_with_data(
                     transaction_info,
                     None,

--- a/rust/processor/src/db/common/models/default_models/transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/transactions.rs
@@ -292,6 +292,21 @@ impl Transaction {
                 vec![],
                 vec![],
             ),
+            Txn::BlockEpilogue(_) => (
+                Self::from_transaction_info_with_data(
+                    transaction_info,
+                    None,
+                    None,
+                    version,
+                    transaction_type,
+                    0,
+                    block_height,
+                    epoch,
+                ),
+                None,
+                vec![],
+                vec![],
+            ),
         }
     }
 


### PR DESCRIPTION
* Add support to new transaction type `BlockEpilogueTransaction`, in details:
  * new transaction is indexed under `Transactions` table
    * Transaction data will not be indexed in any table, i.e.,
      * fields will be ignored.  
```
"block_end_info": {
  "block_gas_limit_reached": false,
  "block_output_limit_reached": false,
  "block_effective_block_gas_units": 0,
  "block_approx_output_size": 1244
},
```   


## next step

* update the dependency to use a tagged version
