### PR TITLE
add parquet-txn-metadata-processor

### DIFF
--- a/rust/processor/src/db/common/models/transaction_metadata_model/mod.rs
+++ b/rust/processor/src/db/common/models/transaction_metadata_model/mod.rs
@@ -4,3 +4,8 @@
 pub mod event_size_info;
 pub mod transaction_size_info;
 pub mod write_set_size_info;
+
+// parquet models
+pub mod parquet_event_size_info;
+pub mod parquet_transaction_size_info;
+pub mod parquet_write_set_size_info;

--- a/rust/processor/src/db/common/models/transaction_metadata_model/parquet_event_size_info.rs
+++ b/rust/processor/src/db/common/models/transaction_metadata_model/parquet_event_size_info.rs
@@ -1,0 +1,42 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::extra_unused_lifetimes)]
+
+use crate::bq_analytics::generic_parquet_processor::{HasVersion, NamedTable};
+use allocative_derive::Allocative;
+use aptos_protos::transaction::v1::EventSizeInfo;
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
+)]
+pub struct EventSize {
+    pub txn_version: i64,
+    pub index: i64,
+    pub type_tag_bytes: i64,
+    pub total_bytes: i64,
+}
+
+impl NamedTable for EventSize {
+    const TABLE_NAME: &'static str = "event_size";
+}
+
+impl HasVersion for EventSize {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl EventSize {
+    pub fn from_event_size_info(info: &EventSizeInfo, txn_version: i64, index: i64) -> Self {
+        EventSize {
+            txn_version,
+            index,
+            type_tag_bytes: info.type_tag_bytes as i64,
+            total_bytes: info.total_bytes as i64,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/transaction_metadata_model/parquet_event_size_info.rs
+++ b/rust/processor/src/db/common/models/transaction_metadata_model/parquet_event_size_info.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct EventSize {
     pub txn_version: i64,
-    pub index: i64,
+    pub event_index: i64,
     pub type_tag_bytes: i64,
     pub total_bytes: i64,
 }
@@ -31,10 +31,10 @@ impl HasVersion for EventSize {
 }
 
 impl EventSize {
-    pub fn from_event_size_info(info: &EventSizeInfo, txn_version: i64, index: i64) -> Self {
+    pub fn from_event_size_info(info: &EventSizeInfo, txn_version: i64, event_index: i64) -> Self {
         EventSize {
             txn_version,
-            index,
+            event_index,
             type_tag_bytes: info.type_tag_bytes as i64,
             total_bytes: info.total_bytes as i64,
         }

--- a/rust/processor/src/db/common/models/transaction_metadata_model/parquet_transaction_size_info.rs
+++ b/rust/processor/src/db/common/models/transaction_metadata_model/parquet_transaction_size_info.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
 pub struct TransactionSize {
     pub txn_version: i64,
-    pub size_bytes: i64,
+    pub total_bytes: i64,
 }
 
 impl NamedTable for TransactionSize {
@@ -29,7 +29,7 @@ impl TransactionSize {
     pub fn from_transaction_info(info: &TransactionSizeInfo, txn_version: i64) -> Self {
         TransactionSize {
             txn_version,
-            size_bytes: info.transaction_bytes as i64,
+            total_bytes: info.transaction_bytes as i64,
         }
     }
 }

--- a/rust/processor/src/db/common/models/transaction_metadata_model/parquet_transaction_size_info.rs
+++ b/rust/processor/src/db/common/models/transaction_metadata_model/parquet_transaction_size_info.rs
@@ -1,0 +1,35 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::extra_unused_lifetimes)]
+
+use crate::bq_analytics::generic_parquet_processor::{HasVersion, NamedTable};
+use allocative_derive::Allocative;
+use aptos_protos::transaction::v1::TransactionSizeInfo;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
+pub struct TransactionSize {
+    pub txn_version: i64,
+    pub size_bytes: i64,
+}
+
+impl NamedTable for TransactionSize {
+    const TABLE_NAME: &'static str = "transaction_size";
+}
+
+impl HasVersion for TransactionSize {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl TransactionSize {
+    pub fn from_transaction_info(info: &TransactionSizeInfo, txn_version: i64) -> Self {
+        TransactionSize {
+            txn_version,
+            size_bytes: info.transaction_bytes as i64,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/transaction_metadata_model/parquet_write_set_size_info.rs
+++ b/rust/processor/src/db/common/models/transaction_metadata_model/parquet_write_set_size_info.rs
@@ -15,9 +15,10 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct WriteSetSize {
     pub txn_version: i64,
-    pub index: i64,
+    pub change_index: i64,
     pub key_bytes: i64,
     pub value_bytes: i64,
+    pub total_bytes: i64,
 }
 
 impl NamedTable for WriteSetSize {
@@ -31,12 +32,13 @@ impl HasVersion for WriteSetSize {
 }
 
 impl WriteSetSize {
-    pub fn from_transaction_info(info: &WriteOpSizeInfo, txn_version: i64, index: i64) -> Self {
+    pub fn from_transaction_info(info: &WriteOpSizeInfo, txn_version: i64, change_index: i64) -> Self {
         WriteSetSize {
             txn_version,
-            index,
+            change_index,
             key_bytes: info.key_bytes as i64,
             value_bytes: info.value_bytes as i64,
+            total_bytes: info.key_bytes as i64 + info.value_bytes as i64,
         }
     }
 }

--- a/rust/processor/src/db/common/models/transaction_metadata_model/parquet_write_set_size_info.rs
+++ b/rust/processor/src/db/common/models/transaction_metadata_model/parquet_write_set_size_info.rs
@@ -1,0 +1,42 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::extra_unused_lifetimes)]
+
+use crate::bq_analytics::generic_parquet_processor::{HasVersion, NamedTable};
+use allocative_derive::Allocative;
+use aptos_protos::transaction::v1::WriteOpSizeInfo;
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
+)]
+pub struct WriteSetSize {
+    pub txn_version: i64,
+    pub index: i64,
+    pub key_bytes: i64,
+    pub value_bytes: i64,
+}
+
+impl NamedTable for WriteSetSize {
+    const TABLE_NAME: &'static str = "write_set_size";
+}
+
+impl HasVersion for WriteSetSize {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl WriteSetSize {
+    pub fn from_transaction_info(info: &WriteOpSizeInfo, txn_version: i64, index: i64) -> Self {
+        WriteSetSize {
+            txn_version,
+            index,
+            key_bytes: info.key_bytes as i64,
+            value_bytes: info.value_bytes as i64,
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/user_transactions_models/mod.rs
+++ b/rust/processor/src/db/common/models/user_transactions_models/mod.rs
@@ -3,3 +3,5 @@
 
 pub mod signatures;
 pub mod user_transactions;
+
+// parquet models

--- a/rust/processor/src/processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_default_processor.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{ProcessorName, ProcessorTrait};
+use super::{ProcessorName, ProcessorTrait, GOOGLE_APPLICATION_CREDENTIALS};
 use crate::{
     bq_analytics::{
         generic_parquet_processor::ParquetDataGeneric,
@@ -23,8 +23,6 @@ use async_trait::async_trait;
 use kanal::AsyncSender;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter, Result};
-
-const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/rust/processor/src/processors/parquet_transaction_metadata_processor.rs
+++ b/rust/processor/src/processors/parquet_transaction_metadata_processor.rs
@@ -1,0 +1,214 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{ProcessorName, ProcessorTrait};
+use crate::{
+    bq_analytics::{
+        generic_parquet_processor::ParquetDataGeneric,
+        parquet_handler::create_parquet_handler_loop, ParquetProcessingResult,
+    },
+    db::common::models::transaction_metadata_model::{
+        parquet_event_size_info::EventSize, parquet_transaction_size_info::TransactionSize,
+        parquet_write_set_size_info::WriteSetSize,
+    },
+    gap_detectors::ProcessingResult,
+    utils::database::ArcDbPool,
+};
+use ahash::AHashMap;
+use anyhow::anyhow;
+use aptos_protos::transaction::v1::Transaction;
+use async_trait::async_trait;
+use kanal::AsyncSender;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use tracing::warn;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ParquetTransactionMetadataProcessorConfig {
+    pub google_application_credentials: Option<String>,
+    pub bucket_name: String,
+    pub parquet_handler_response_channel_size: usize,
+    pub max_buffer_size: usize,
+}
+
+pub struct ParquetTransactionMetadataProcessor {
+    connection_pool: ArcDbPool,
+    transaction_size_info_sender: AsyncSender<ParquetDataGeneric<TransactionSize>>,
+    event_size_sender: AsyncSender<ParquetDataGeneric<EventSize>>,
+    ws_size_sender: AsyncSender<ParquetDataGeneric<WriteSetSize>>,
+}
+
+impl ParquetTransactionMetadataProcessor {
+    pub fn new(
+        connection_pool: ArcDbPool,
+        config: ParquetTransactionMetadataProcessorConfig,
+        new_gap_detector_sender: AsyncSender<ProcessingResult>,
+    ) -> Self {
+        if let Some(credentials) = config.google_application_credentials.clone() {
+            std::env::set_var(
+                crate::processors::GOOGLE_APPLICATION_CREDENTIALS,
+                credentials,
+            );
+        }
+
+        let transaction_size_info_sender = create_parquet_handler_loop::<TransactionSize>(
+            new_gap_detector_sender.clone(),
+            ProcessorName::ParquetTransactionMetadataProcessor.into(),
+            config.bucket_name.clone(),
+            config.parquet_handler_response_channel_size,
+            config.max_buffer_size,
+        );
+
+        let event_size_sender = create_parquet_handler_loop::<EventSize>(
+            new_gap_detector_sender.clone(),
+            ProcessorName::ParquetTransactionMetadataProcessor.into(),
+            config.bucket_name.clone(),
+            config.parquet_handler_response_channel_size,
+            config.max_buffer_size,
+        );
+
+        let ws_size_sender = create_parquet_handler_loop::<WriteSetSize>(
+            new_gap_detector_sender.clone(),
+            ProcessorName::ParquetTransactionMetadataProcessor.into(),
+            config.bucket_name.clone(),
+            config.parquet_handler_response_channel_size,
+            config.max_buffer_size,
+        );
+
+        Self {
+            connection_pool,
+            transaction_size_info_sender,
+            event_size_sender,
+            ws_size_sender,
+        }
+    }
+}
+
+impl Debug for ParquetTransactionMetadataProcessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ParquetTransactionMetadataProcessor {{ capacity of tsi channel: {:?}, capacity of es channel: {:?}, capacity of ws channel: {:?} }}",
+            &self.transaction_size_info_sender.capacity(),
+            &self.event_size_sender.capacity(),
+            &self.ws_size_sender.capacity(),
+        )
+    }
+}
+
+#[async_trait]
+impl ProcessorTrait for ParquetTransactionMetadataProcessor {
+    fn name(&self) -> &'static str {
+        ProcessorName::TransactionMetadataProcessor.into()
+    }
+
+    async fn process_transactions(
+        &self,
+        transactions: Vec<Transaction>,
+        start_version: u64,
+        end_version: u64,
+        _: Option<u64>,
+    ) -> anyhow::Result<ProcessingResult> {
+        let last_transaction_timestamp = transactions.last().unwrap().timestamp.clone();
+        let mut transaction_version_to_struct_count: AHashMap<i64, i64> = AHashMap::new();
+
+        let mut transaction_sizes = vec![];
+        let mut event_sizes = vec![];
+        let mut write_set_sizes = vec![];
+        for txn in &transactions {
+            let txn_version = txn.version as i64;
+            let size_info = match txn.size_info.as_ref() {
+                Some(size_info) => size_info,
+                None => {
+                    warn!(version = txn.version, "Transaction size info not found");
+                    continue;
+                },
+            };
+            transaction_sizes.push(TransactionSize::from_transaction_info(
+                size_info,
+                txn_version,
+            ));
+            transaction_version_to_struct_count
+                .entry(txn_version)
+                .and_modify(|e| *e += 1)
+                .or_insert(1);
+
+            for (index, event_size_info) in size_info.event_size_info.iter().enumerate() {
+                event_sizes.push(EventSize::from_event_size_info(
+                    event_size_info,
+                    txn_version,
+                    index as i64,
+                ));
+            }
+            transaction_version_to_struct_count
+                .entry(txn_version)
+                .and_modify(|e| *e += event_sizes.len() as i64)
+                .or_insert(1);
+
+            for (index, write_set_size_info) in size_info.write_op_size_info.iter().enumerate() {
+                write_set_sizes.push(WriteSetSize::from_transaction_info(
+                    write_set_size_info,
+                    txn_version,
+                    index as i64,
+                ));
+            }
+            transaction_version_to_struct_count
+                .entry(txn_version)
+                .and_modify(|e| *e += write_set_sizes.len() as i64)
+                .or_insert(1);
+        }
+
+        let tsi = ParquetDataGeneric {
+            data: transaction_sizes,
+            last_transaction_timestamp: last_transaction_timestamp.clone(),
+            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
+            first_txn_version: start_version,
+            last_txn_version: end_version,
+        };
+
+        self.transaction_size_info_sender
+            .send(tsi)
+            .await
+            .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
+
+        let esi = ParquetDataGeneric {
+            data: event_sizes,
+            last_transaction_timestamp: last_transaction_timestamp.clone(),
+            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
+            first_txn_version: start_version,
+            last_txn_version: end_version,
+        };
+
+        self.event_size_sender
+            .send(esi)
+            .await
+            .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
+
+        let wssi = ParquetDataGeneric {
+            data: write_set_sizes,
+            last_transaction_timestamp: last_transaction_timestamp.clone(),
+            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
+            first_txn_version: start_version,
+            last_txn_version: end_version,
+        };
+
+        self.ws_size_sender
+            .send(wssi)
+            .await
+            .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
+
+        Ok(ProcessingResult::ParquetProcessingResult(
+            ParquetProcessingResult {
+                start_version: start_version as i64,
+                end_version: end_version as i64,
+                last_transaction_timestamp: last_transaction_timestamp.clone(),
+                txn_version_to_struct_count: AHashMap::new(),
+            },
+        ))
+    }
+
+    fn connection_pool(&self) -> &ArcDbPool {
+        &self.connection_pool
+    }
+}

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -12,6 +12,7 @@ use crate::{
         events_processor::EventsProcessor, fungible_asset_processor::FungibleAssetProcessor,
         monitoring_processor::MonitoringProcessor, nft_metadata_processor::NftMetadataProcessor,
         objects_processor::ObjectsProcessor, parquet_default_processor::DefaultParquetProcessor,
+        parquet_transaction_metadata_processor::ParquetTransactionMetadataProcessor,
         stake_processor::StakeProcessor, token_processor::TokenProcessor,
         token_v2_processor::TokenV2Processor,
         transaction_metadata_processor::TransactionMetadataProcessor,
@@ -870,6 +871,13 @@ pub fn build_processor(
         ),
         ProcessorConfig::DefaultParquetProcessor(config) => {
             Processor::from(DefaultParquetProcessor::new(
+                db_pool,
+                config.clone(),
+                gap_detector_sender.expect("Parquet processor requires a gap detector sender"),
+            ))
+        },
+        ProcessorConfig::ParquetTransactionMetadataProcessor(config) => {
+            Processor::from(ParquetTransactionMetadataProcessor::new(
                 db_pool,
                 config.clone(),
                 gap_detector_sender.expect("Parquet processor requires a gap detector sender"),


### PR DESCRIPTION
### Summary

Adding a parquet processors for tables handled by transaction_metadata_processor. 

dependent pr: https://github.com/aptos-labs/aptos-indexer-processors/pull/428


### Test Plan
tested locally and verified parquet files being uploaded to gcs bucket
![Screenshot 2024-06-26 at 4 44 46 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/4d9877ca-f399-448e-824d-b9b96b707e88)
