### PR TITLE
truncate deprecated tables

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-07-08-182507_truncate_deprecated_tables/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-07-08-182507_truncate_deprecated_tables/down.sql
@@ -1,0 +1,2 @@
+-- No down migration for truncate operation
+SELECT 1;

--- a/rust/processor/src/db/postgres/migrations/2024-07-08-182507_truncate_deprecated_tables/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-07-08-182507_truncate_deprecated_tables/up.sql
@@ -1,4 +1,5 @@
 ---- Delete the data inside the tables
-TRUNCATE TABLE move_resources;
-TRUNCATE TABLE write_set_changes;
-TRUNCATE TABLE transactions;
+-- If you don't need the data and would like to delete, you could uncomment to run it.
+--TRUNCATE TABLE move_resources;
+--TRUNCATE TABLE write_set_changes;
+--TRUNCATE TABLE transactions;

--- a/rust/processor/src/db/postgres/migrations/2024-07-08-182507_truncate_deprecated_tables/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-07-08-182507_truncate_deprecated_tables/up.sql
@@ -1,0 +1,4 @@
+---- Delete the data inside the tables
+TRUNCATE TABLE move_resources;
+TRUNCATE TABLE write_set_changes;
+TRUNCATE TABLE transactions;


### PR DESCRIPTION
### Description
We stopped writing to move_resources, write_set_changes, and transactions tables, and migrated over to parquet. and we almost reached our alloydb quota, this is to free some spaces.


### Test plan
locally tested