### PR TITLE
create migration view for current_collection_datas

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW IF EXISTS legacy_migration_v1.current_collection_datas

--- a/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/down.sql
@@ -1,2 +1,3 @@
 -- This file should undo anything in `up.sql`
-DROP VIEW IF EXISTS legacy_migration_v1.current_collection_datas
+DROP VIEW IF EXISTS legacy_migration_v1.current_collection_datas;
+DROP INDEX IF EXISTS lm1_curr_cd_th_index;

--- a/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/up.sql
@@ -18,4 +18,4 @@ FROM current_collections_v2
 WHERE token_standard = 'v1';
 
 -- If you would like to run these indices, please do it outside of diesel migration since it will be blocking processing
--- CREATE INDEX CONCURRENTLY IF NOT EXISTS lm1_curr_cd_th_index ON public.current_collections_v2 USING btree (table_handle);
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS lm1_curr_cd_th_index ON public.current_collections_v2 USING btree (table_handle_v1);

--- a/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/up.sql
@@ -15,4 +15,7 @@ SELECT collection_id as collection_data_id_hash,
     table_handle_v1 as table_handle,
     last_transaction_timestamp
 FROM current_collections_v2
-WHERE token_standard = 'v1'
+WHERE token_standard = 'v1';
+
+-- If you would like to run these indices, please do it outside of diesel migration since it will be blocking processing
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS lm1_curr_cd_th_index ON public.current_collections_v2 USING btree (table_handle);

--- a/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-06-27-213336_add_v1_migration_view/up.sql
@@ -1,0 +1,18 @@
+-- Your SQL goes here
+CREATE OR REPLACE VIEW legacy_migration_v1.current_collection_datas AS
+SELECT collection_id as collection_data_id_hash,
+    creator_address,
+    collection_name,
+    description,
+    uri as metadata_uri,
+    current_supply as supply,
+    max_supply as maximum,
+    TRUE AS maximum_mutable,
+    mutable_uri as uri_mutable,
+    mutable_description as description_mutable,
+    last_transaction_version,
+    inserted_at,
+    table_handle_v1 as table_handle,
+    last_transaction_timestamp
+FROM current_collections_v2
+WHERE token_standard = 'v1'


### PR DESCRIPTION
### Description
As part of the V1 table deprecation, replace the v1 table with view using the v2 table


### Test Plan
![Screenshot 2024-06-27 at 2 58 57 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/749c2e23-b559-40f6-8421-8d096f47be30)
![Screenshot 2024-06-27 at 2 58 45 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/1f99ab9a-694f-4ee1-b14d-6e2405b2e590)
![Screenshot 2024-06-28 at 11 03 45 AM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/638c5342-1fe6-4c47-bd58-80b043b39e63)
