### PR TITLE
Generated token standard column

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-06-26-220144_add_token_standard/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-26-220144_add_token_standard/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
+    DROP COLUMN token_standard;

--- a/rust/processor/src/db/postgres/migrations/2024-06-26-220144_add_token_standard/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-26-220144_add_token_standard/up.sql
@@ -1,0 +1,8 @@
+-- Your SQL goes here
+ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
+    ADD COLUMN token_standard VARCHAR(10) GENERATED ALWAYS AS (
+        CASE 
+            WHEN asset_type_v2 IS NOT NULL THEN 'v2'
+            ELSE 'v1'
+        END
+    ) STORED;

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -673,6 +673,8 @@ diesel::table! {
         inserted_at -> Timestamp,
         #[max_length = 1000]
         asset_type -> Nullable<Varchar>,
+        #[max_length = 10]
+        token_standard -> Nullable<Varchar>,
     }
 }
 


### PR DESCRIPTION
## Description 
Adding a generated column for backwards compatibility with `current_fungible_asset_balances`

## Testing 
Run fungible_asset_processor
![Screenshot 2024-06-26 at 7 10 21 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/8248583/6aec061f-b188-4850-abfa-4623e0c41f88)
