### PR TITLE
use option to replace expect with context and avoid creating two gap detectors

### DIFF
--- a/rust/processor/src/bq_analytics/gcs_handler.rs
+++ b/rust/processor/src/bq_analytics/gcs_handler.rs
@@ -13,7 +13,6 @@ use tokio::{
     time::{sleep, timeout, Duration},
 };
 use tracing::{debug, error, info};
-const BUCKET_REGULAR_TRAFFIC: &str = "devnet-airflow-continue";
 const MAX_RETRIES: usize = 3;
 const INITIAL_DELAY_MS: u64 = 500;
 const TIMEOUT_SECONDS: u64 = 300;
@@ -22,6 +21,7 @@ pub async fn upload_parquet_to_gcs(
     file_path: &PathBuf,
     table_name: &str,
     bucket_name: &str,
+    bucket_root: &str,
 ) -> Result<(), ParquetProcessorError> {
     let mut file = TokioFile::open(&file_path)
         .await
@@ -54,13 +54,8 @@ pub async fn upload_parquet_to_gcs(
     let highwater_s = start_of_month.timestamp_millis();
     let highwater_ms = now.timestamp_millis();
     let counter = 0; // THIS NEED TO BE REPLACED OR REIMPLEMENTED WITH AN ACTUAL LOGIC TO ENSURE FILE UNIQUENESS.
-    let object_name: PathBuf = generate_parquet_file_path(
-        BUCKET_REGULAR_TRAFFIC,
-        table_name,
-        highwater_s,
-        highwater_ms,
-        counter,
-    );
+    let object_name: PathBuf =
+        generate_parquet_file_path(bucket_root, table_name, highwater_s, highwater_ms, counter);
 
     let file_name = object_name.to_str().unwrap().to_owned();
     let upload_type: UploadType = UploadType::Simple(Media::new(file_name.clone()));

--- a/rust/processor/src/bq_analytics/gcs_handler.rs
+++ b/rust/processor/src/bq_analytics/gcs_handler.rs
@@ -6,7 +6,7 @@ use google_cloud_storage::{
     http::objects::upload::{Media, UploadObjectRequest, UploadType},
 };
 use hyper::Body;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::io::AsyncReadExt; // for read_to_end()
 use tokio::{
     fs::File as TokioFile,
@@ -18,10 +18,10 @@ const INITIAL_DELAY_MS: u64 = 500;
 const TIMEOUT_SECONDS: u64 = 300;
 pub async fn upload_parquet_to_gcs(
     client: &GCSClient,
-    file_path: &PathBuf,
+    file_path: &Path,
     table_name: &str,
     bucket_name: &str,
-    bucket_root: &str,
+    bucket_root: &Path,
 ) -> Result<(), ParquetProcessorError> {
     let mut file = TokioFile::open(&file_path)
         .await
@@ -103,14 +103,14 @@ pub async fn upload_parquet_to_gcs(
 }
 
 fn generate_parquet_file_path(
-    gcs_bucket_root: &str,
+    gcs_bucket_root: &Path,
     table: &str,
     highwater_s: i64,
     highwater_ms: i64,
     counter: u32,
 ) -> PathBuf {
-    PathBuf::from(format!(
-        "{}/{}/{}/{}_{}.parquet",
-        gcs_bucket_root, table, highwater_s, highwater_ms, counter
+    gcs_bucket_root.join(format!(
+        "{}/{}/{}_{}.parquet",
+        table, highwater_s, highwater_ms, counter
     ))
 }

--- a/rust/processor/src/bq_analytics/parquet_handler.rs
+++ b/rust/processor/src/bq_analytics/parquet_handler.rs
@@ -1,6 +1,6 @@
 use crate::{
     bq_analytics::generic_parquet_processor::{
-        HasParquetSchema, HasVersion, NamedTable, ParquetDataGeneric,
+        GetTimeStamp, HasParquetSchema, HasVersion, NamedTable, ParquetDataGeneric,
         ParquetHandler as GenericParquetHandler,
     },
     gap_detectors::ProcessingResult,
@@ -17,11 +17,19 @@ pub fn create_parquet_handler_loop<ParquetType>(
     new_gap_detector_sender: AsyncSender<ProcessingResult>,
     processor_name: &str,
     bucket_name: String,
+    bucket_root: String,
     parquet_handler_response_channel_size: usize,
     max_buffer_size: usize,
 ) -> AsyncSender<ParquetDataGeneric<ParquetType>>
 where
-    ParquetType: NamedTable + HasVersion + HasParquetSchema + Send + Sync + 'static + Allocative,
+    ParquetType: NamedTable
+        + GetTimeStamp
+        + HasVersion
+        + HasParquetSchema
+        + Send
+        + Sync
+        + 'static
+        + Allocative,
     for<'a> &'a [ParquetType]: RecordWriter<ParquetType>,
 {
     let processor_name = processor_name.to_owned();
@@ -38,6 +46,7 @@ where
 
     let mut parquet_manager = GenericParquetHandler::new(
         bucket_name.clone(),
+        bucket_root.clone(),
         new_gap_detector_sender.clone(),
         ParquetType::schema(),
     )

--- a/rust/processor/src/db/common/models/default_models/parquet_move_resources.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_move_resources.rs
@@ -99,14 +99,13 @@ impl MoveResource {
         txn_version: i64,
         block_height: i64,
         block_timestamp: chrono::NaiveDateTime,
-    ) -> Self {
-        let parsed_data = convert_move_struct_tag(
-            delete_resource
-                .r#type
-                .as_ref()
-                .expect("MoveStructTag Not Exists."),
-        );
-        Self {
+    ) -> Result<Option<Self>> {
+        let move_struct_tag = match delete_resource.r#type.as_ref() {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+        let parsed_data = convert_move_struct_tag(move_struct_tag);
+        let move_resource = Self {
             txn_version,
             block_height,
             write_set_change_index,
@@ -121,7 +120,8 @@ impl MoveResource {
                 hex::encode(delete_resource.state_key_hash.as_slice()).as_str(),
             ),
             block_timestamp,
-        }
+        };
+        Ok(Some(move_resource))
     }
 }
 

--- a/rust/processor/src/db/common/models/default_models/parquet_move_resources.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_move_resources.rs
@@ -66,7 +66,7 @@ impl MoveResource {
         txn_version: i64,
         block_height: i64,
         block_timestamp: chrono::NaiveDateTime,
-    ) -> anyhow::Result<Option<Self>> {
+    ) -> Result<Option<Self>> {
         let move_struct_tag = match write_resource.r#type.as_ref() {
             Some(t) => t,
             None => return Ok(None),

--- a/rust/processor/src/db/common/models/default_models/parquet_move_resources.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_move_resources.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::extra_unused_lifetimes)]
 
 use crate::{
-    bq_analytics::generic_parquet_processor::{HasVersion, NamedTable},
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
     utils::util::standardize_address,
 };
 use allocative_derive::Allocative;
@@ -45,7 +45,14 @@ impl HasVersion for MoveResource {
     }
 }
 
+impl GetTimeStamp for MoveResource {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
+    }
+}
+
 pub struct MoveStructTag {
+    #[allow(dead_code)]
     resource_address: String,
     pub module: String,
     pub fun: String,
@@ -59,14 +66,15 @@ impl MoveResource {
         txn_version: i64,
         block_height: i64,
         block_timestamp: chrono::NaiveDateTime,
-    ) -> Self {
-        let parsed_data = Self::convert_move_struct_tag(
-            write_resource
-                .r#type
-                .as_ref()
-                .expect("MoveStructTag Not Exists."),
-        );
-        Self {
+    ) -> anyhow::Result<Option<Self>> {
+        let move_struct_tag = match write_resource.r#type.as_ref() {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+
+        let parsed_data = convert_move_struct_tag(move_struct_tag);
+
+        let move_resource = Self {
             txn_version,
             block_height,
             write_set_change_index,
@@ -81,7 +89,8 @@ impl MoveResource {
                 hex::encode(write_resource.state_key_hash.as_slice()).as_str(),
             ),
             block_timestamp,
-        }
+        };
+        Ok(Some(move_resource))
     }
 
     pub fn from_delete_resource(
@@ -91,7 +100,7 @@ impl MoveResource {
         block_height: i64,
         block_timestamp: chrono::NaiveDateTime,
     ) -> Self {
-        let parsed_data = Self::convert_move_struct_tag(
+        let parsed_data = convert_move_struct_tag(
             delete_resource
                 .r#type
                 .as_ref()
@@ -114,40 +123,22 @@ impl MoveResource {
             block_timestamp,
         }
     }
-
-    pub fn convert_move_struct_tag(struct_tag: &MoveStructTagPB) -> MoveStructTag {
-        MoveStructTag {
-            resource_address: standardize_address(struct_tag.address.as_str()),
-            module: struct_tag.module.to_string(),
-            fun: struct_tag.name.to_string(),
-            generic_type_params: struct_tag
-                .generic_type_params
-                .iter()
-                .map(|move_type| -> Result<Option<String>> {
-                    Ok(Some(
-                        serde_json::to_string(move_type).context("Failed to parse move type")?,
-                    ))
-                })
-                .collect::<Result<Option<String>>>()
-                .unwrap_or(None),
-        }
-    }
-
-    pub fn get_outer_type_from_resource(write_resource: &WriteResource) -> String {
-        let move_struct_tag =
-            Self::convert_move_struct_tag(write_resource.r#type.as_ref().unwrap());
-
-        format!(
-            "{}::{}::{}",
-            move_struct_tag.get_address(),
-            move_struct_tag.module,
-            move_struct_tag.fun,
-        )
-    }
 }
 
-impl MoveStructTag {
-    pub fn get_address(&self) -> String {
-        standardize_address(self.resource_address.as_str())
+pub fn convert_move_struct_tag(struct_tag: &MoveStructTagPB) -> MoveStructTag {
+    MoveStructTag {
+        resource_address: standardize_address(struct_tag.address.as_str()),
+        module: struct_tag.module.to_string(),
+        fun: struct_tag.name.to_string(),
+        generic_type_params: struct_tag
+            .generic_type_params
+            .iter()
+            .map(|move_type| -> Result<Option<String>> {
+                Ok(Some(
+                    serde_json::to_string(move_type).context("Failed to parse move type")?,
+                ))
+            })
+            .collect::<Result<Option<String>>>()
+            .unwrap_or(None),
     }
 }

--- a/rust/processor/src/db/common/models/default_models/parquet_move_tables.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_move_tables.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::extra_unused_lifetimes)]
 
 use crate::{
-    bq_analytics::generic_parquet_processor::{HasVersion, NamedTable},
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
     utils::util::{hash_str, standardize_address},
 };
 use allocative_derive::Allocative;
@@ -38,6 +38,13 @@ impl HasVersion for TableItem {
         self.txn_version
     }
 }
+
+impl GetTimeStamp for TableItem {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, FieldCount, Serialize)]
 pub struct CurrentTableItem {
     pub table_handle: String,

--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -10,7 +10,7 @@ use super::{
     parquet_write_set_changes::{WriteSetChangeDetail, WriteSetChangeModel},
 };
 use crate::{
-    bq_analytics::generic_parquet_processor::{HasVersion, NamedTable},
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
     utils::{
         counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
         util::{get_clean_payload, get_clean_writeset, get_payload_type, standardize_address},
@@ -57,6 +57,12 @@ impl NamedTable for Transaction {
 impl HasVersion for Transaction {
     fn version(&self) -> i64 {
         self.txn_version
+    }
+}
+
+impl GetTimeStamp for Transaction {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
     }
 }
 

--- a/rust/processor/src/db/common/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/db/common/models/default_models/write_set_changes.rs
@@ -9,7 +9,10 @@ use super::{
     move_tables::{CurrentTableItem, TableItem, TableMetadata},
     transactions::Transaction,
 };
-use crate::{schema::write_set_changes, utils::util::standardize_address};
+use crate::{
+    schema::write_set_changes,
+    utils::util::{standardize_address, standardize_address_from_bytes},
+};
 use aptos_protos::transaction::v1::{
     write_set_change::{Change as WriteSetChangeEnum, Type as WriteSetChangeTypeEnum},
     WriteSetChange as WriteSetChangePB,
@@ -49,12 +52,10 @@ impl WriteSetChange {
             WriteSetChangeEnum::WriteModule(inner) => (
                 Self {
                     transaction_version,
-                    hash: standardize_address(
-                        hex::encode(inner.state_key_hash.as_slice()).as_str(),
-                    ),
+                    hash: standardize_address_from_bytes(inner.state_key_hash.as_slice()),
                     transaction_block_height,
                     type_,
-                    address: standardize_address(&inner.address.to_string()),
+                    address: standardize_address(&inner.address),
                     index,
                 },
                 WriteSetChangeDetail::Module(MoveModule::from_write_module(
@@ -67,12 +68,10 @@ impl WriteSetChange {
             WriteSetChangeEnum::DeleteModule(inner) => (
                 Self {
                     transaction_version,
-                    hash: standardize_address(
-                        hex::encode(inner.state_key_hash.as_slice()).as_str(),
-                    ),
+                    hash: standardize_address_from_bytes(inner.state_key_hash.as_slice()),
                     transaction_block_height,
                     type_,
-                    address: standardize_address(&inner.address.to_string()),
+                    address: standardize_address(&inner.address),
                     index,
                 },
                 WriteSetChangeDetail::Module(MoveModule::from_delete_module(
@@ -85,12 +84,10 @@ impl WriteSetChange {
             WriteSetChangeEnum::WriteResource(inner) => (
                 Self {
                     transaction_version,
-                    hash: standardize_address(
-                        hex::encode(inner.state_key_hash.as_slice()).as_str(),
-                    ),
+                    hash: standardize_address_from_bytes(inner.state_key_hash.as_slice()),
                     transaction_block_height,
                     type_,
-                    address: standardize_address(&inner.address.to_string()),
+                    address: standardize_address(&inner.address),
                     index,
                 },
                 WriteSetChangeDetail::Resource(MoveResource::from_write_resource(
@@ -103,12 +100,10 @@ impl WriteSetChange {
             WriteSetChangeEnum::DeleteResource(inner) => (
                 Self {
                     transaction_version,
-                    hash: standardize_address(
-                        hex::encode(inner.state_key_hash.as_slice()).as_str(),
-                    ),
+                    hash: standardize_address_from_bytes(inner.state_key_hash.as_slice()),
                     transaction_block_height,
                     type_,
-                    address: standardize_address(&inner.address.to_string()),
+                    address: standardize_address(&inner.address),
                     index,
                 },
                 WriteSetChangeDetail::Resource(MoveResource::from_delete_resource(
@@ -128,9 +123,7 @@ impl WriteSetChange {
                 (
                     Self {
                         transaction_version,
-                        hash: standardize_address(
-                            hex::encode(inner.state_key_hash.as_slice()).as_str(),
-                        ),
+                        hash: standardize_address_from_bytes(inner.state_key_hash.as_slice()),
                         transaction_block_height,
                         type_,
                         address: String::default(),
@@ -153,9 +146,7 @@ impl WriteSetChange {
                 (
                     Self {
                         transaction_version,
-                        hash: standardize_address(
-                            hex::encode(inner.state_key_hash.as_slice()).as_str(),
-                        ),
+                        hash: standardize_address_from_bytes(inner.state_key_hash.as_slice()),
                         transaction_block_height,
                         type_,
                         address: String::default(),

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -165,6 +165,7 @@ impl FungibleAssetBalance {
                 let asset_type = inner.metadata.get_reference_address();
                 let is_primary = Self::is_primary(&owner_address, &asset_type, &storage_id);
 
+                #[allow(clippy::useless_asref)]
                 let concurrent_balance = object_data
                     .concurrent_fungible_asset_balance
                     .as_ref()

--- a/rust/processor/src/gap_detectors/gap_detector.rs
+++ b/rust/processor/src/gap_detectors/gap_detector.rs
@@ -6,6 +6,7 @@ use crate::{
     processors::DefaultProcessingResult,
 };
 use ahash::AHashMap;
+use anyhow::Result;
 
 pub struct DefaultGapDetector {
     next_version_to_process: u64,
@@ -20,10 +21,7 @@ pub struct DefaultGapDetectorResult {
 }
 
 impl GapDetectorTrait for DefaultGapDetector {
-    fn process_versions(
-        &mut self,
-        result: ProcessingResult,
-    ) -> anyhow::Result<GapDetectorResult, Box<dyn std::error::Error + Send + Sync>> {
+    fn process_versions(&mut self, result: ProcessingResult) -> Result<GapDetectorResult> {
         match result {
             ProcessingResult::DefaultProcessingResult(result) => {
                 // Check for gaps

--- a/rust/processor/src/gap_detectors/gap_detector.rs
+++ b/rust/processor/src/gap_detectors/gap_detector.rs
@@ -2,14 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    gap_detectors::{GapDetectorResult, ProcessingResult},
+    gap_detectors::{GapDetectorResult, GapDetectorTrait, ProcessingResult},
     processors::DefaultProcessingResult,
 };
 use ahash::AHashMap;
-
-pub trait GapDetectorTrait {
-    fn process_versions(&mut self, result: ProcessingResult) -> anyhow::Result<GapDetectorResult>;
-}
 
 pub struct DefaultGapDetector {
     next_version_to_process: u64,
@@ -24,7 +20,10 @@ pub struct DefaultGapDetectorResult {
 }
 
 impl GapDetectorTrait for DefaultGapDetector {
-    fn process_versions(&mut self, result: ProcessingResult) -> anyhow::Result<GapDetectorResult> {
+    fn process_versions(
+        &mut self,
+        result: ProcessingResult,
+    ) -> anyhow::Result<GapDetectorResult, Box<dyn std::error::Error + Send + Sync>> {
         match result {
             ProcessingResult::DefaultProcessingResult(result) => {
                 // Check for gaps

--- a/rust/processor/src/gap_detectors/mod.rs
+++ b/rust/processor/src/gap_detectors/mod.rs
@@ -45,11 +45,10 @@ pub enum ProcessingResult {
 }
 
 pub async fn create_gap_detector_status_tracker_loop(
+    mut gap_detector: Box<dyn GapDetectorTrait + Send>,
     gap_detector_receiver: AsyncReceiver<ProcessingResult>,
     processor: Processor,
-    starting_version: u64,
     gap_detection_batch_size: u64,
-    is_parquet_processor: bool,
 ) {
     let processor_name = processor.name();
     info!(
@@ -58,11 +57,6 @@ pub async fn create_gap_detector_status_tracker_loop(
         "[Parser] Starting gap detector task",
     );
 
-    let mut gap_detector: Box<dyn GapDetectorTrait + Send> = if is_parquet_processor {
-        Box::new(ParquetFileGapDetector::new(starting_version))
-    } else {
-        Box::new(DefaultGapDetector::new(starting_version))
-    };
     let mut last_update_time = std::time::Instant::now();
     loop {
         match gap_detector_receiver.recv().await {

--- a/rust/processor/src/gap_detectors/parquet_gap_detector.rs
+++ b/rust/processor/src/gap_detectors/parquet_gap_detector.rs
@@ -3,6 +3,7 @@
 
 use crate::gap_detectors::{GapDetectorResult, GapDetectorTrait, ProcessingResult};
 use ahash::AHashMap;
+use anyhow::Result;
 use std::cmp::max;
 use tracing::{debug, info};
 
@@ -29,10 +30,7 @@ impl ParquetFileGapDetector {
     }
 }
 impl GapDetectorTrait for ParquetFileGapDetector {
-    fn process_versions(
-        &mut self,
-        result: ProcessingResult,
-    ) -> anyhow::Result<GapDetectorResult, Box<dyn std::error::Error + Send + Sync>> {
+    fn process_versions(&mut self, result: ProcessingResult) -> Result<GapDetectorResult> {
         // Update counts of structures for each transaction version
         let result = match result {
             ProcessingResult::ParquetProcessingResult(r) => r,

--- a/rust/processor/src/processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_default_processor.rs
@@ -31,6 +31,7 @@ const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
 pub struct DefaultParquetProcessorConfig {
     pub google_application_credentials: Option<String>,
     pub bucket_name: String,
+    pub bucket_root: String,
     pub parquet_handler_response_channel_size: usize,
     pub max_buffer_size: usize,
 }
@@ -59,6 +60,7 @@ impl DefaultParquetProcessor {
             new_gap_detector_sender.clone(),
             ProcessorName::DefaultParquetProcessor.into(),
             config.bucket_name.clone(),
+            config.bucket_root.clone(),
             config.parquet_handler_response_channel_size,
             config.max_buffer_size,
         );
@@ -67,6 +69,7 @@ impl DefaultParquetProcessor {
             new_gap_detector_sender.clone(),
             ProcessorName::DefaultParquetProcessor.into(),
             config.bucket_name.clone(),
+            config.bucket_root.clone(),
             config.parquet_handler_response_channel_size,
             config.max_buffer_size,
         );
@@ -75,6 +78,7 @@ impl DefaultParquetProcessor {
             new_gap_detector_sender.clone(),
             ProcessorName::DefaultParquetProcessor.into(),
             config.bucket_name.clone(),
+            config.bucket_root.clone(),
             config.parquet_handler_response_channel_size,
             config.max_buffer_size,
         );
@@ -83,6 +87,7 @@ impl DefaultParquetProcessor {
             new_gap_detector_sender.clone(),
             ProcessorName::DefaultParquetProcessor.into(),
             config.bucket_name.clone(),
+            config.bucket_root.clone(),
             config.parquet_handler_response_channel_size,
             config.max_buffer_size,
         );
@@ -132,10 +137,7 @@ impl ProcessorTrait for DefaultParquetProcessor {
 
         let mr_parquet_data = ParquetDataGeneric {
             data: mr,
-            last_transaction_timestamp: last_transaction_timestamp.clone(),
             transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
-            first_txn_version: start_version,
-            last_txn_version: end_version,
         };
 
         self.move_resource_sender
@@ -145,10 +147,7 @@ impl ProcessorTrait for DefaultParquetProcessor {
 
         let wsc_parquet_data = ParquetDataGeneric {
             data: wsc,
-            last_transaction_timestamp: last_transaction_timestamp.clone(),
             transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
-            first_txn_version: start_version,
-            last_txn_version: end_version,
         };
         self.wsc_sender
             .send(wsc_parquet_data)
@@ -157,10 +156,7 @@ impl ProcessorTrait for DefaultParquetProcessor {
 
         let t_parquet_data = ParquetDataGeneric {
             data: t,
-            last_transaction_timestamp: last_transaction_timestamp.clone(),
             transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
-            first_txn_version: start_version,
-            last_txn_version: end_version,
         };
         self.transaction_sender
             .send(t_parquet_data)
@@ -169,10 +165,7 @@ impl ProcessorTrait for DefaultParquetProcessor {
 
         let ti_parquet_data = ParquetDataGeneric {
             data: ti,
-            last_transaction_timestamp: last_transaction_timestamp.clone(),
             transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
-            first_txn_version: start_version,
-            last_txn_version: end_version,
         };
 
         self.ti_sender

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -15,6 +15,7 @@ use aptos_protos::{
     util::timestamp::Timestamp,
 };
 use bigdecimal::{BigDecimal, Signed, ToPrimitive, Zero};
+use chrono::NaiveDateTime;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
@@ -264,6 +265,13 @@ fn get_clean_script_payload(payload: &ScriptPayload, version: i64) -> ScriptPayl
                 })
             })
             .collect(),
+    }
+}
+
+pub fn naive_datetime_to_timestamp(ndt: NaiveDateTime) -> Timestamp {
+    Timestamp {
+        seconds: ndt.and_utc().timestamp(),
+        nanos: ndt.and_utc().timestamp_subsec_nanos() as i32,
     }
 }
 

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -75,6 +75,18 @@ pub fn standardize_address(handle: &str) -> String {
     }
 }
 
+/// Standardizes all addresses and table handles to be length 66 (0x-64 length hash) that takes in a slice.
+pub fn standardize_address_from_bytes(bytes: &[u8]) -> String {
+    let encdoed_bytes = hex::encode(bytes);
+    // let encdoed_bytes = binding.as_str();
+
+    if let Some(handle) = &encdoed_bytes.strip_prefix("0x") {
+        format!("0x{:0>64}", handle)
+    } else {
+        format!("0x{:0>64}", encdoed_bytes)
+    }
+}
+
 pub fn hash_str(val: &str) -> String {
     hex::encode(sha2::Sha256::digest(val.as_bytes()))
 }

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -4,7 +4,10 @@
 use crate::{
     config::IndexerGrpcHttp2Config,
     db::common::models::{ledger_info::LedgerInfo, processor_status::ProcessorStatusQuery},
-    gap_detectors::{create_gap_detector_status_tracker_loop, ProcessingResult},
+    gap_detectors::{
+        create_gap_detector_status_tracker_loop, gap_detector::DefaultGapDetector,
+        parquet_gap_detector::ParquetFileGapDetector, GapDetectorTrait, ProcessingResult,
+    },
     grpc_stream::TransactionsPBResponse,
     processors::{
         account_transactions_processor::AccountTransactionsProcessor, ans_processor::AnsProcessor,
@@ -45,9 +48,6 @@ use std::collections::HashSet;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info};
 use url::Url;
-use crate::gap_detectors::gap_detector::DefaultGapDetector;
-use crate::gap_detectors::GapDetectorTrait;
-use crate::gap_detectors::parquet_gap_detector::ParquetFileGapDetector;
 
 // this is how large the fetch queue should be. Each bucket should have a max of 80MB or so, so a batch
 // of 50 means that we could potentially have at least 4.8GB of data in memory at any given time and that we should provision


### PR DESCRIPTION
### Summary
- made bucket root to be configurable for each stage.
- fix gap detector issue where the parquet gap detector wasn't updating its processor status to db.
- move unrelated functions in MoveResource to outside of the struct impl
- removed unnecessary fields in the parquetProcessingResult

### Test Plan
Tested locally and verified status being updated
![Screenshot 2024-06-25 at 4 54 51 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/eab93f40-f17e-4d90-9783-7466e57abcd1)
