### PR TITLE
add sql scripts for table items bq load

### DIFF
--- a/rust/parquet-bq-scripts/table_items_create.sql
+++ b/rust/parquet-bq-scripts/table_items_create.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `{}`
+(
+  key STRING,
+  txn_version INT64,
+  write_set_change_index INT64,
+  transaction_block_height INT64,
+  table_handle STRING,
+  decoded_key STRING, -- json
+  decoded_value STRING, -- json
+  is_deleted BOOL,
+  --
+  bq_inserted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
+
+  PRIMARY KEY(txn_version, write_set_change_index) NOT ENFORCED
+)
+PARTITION BY RANGE_BUCKET(txn_version, GENERATE_ARRAY(1, 3999, 1))
+;
+

--- a/rust/parquet-bq-scripts/table_items_create.sql
+++ b/rust/parquet-bq-scripts/table_items_create.sql
@@ -1,9 +1,10 @@
 CREATE TABLE `{}`
 (
-  key STRING,
   txn_version INT64,
+  block_timestamp TIMESTAMP,
   write_set_change_index INT64,
   transaction_block_height INT64,
+  table_key STRING,
   table_handle STRING,
   decoded_key STRING, -- json
   decoded_value STRING, -- json
@@ -13,6 +14,7 @@ CREATE TABLE `{}`
 
   PRIMARY KEY(txn_version, write_set_change_index) NOT ENFORCED
 )
-PARTITION BY RANGE_BUCKET(txn_version, GENERATE_ARRAY(1, 3999, 1))
+PARTITION BY TIMESTAMP_TRUNC(block_timestamp, DAY)
+CLUSTER BY table_key, txn_version
 ;
 

--- a/rust/parquet-bq-scripts/table_items_merge.sql
+++ b/rust/parquet-bq-scripts/table_items_merge.sql
@@ -27,6 +27,7 @@ THEN
     decoded_key,
     decoded_value,
     is_deleted,
+    block_timestamp,
   )
   VALUES (
     staging.key,

--- a/rust/parquet-bq-scripts/table_items_merge.sql
+++ b/rust/parquet-bq-scripts/table_items_merge.sql
@@ -38,6 +38,7 @@ THEN
     staging.decoded_key,
     staging.decoded_value,
     staging.is_deleted,
+    staging.block_timestamp,
 
     CAST(FLOOR(staging.transaction_block_height / 1e6) AS INT64),
   );

--- a/rust/parquet-bq-scripts/table_items_merge.sql
+++ b/rust/parquet-bq-scripts/table_items_merge.sql
@@ -1,0 +1,42 @@
+MERGE INTO `{}` AS main
+USING (
+  SELECT *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (
+        PARTITION BY -- primary key(s)
+          txn_version,
+          write_set_change_index
+      ) AS row_num
+    FROM `{}`
+  ) AS foo
+  WHERE foo.row_num = 1
+) AS staging
+  ON
+    main.txn_version = staging.txn_version -- primary key(s)
+    AND main.write_set_change_index = staging.write_set_change_index
+WHEN NOT MATCHED BY TARGET
+THEN
+  INSERT (
+    key,
+    txn_version,
+    write_set_change_index,
+    transaction_block_height,
+    table_handle,
+    decoded_key,
+    decoded_value,
+    is_deleted,
+  )
+  VALUES (
+    staging.key,
+    staging.txn_version,
+    staging.write_set_change_index,
+    staging.transaction_block_height,
+    staging.table_handle,
+    staging.decoded_key,
+    staging.decoded_value,
+    staging.is_deleted,
+
+    CAST(FLOOR(staging.transaction_block_height / 1e6) AS INT64),
+  );


### PR DESCRIPTION
These are the scripts that will be used to load table_item parquet files in GCS buckets into BigQuery.  

