### PR TITLE
drop deprecated tables

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-07-08-182507_delete_deprecated_tables/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-07-08-182507_delete_deprecated_tables/down.sql
@@ -1,0 +1,100 @@
+-- Recreate the transactions table
+CREATE TABLE transactions (
+  version BIGINT UNIQUE PRIMARY KEY NOT NULL,
+  block_height BIGINT NOT NULL,
+  hash VARCHAR(66) UNIQUE NOT NULL,
+  type VARCHAR(50) NOT NULL,
+  payload jsonb,
+  state_change_hash VARCHAR(66) NOT NULL,
+  event_root_hash VARCHAR(66) NOT NULL,
+  state_checkpoint_hash VARCHAR(66),
+  gas_used NUMERIC NOT NULL,
+  success BOOLEAN NOT NULL,
+  vm_status TEXT NOT NULL,
+  accumulator_root_hash VARCHAR(66) NOT NULL,
+  num_events BIGINT NOT NULL,
+  num_write_set_changes BIGINT NOT NULL,
+  -- Default time columns
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+---- Recreate the move_resources table
+CREATE TABLE move_resources (
+  transaction_version BIGINT NOT NULL,
+  write_set_change_index BIGINT NOT NULL,
+  transaction_block_height BIGINT NOT NULL,
+  name TEXT NOT NULL,
+  address VARCHAR(66) NOT NULL,
+  type TEXT NOT NULL,
+  module TEXT NOT NULL,
+  generic_type_params jsonb,
+  data jsonb,
+  is_deleted BOOLEAN NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (transaction_version, write_set_change_index),
+  CONSTRAINT fk_transaction_versions FOREIGN KEY (transaction_version) REFERENCES transactions (version)
+);
+
+-- Recreate indexes and views for move_resources
+CREATE INDEX mr_addr_mod_name_ver_index ON move_resources (address, module, name, transaction_version);
+CREATE INDEX mr_insat_index ON move_resources (inserted_at);
+CREATE INDEX IF NOT EXISTS mr_ver_index ON move_resources(transaction_version DESC);
+
+CREATE VIEW move_resources_view AS
+SELECT transaction_version,
+  write_set_change_index,
+  transaction_block_height,
+  name,
+  address,
+  "type",
+  "module",
+  generic_type_params,
+  data#>>'{}' as json_data,
+  is_deleted,
+  inserted_at
+FROM move_resources;
+
+-- Recreate the address_version_from_move_resources view
+CREATE OR REPLACE VIEW address_version_from_move_resources AS
+SELECT address,
+  transaction_version
+FROM move_resources
+GROUP BY 1, 2;
+
+-- Recreate the write_set_changes table
+CREATE TABLE write_set_changes (
+  transaction_version BIGINT NOT NULL,
+  index BIGINT NOT NULL,
+  hash VARCHAR(66) NOT NULL,
+  transaction_block_height BIGINT NOT NULL,
+  type TEXT NOT NULL,
+  address VARCHAR(66) NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (transaction_version, index)
+--  CONSTRAINT fk_transaction_versions FOREIGN KEY (transaction_version) REFERENCES transactions (version)
+);
+
+-- Recreate indexes for write_set_changes
+CREATE INDEX wsc_addr_type_ver_index ON write_set_changes (address, transaction_version DESC);
+CREATE INDEX wsc_insat_index ON write_set_changes (inserted_at);
+
+-- Recreate the transactions_view
+CREATE VIEW transactions_view AS
+SELECT "version",
+  block_height,
+  "hash",
+  "type",
+  payload#>>'{}' AS json_payload,
+  state_change_hash,
+  event_root_hash,
+  state_checkpoint_hash,
+  gas_used,
+  success,
+  vm_status,
+  accumulator_root_hash,
+  num_events,
+  num_write_set_changes,
+  inserted_at
+FROM transactions;

--- a/rust/processor/src/db/postgres/migrations/2024-07-08-182507_delete_deprecated_tables/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-07-08-182507_delete_deprecated_tables/up.sql
@@ -1,0 +1,14 @@
+-- Drop dependent views and indexes first
+DROP VIEW IF EXISTS move_resources_view;
+DROP VIEW IF EXISTS address_version_from_move_resources;
+
+-- Drop the move_resources table
+DROP TABLE IF EXISTS move_resources;
+
+-- Drop the transactions table and related objects
+DROP VIEW IF EXISTS transactions_view;
+DROP INDEX IF EXISTS txn_insat_index;
+DROP TABLE IF EXISTS transactions;
+
+-- Drop the write_set_changes table and related indexes
+DROP TABLE IF EXISTS write_set_changes;

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -877,26 +877,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    move_resources (transaction_version, write_set_change_index) {
-        transaction_version -> Int8,
-        write_set_change_index -> Int8,
-        transaction_block_height -> Int8,
-        name -> Text,
-        #[max_length = 66]
-        address -> Varchar,
-        #[sql_name = "type"]
-        type_ -> Text,
-        module -> Text,
-        generic_type_params -> Nullable<Jsonb>,
-        data -> Nullable<Jsonb>,
-        is_deleted -> Bool,
-        inserted_at -> Timestamp,
-        #[max_length = 66]
-        state_key_hash -> Varchar,
-    }
-}
-
-diesel::table! {
     nft_points (transaction_version) {
         transaction_version -> Int8,
         #[max_length = 66]
@@ -1207,35 +1187,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    transactions (version) {
-        version -> Int8,
-        block_height -> Int8,
-        #[max_length = 66]
-        hash -> Varchar,
-        #[sql_name = "type"]
-        type_ -> Varchar,
-        payload -> Nullable<Jsonb>,
-        #[max_length = 66]
-        state_change_hash -> Varchar,
-        #[max_length = 66]
-        event_root_hash -> Varchar,
-        #[max_length = 66]
-        state_checkpoint_hash -> Nullable<Varchar>,
-        gas_used -> Numeric,
-        success -> Bool,
-        vm_status -> Text,
-        #[max_length = 66]
-        accumulator_root_hash -> Varchar,
-        num_events -> Int8,
-        num_write_set_changes -> Int8,
-        inserted_at -> Timestamp,
-        epoch -> Int8,
-        #[max_length = 50]
-        payload_type -> Nullable<Varchar>,
-    }
-}
-
-diesel::table! {
     user_transactions (version) {
         version -> Int8,
         block_height -> Int8,
@@ -1252,21 +1203,6 @@ diesel::table! {
         entry_function_id_str -> Varchar,
         inserted_at -> Timestamp,
         epoch -> Int8,
-    }
-}
-
-diesel::table! {
-    write_set_changes (transaction_version, index) {
-        transaction_version -> Int8,
-        index -> Int8,
-        #[max_length = 66]
-        hash -> Varchar,
-        transaction_block_height -> Int8,
-        #[sql_name = "type"]
-        type_ -> Text,
-        #[max_length = 66]
-        address -> Varchar,
-        inserted_at -> Timestamp,
     }
 }
 
@@ -1327,7 +1263,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     indexer_status,
     ledger_infos,
     move_modules,
-    move_resources,
     nft_points,
     objects,
     processor_status,
@@ -1344,8 +1279,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     token_ownerships_v2,
     tokens,
     transaction_size_info,
-    transactions,
     user_transactions,
-    write_set_changes,
     write_set_size_info,
 );


### PR DESCRIPTION
### Description
 we stopped writing to move_resources, write_set_changes, and transactions tables, and migrated over to parquet. 

- ### This requires removing code references.


### Test Plan
tested against local db instance. 
![Screenshot 2024-07-08 at 2 34 31 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/3ba9cafa-ae70-4675-9263-91b9870258b9)
