### PR TITLE
move current_token_pending_claims to token_v2 processor

### DIFF
--- a/rust/processor/src/db/common/models/token_models/token_claims.rs
+++ b/rust/processor/src/db/common/models/token_models/token_claims.rs
@@ -12,7 +12,9 @@ use bigdecimal::{BigDecimal, Zero};
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, FieldCount, Identifiable, Insertable, PartialEq, Serialize,
+)]
 #[diesel(primary_key(token_data_id_hash, property_version, from_address, to_address))]
 #[diesel(table_name = current_token_pending_claims)]
 pub struct CurrentTokenPendingClaim {
@@ -30,6 +32,22 @@ pub struct CurrentTokenPendingClaim {
     pub last_transaction_timestamp: chrono::NaiveDateTime,
     pub token_data_id: String,
     pub collection_id: String,
+}
+
+impl Ord for CurrentTokenPendingClaim {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id_hash
+            .cmp(&other.token_data_id_hash)
+            .then(self.property_version.cmp(&other.property_version))
+            .then(self.from_address.cmp(&other.from_address))
+            .then(self.to_address.cmp(&other.to_address))
+    }
+}
+
+impl PartialOrd for CurrentTokenPendingClaim {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl CurrentTokenPendingClaim {

--- a/rust/processor/src/db/common/models/token_v2_models/v2_token_metadata.rs
+++ b/rust/processor/src/db/common/models/token_v2_models/v2_token_metadata.rs
@@ -25,7 +25,9 @@ use serde_json::Value;
 // PK of current_objects, i.e. object_address, resource_type
 pub type CurrentTokenV2MetadataPK = (String, String);
 
-#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, FieldCount, Identifiable, Insertable, PartialEq, Serialize,
+)]
 #[diesel(primary_key(object_address, resource_type))]
 #[diesel(table_name = current_token_v2_metadata)]
 pub struct CurrentTokenV2Metadata {
@@ -34,6 +36,19 @@ pub struct CurrentTokenV2Metadata {
     pub data: Value,
     pub state_key_hash: String,
     pub last_transaction_version: i64,
+}
+
+impl Ord for CurrentTokenV2Metadata {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.object_address
+            .cmp(&other.object_address)
+            .then(self.resource_type.cmp(&other.resource_type))
+    }
+}
+impl PartialOrd for CurrentTokenV2Metadata {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl CurrentTokenV2Metadata {

--- a/rust/processor/src/db/common/models/token_v2_models/v2_token_ownerships.rs
+++ b/rust/processor/src/db/common/models/token_v2_models/v2_token_ownerships.rs
@@ -55,7 +55,9 @@ pub struct TokenOwnershipV2 {
     pub non_transferrable_by_owner: Option<bool>,
 }
 
-#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, FieldCount, Identifiable, Insertable, PartialEq, Serialize,
+)]
 #[diesel(primary_key(token_data_id, property_version_v1, owner_address, storage_id))]
 #[diesel(table_name = current_token_ownerships_v2)]
 pub struct CurrentTokenOwnershipV2 {
@@ -72,6 +74,22 @@ pub struct CurrentTokenOwnershipV2 {
     pub last_transaction_version: i64,
     pub last_transaction_timestamp: chrono::NaiveDateTime,
     pub non_transferrable_by_owner: Option<bool>,
+}
+
+impl Ord for CurrentTokenOwnershipV2 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id
+            .cmp(&other.token_data_id)
+            .then(self.property_version_v1.cmp(&other.property_version_v1))
+            .then(self.owner_address.cmp(&other.owner_address))
+            .then(self.storage_id.cmp(&other.storage_id))
+    }
+}
+
+impl PartialOrd for CurrentTokenOwnershipV2 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 // Facilitate tracking when a token is burned

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -91,6 +91,7 @@ impl Debug for TokenV2Processor {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn insert_to_db(
     conn: ArcDbPool,
     name: &'static str,

--- a/rust/processor/src/processors/token_v2_processor.rs
+++ b/rust/processor/src/processors/token_v2_processor.rs
@@ -590,8 +590,6 @@ impl ProcessorTrait for TokenV2Processor {
         let table_handle_to_owner =
             TableMetadataForToken::get_table_handle_to_owner_from_transactions(&transactions);
 
-        // get pending token
-
         let query_retries = self.config.query_retries;
         let query_retry_delay_ms = self.config.query_retry_delay_ms;
         // Token V2 processing which includes token v1
@@ -1264,52 +1262,11 @@ async fn parse_v2_token(
     current_collections_v2.sort_by(|a, b| a.collection_id.cmp(&b.collection_id));
     current_deleted_token_datas_v2.sort_by(|a, b| a.token_data_id.cmp(&b.token_data_id));
     current_token_datas_v2.sort_by(|a, b| a.token_data_id.cmp(&b.token_data_id));
-    current_token_ownerships_v2.sort_by(|a, b| {
-        (
-            &a.token_data_id,
-            &a.property_version_v1,
-            &a.owner_address,
-            &a.storage_id,
-        )
-            .cmp(&(
-                &b.token_data_id,
-                &b.property_version_v1,
-                &b.owner_address,
-                &b.storage_id,
-            ))
-    });
-    current_token_v2_metadata.sort_by(|a, b| {
-        (&a.object_address, &a.resource_type).cmp(&(&b.object_address, &b.resource_type))
-    });
-    current_deleted_token_ownerships_v2.sort_by(|a, b| {
-        (
-            &a.token_data_id,
-            &a.property_version_v1,
-            &a.owner_address,
-            &a.storage_id,
-        )
-            .cmp(&(
-                &b.token_data_id,
-                &b.property_version_v1,
-                &b.owner_address,
-                &b.storage_id,
-            ))
-    });
+    current_token_ownerships_v2.sort();
+    current_token_v2_metadata.sort();
+    current_deleted_token_ownerships_v2.sort();
     current_token_royalties_v1.sort();
-    all_current_token_claims.sort_by(|a, b| {
-        (
-            &a.token_data_id_hash,
-            &a.property_version,
-            &a.from_address,
-            &a.to_address,
-        )
-            .cmp(&(
-                &b.token_data_id_hash,
-                &b.property_version,
-                &b.from_address,
-                &a.to_address,
-            ))
-    });
+    all_current_token_claims.sort();
 
     (
         collections_v2,


### PR DESCRIPTION
### Descriptioin
As part of the V1 table deprecation, we will be deprecating token_processor. However, there is no replacement table for `current_token_pending_claims`, so we move this table to token_v2 processor 

### Test Plan
![Screenshot 2024-06-27 at 2 02 41 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/be03625d-a542-443b-9979-20448dca9761)
![Screenshot 2024-06-27 at 2 15 45 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/d4451b72-cbbb-45ee-ab20-5869023d13f2)
