### PR TITLE
[metadata] migrate move_resources and add unified fa table

### DIFF
--- a/hasura-api/metadata-json/unified.json
+++ b/hasura-api/metadata-json/unified.json
@@ -1,5 +1,5 @@
 {
-  "resource_version": 319,
+  "resource_version": 333,
   "metadata": {
     "version": 3,
     "sources": [
@@ -7,6 +7,29 @@
         "name": "indexer-v2",
         "kind": "postgres",
         "tables": [
+          {
+            "table": {
+              "name": "move_resources",
+              "schema": "legacy_migration_v1"
+            },
+            "configuration": {
+              "column_config": {},
+              "custom_column_names": {},
+              "custom_name": "move_resources",
+              "custom_root_fields": {}
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
           {
             "table": {
               "name": "parsed_asset_uris",
@@ -1453,6 +1476,50 @@
           },
           {
             "table": {
+              "name": "current_unified_fungible_asset_balances_to_be_renamed",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "asset_type": "asset_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_metadata",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "asset_type",
+                    "is_frozen",
+                    "is_primary",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "owner_address",
+                    "storage_id"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
               "name": "delegated_staking_activities",
               "schema": "public"
             },
@@ -1736,23 +1803,6 @@
                 "permission": {
                   "columns": ["chain_id"],
                   "filter": {}
-                }
-              }
-            ]
-          },
-          {
-            "table": {
-              "name": "move_resources",
-              "schema": "public"
-            },
-            "select_permissions": [
-              {
-                "role": "anonymous",
-                "permission": {
-                  "columns": ["address", "transaction_version"],
-                  "filter": {},
-                  "limit": 100,
-                  "allow_aggregations": true
                 }
               }
             ]


### PR DESCRIPTION
* Move resources is now the new view
* unified FA has same configuration as current fa balances

test
![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/11738325/125351dc-f086-4ec1-995b-a2515ab28245)


https://cloud.hasura.io/public/graphiql?endpoint=https%3A%2F%2Findexer.mainnet.aptoslabs.com%2Fv1%2Fgraphql&query=query+MyQuery+%7B%0A++current_unified_fungible_asset_balances_to_be_renamed%28limit%3A+1%29+%7B%0A++++amount%0A++++asset_type%0A++++is_frozen%0A++++is_primary%0A++++last_transaction_timestamp%0A++++last_transaction_version%0A++++owner_address%0A++++storage_id%0A++++metadata+%7B%0A++++++name%0A++++%7D%0A++%7D%0A%7D%0A