### PR TITLE
fix: primary key conflict in upsert

### DIFF
--- a/rust/processor/src/processors/account_transactions_processor.rs
+++ b/rust/processor/src/processors/account_transactions_processor.rs
@@ -79,8 +79,7 @@ fn insert_account_transactions_query(
     (
         diesel::insert_into(schema::account_transactions::table)
             .values(item_to_insert)
-            .on_conflict((transaction_version, account_address))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }

--- a/rust/processor/src/processors/ans_processor.rs
+++ b/rust/processor/src/processors/ans_processor.rs
@@ -222,8 +222,7 @@ fn insert_ans_lookups_query(
     (
         diesel::insert_into(schema::ans_lookup::table)
             .values(item_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -264,8 +263,7 @@ fn insert_ans_primary_names_query(
     (
         diesel::insert_into(schema::ans_primary_name::table)
             .values(item_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -353,8 +351,7 @@ fn insert_ans_primary_names_v2_query(
     (
         diesel::insert_into(schema::ans_primary_name_v2::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }

--- a/rust/processor/src/processors/coin_processor.rs
+++ b/rust/processor/src/processors/coin_processor.rs
@@ -170,8 +170,7 @@ fn insert_coin_balances_query(
     (
         diesel::insert_into(schema::coin_balances::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, owner_address, coin_type_hash))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }

--- a/rust/processor/src/processors/default_processor.rs
+++ b/rust/processor/src/processors/default_processor.rs
@@ -193,8 +193,7 @@ fn insert_block_metadata_transactions_query(
     (
         diesel::insert_into(schema::block_metadata_transactions::table)
             .values(items_to_insert)
-            .on_conflict(version)
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -210,8 +209,7 @@ fn insert_write_set_changes_query(
     (
         diesel::insert_into(schema::write_set_changes::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -227,8 +225,7 @@ fn insert_move_modules_query(
     (
         diesel::insert_into(schema::move_modules::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -244,8 +241,7 @@ fn insert_move_resources_query(
     (
         diesel::insert_into(schema::move_resources::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -261,8 +257,7 @@ fn insert_table_items_query(
     (
         diesel::insert_into(schema::table_items::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -303,8 +298,7 @@ fn insert_table_metadata_query(
     (
         diesel::insert_into(schema::table_metadatas::table)
             .values(items_to_insert)
-            .on_conflict(handle)
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -179,8 +179,7 @@ fn insert_fungible_asset_activities_query(
     (
         diesel::insert_into(schema::fungible_asset_activities::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, event_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -232,8 +231,7 @@ fn insert_fungible_asset_balances_query(
     (
         diesel::insert_into(schema::fungible_asset_balances::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -337,8 +335,7 @@ fn insert_coin_supply_query(
     (
         diesel::insert_into(schema::coin_supply::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, coin_type_hash))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }

--- a/rust/processor/src/processors/stake_processor.rs
+++ b/rust/processor/src/processors/stake_processor.rs
@@ -226,8 +226,7 @@ fn insert_proposal_votes_query(
     (
         diesel::insert_into(schema::proposal_votes::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, proposal_id, voter_address))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -243,8 +242,7 @@ fn insert_delegator_activities_query(
     (
         diesel::insert_into(schema::delegated_staking_activities::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, event_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -260,8 +258,7 @@ fn insert_delegator_balances_query(
     (
         diesel::insert_into(schema::delegator_balances::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -323,8 +320,7 @@ fn insert_delegator_pool_balances_query(
     (
         diesel::insert_into(schema::delegated_staking_pool_balances::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, staking_pool_address))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }

--- a/rust/processor/src/processors/token_processor.rs
+++ b/rust/processor/src/processors/token_processor.rs
@@ -184,8 +184,7 @@ fn insert_tokens_query(
     (
         diesel::insert_into(schema::tokens::table)
             .values(tokens_to_insert)
-            .on_conflict((token_data_id_hash, property_version, transaction_version))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -201,13 +200,7 @@ fn insert_token_ownerships_query(
     (
         diesel::insert_into(schema::token_ownerships::table)
             .values(token_ownerships_to_insert)
-            .on_conflict((
-                token_data_id_hash,
-                property_version,
-                transaction_version,
-                table_handle,
-            ))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -222,8 +215,7 @@ fn insert_token_datas_query(
     (
         diesel::insert_into(schema::token_datas::table)
             .values(token_datas_to_insert)
-            .on_conflict((token_data_id_hash, transaction_version))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -239,8 +231,7 @@ fn insert_collection_datas_query(
     (
         diesel::insert_into(schema::collection_datas::table)
             .values(collection_datas_to_insert)
-            .on_conflict((collection_data_id_hash, transaction_version))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -350,13 +341,7 @@ fn insert_token_activities_query(
     (
         diesel::insert_into(schema::token_activities::table)
             .values(items_to_insert)
-            .on_conflict((
-                transaction_version,
-                event_account_address,
-                event_creation_number,
-                event_sequence_number,
-            ))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -372,8 +357,7 @@ fn insert_nft_points_query(
     (
         diesel::insert_into(schema::nft_points::table)
             .values(items_to_insert)
-            .on_conflict(transaction_version)
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }

--- a/rust/processor/src/processors/transaction_metadata_processor.rs
+++ b/rust/processor/src/processors/transaction_metadata_processor.rs
@@ -99,8 +99,7 @@ fn insert_transaction_sizes_query(
     (
         diesel::insert_into(schema::transaction_size_info::table)
             .values(items_to_insert)
-            .on_conflict(transaction_version)
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -115,8 +114,7 @@ fn insert_event_sizes_query(
     (
         diesel::insert_into(schema::event_size_info::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }
@@ -131,8 +129,7 @@ fn insert_write_set_sizes_query(
     (
         diesel::insert_into(schema::write_set_size_info::table)
             .values(items_to_insert)
-            .on_conflict((transaction_version, index))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }

--- a/rust/processor/src/processors/user_transaction_processor.rs
+++ b/rust/processor/src/processors/user_transaction_processor.rs
@@ -126,13 +126,7 @@ fn insert_signatures_query(
     (
         diesel::insert_into(schema::signatures::table)
             .values(items_to_insert)
-            .on_conflict((
-                transaction_version,
-                multi_agent_index,
-                multi_sig_index,
-                is_sender_primary,
-            ))
-            .do_nothing(),
+            .on_conflict_do_nothing(),
         None,
     )
 }


### PR DESCRIPTION
You do not need to enter the column 'ON CONFLICT' to process 'DO NOTHING' when the Primary Key CONFLICT occurs.

For example, 
if you create a partition table using `pg_partman` extention in PostgreSQL, the parent table might not have a PK.

```SQL
create table test_table (id int, tt timestamp) partition by range (tt);
create table test_table_template (LIKE test_table);
alter table test_table_template add constraint test_table_pk primary key (id);

select partman.create_parent('temp.test_table', 'tt', 'native', '1 month', p_template_table := 'temp.test_table_template', p_premake := 2);

select constraint_name, constraint_type from information_schema.table_constraints where table_name = 'test_table';
-- no exists primary key
-- +---------------+---------------+
-- |constraint_name|constraint_type|
-- +---------------+---------------+

```
Create a parent table as above and inject pk into the partitioning table through the template table.
As a result, there is no PK in the parent table.

```SQL
-- success
insert into test_table (id, tt) values (1, now());

-- there is no unique or exclusion constraint matching the ON CONFLICT specification
insert into test_table (id, tt)
values (1, now()) on conflict (id) do nothing ;

-- success
insert into test_table (id, tt)
values (1, now()) on conflict do nothing ;
```

So, it looks better to use on_conflict_do_nothing() when it's PK CONFLICT.
