### PR TITLE
fix payload filtering for parquet processor

### DIFF
--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -187,24 +187,26 @@ impl Transaction {
                     block_height,
                     block_timestamp,
                 );
-                let payload = user_txn
+                let request = &user_txn
                     .request
                     .as_ref()
-                    .expect("Getting user request failed.")
-                    .payload
-                    .as_ref()
-                    .expect("Getting payload failed.");
-                let payload_cleaned = get_clean_payload(payload, txn_version);
-                let payload_type = get_payload_type(payload);
+                    .expect("Getting user request failed.");
 
-                // let serialized_payload = serde_json::to_string(&payload_cleaned).unwrap(); // Handle errors as needed)
+                let (payload_cleaned, payload_type) = match request.payload.as_ref() {
+                    Some(payload) => {
+                        let payload_cleaned = get_clean_payload(payload, txn_version);
+                        (payload_cleaned, Some(get_payload_type(payload)))
+                    },
+                    None => (None, None),
+                };
+
                 let serialized_payload =
                     payload_cleaned.map(|payload| canonical_json::to_string(&payload).unwrap());
                 (
                     Self::from_transaction_info_with_data(
                         transaction_info,
                         serialized_payload,
-                        Some(payload_type),
+                        payload_type,
                         txn_version,
                         transaction_type,
                         user_txn.events.len() as i64,


### PR DESCRIPTION
### 
Fix a bug with txn payload filtering: 
```
│       Message:   mber":126,"threadName":"tokio-runtime-worker","threadId":"ThreadId(41)"}                                                                                                                                                                                   │
│ details = """                                                                                                                                                                                                                                                               │
│ panicked at processor/src/db/common/models/default_models/parquet_transactions.rs:196:22:                                                                                                                                                                                   │
│ Getting payload failed."""                                                                                                                                                                                                                                                  │
│ backtrace = """                                                                                                                                                                                                                                                             │
│    0:     0x56a4c9ea1ae9 - backtrace::capture::Backtrace::new::h3c022c8b3242bd1e                                                                                                                                                                                            │
│    1:     0x56a4c9d7be50 - server_framework::setup_panic_handler::{{closure}}::h427021b0f79aebcf                                                                                                                                                                            │
│    2:     0x56a4ca2bd616 - std::panicking::rust_panic_with_hook::hac8bdceee1e4fe2c                                                                                                                                                                                          │
│    3:     0x56a4ca2bd3c4 - std::panicking::begin_panic_handler::{{closure}}::h00d785e82757ce3c                                                                                                                                                                              │
│    4:     0x56a4ca2bc419 - std::sys_common::backtrace::__rust_end_short_backtrace::h1628d957bcd06996                                                                                                                                                                        │
│    5:     0x56a4ca2bd0f7 - rust_begin_unwind                                                                                                                                                                                                                                │
│    6:     0x56a4c9095b03 - core::panicking::panic_fmt::hdc63834ffaaefae5                                                                                                                                                                                                    │
│    7:     0x56a4ca2e218c - core::panicking::panic_display::h57ec0894e5f003fc                                                                                                                                                                                                │
│    8:     0x56a4c9095acc - core::option::expect_failed::h7f842a57ad883afa                                                                                                                                                                                                   │
│    9:     0x56a4c95bae7f - processor::db::common::models::default_models::parquet_transactions::Transaction::from_transaction::h30fcd823adb401af                                                                                                                            │
│   10:     0x56a4c95bb567 - processor::db::common::models::default_models::parquet_transactions::Transaction::from_transactions::h397fcdcee109b99b                                                                                                                           │
│   11:     0x56a4c926a2e1 - processor::processors::parquet_default_processor::process_transactions::hf0c14fe9549790fe                                                                                                                                                        │
│   12:     0x56a4c9885b64 - tokio::runtime::task::core::Core<T,S>::poll::h68e4a3842ef1743a                                                                                                                                                                                   │
│   13:     0x56a4c92ed774 - tokio::runtime::task::harness::Harness<T,S>::poll::h5357f728210cde3f                                                                                                                                                                             │
│   14:     0x56a4ca0bc4b8 - tokio::runtime::blocking::pool::Inner::run::hc83a015021acf1d3                                                                                                                                                                                    │
│   15:     0x56a4ca0c4036 - std::sys_common::backtrace::__rust_begin_short_backtrace::h1d78f792019de3a8                                                                                                                                                                      │
│   16:     0x56a4ca0a4702 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h6d89deeff2847687                                                                                                                                                                         │
│   17:     0x56a4ca2c013b - std::sys::pal::unix::thread::Thread::new::thread_start::h522bc89a54da820a                                                                                                                                                                        │
│   18:     0x7e45f6022ea7 - start_thread                                                                                                                                                                                                                                     │
│   19:     0x7e45f5df6a6f - clone                                                                                                                                                                                                                                            │
│   20:                0x0 - <unknown>                                                                                                                                                                                                                                        │
│ """                                                                                             
```

### test plan

![Screenshot 2024-07-01 at 5 17 20 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/1d99c212-1b32-4aee-91d6-09d9b0ec1ae4)
