### PR TITLE
Run Rust tests in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,3 +44,6 @@ jobs:
       - name: Ensure the --no-default-features build passes too
         run: cargo build --no-default-features
         working-directory: rust
+      - name: Ensure tests pass
+        run: cargo test
+        working-directory: rust


### PR DESCRIPTION
We have tests defined but we don't actually run them in CI. Let's do that. Fortunately they all still pass.