### PR TITLE
add table_items to deprecated table flag

### DIFF
--- a/rust/processor/src/processors/default_processor.rs
+++ b/rust/processor/src/processors/default_processor.rs
@@ -449,6 +449,9 @@ fn process_transactions(
     if flags.contains(TableFlags::WRITE_SET_CHANGES) {
         write_set_changes.clear();
     }
+    if flags.contains(TableFlags::TABLE_ITEMS) {
+        table_items.clear();
+    }
 
     (
         txns,

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -60,6 +60,7 @@ bitflags! {
         const TRANSACTIONS = 1;
         const WRITE_SET_CHANGES = 2;
         const MOVE_RESOURCES = 4;
+        const TABLE_ITEMS = 8;
     }
 }
 


### PR DESCRIPTION
Add a db skip flag for table items 

tested locally when only skip table_items

![Screenshot 2024-06-24 at 4 01 30 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/a8f2f159-0371-446d-b4a0-a62f8bd191cf)
![Screenshot 2024-06-24 at 4 01 24 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/97cdc668-1f24-4cca-9e3f-7000754cdf92)
