### PR TITLE
Add tranche 2 default model to Parquet 

### DIFF
--- a/rust/processor/src/db/common/models/default_models/mod.rs
+++ b/rust/processor/src/db/common/models/default_models/mod.rs
@@ -9,6 +9,7 @@ pub mod transactions;
 pub mod write_set_changes;
 
 // parquet models
+pub mod parquet_move_modules;
 pub mod parquet_move_resources;
 pub mod parquet_move_tables;
 pub mod parquet_transactions;

--- a/rust/processor/src/db/common/models/default_models/parquet_move_modules.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_move_modules.rs
@@ -1,0 +1,155 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::extra_unused_lifetimes)]
+
+use crate::{
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
+    utils::util::standardize_address,
+};
+use allocative_derive::Allocative;
+use aptos_protos::transaction::v1::{
+    DeleteModule, MoveModule as MoveModulePB, MoveModuleBytecode, WriteModule,
+};
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
+)]
+pub struct MoveModule {
+    pub txn_version: i64,
+    pub write_set_change_index: i64,
+    pub block_height: i64,
+    pub name: String,
+    pub address: String,
+    pub bytecode: Option<Vec<u8>>,
+    pub exposed_functions: Option<String>,
+    pub friends: Option<String>,
+    pub structs: Option<String>,
+    pub is_deleted: bool,
+    #[allocative(skip)]
+    pub block_timestamp: chrono::NaiveDateTime,
+}
+
+impl NamedTable for MoveModule {
+    const TABLE_NAME: &'static str = "move_modules";
+}
+
+impl HasVersion for MoveModule {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl GetTimeStamp for MoveModule {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MoveModuleByteCodeParsed {
+    pub address: String,
+    pub name: String,
+    pub bytecode: Vec<u8>,
+    pub exposed_functions: String,
+    pub friends: String,
+    pub structs: String,
+}
+
+impl MoveModule {
+    pub fn from_write_module(
+        write_module: &WriteModule,
+        write_set_change_index: i64,
+        txn_version: i64,
+        block_height: i64,
+        block_timestamp: chrono::NaiveDateTime,
+    ) -> Self {
+        let parsed_data = Self::convert_move_module_bytecode(write_module.data.as_ref().unwrap());
+        Self {
+            txn_version,
+            write_set_change_index,
+            block_height,
+            // TODO: remove the useless_asref lint when new clippy nighly is released.
+            #[allow(clippy::useless_asref)]
+            name: parsed_data
+                .clone()
+                .map(|d| d.name.clone())
+                .unwrap_or_default(),
+            address: standardize_address(&write_module.address.to_string()),
+            bytecode: parsed_data.clone().map(|d| d.bytecode.clone()),
+            exposed_functions: parsed_data.clone().map(|d| d.exposed_functions.clone()),
+            friends: parsed_data.clone().map(|d| d.friends.clone()),
+            structs: parsed_data.map(|d| d.structs.clone()),
+            is_deleted: false,
+            block_timestamp,
+        }
+    }
+
+    pub fn from_delete_module(
+        delete_module: &DeleteModule,
+        write_set_change_index: i64,
+        txn_version: i64,
+        block_height: i64,
+        block_timestamp: chrono::NaiveDateTime,
+    ) -> Self {
+        Self {
+            txn_version,
+            block_height,
+            write_set_change_index,
+            // TODO: remove the useless_asref lint when new clippy nighly is released.
+            #[allow(clippy::useless_asref)]
+            name: delete_module
+                .module
+                .clone()
+                .map(|d| d.name.clone())
+                .unwrap_or_default(),
+            address: standardize_address(&delete_module.address.to_string()),
+            bytecode: None,
+            exposed_functions: None,
+            friends: None,
+            structs: None,
+            is_deleted: true,
+            block_timestamp,
+        }
+    }
+
+    pub fn convert_move_module_bytecode(
+        mmb: &MoveModuleBytecode,
+    ) -> Option<MoveModuleByteCodeParsed> {
+        mmb.abi
+            .as_ref()
+            .map(|abi| Self::convert_move_module(abi, mmb.bytecode.clone()))
+    }
+
+    pub fn convert_move_module(
+        move_module: &MoveModulePB,
+        bytecode: Vec<u8>,
+    ) -> MoveModuleByteCodeParsed {
+        MoveModuleByteCodeParsed {
+            address: standardize_address(&move_module.address.to_string()),
+            name: move_module.name.clone(),
+            bytecode,
+            exposed_functions: move_module
+                .exposed_functions
+                .iter()
+                .map(|move_func| serde_json::to_value(move_func).unwrap())
+                .map(|value| canonical_json::to_string(&value).unwrap())
+                .collect(),
+            friends: move_module
+                .friends
+                .iter()
+                .map(|move_module_id| serde_json::to_value(move_module_id).unwrap())
+                .map(|value| canonical_json::to_string(&value).unwrap())
+                .collect(),
+            structs: move_module
+                .structs
+                .iter()
+                .map(|move_struct| serde_json::to_value(move_struct).unwrap())
+                .map(|value| canonical_json::to_string(&value).unwrap())
+                .collect(),
+        }
+    }
+}

--- a/rust/processor/src/db/common/models/default_models/parquet_move_tables.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_move_tables.rs
@@ -55,11 +55,31 @@ pub struct CurrentTableItem {
     pub last_transaction_version: i64,
     pub is_deleted: bool,
 }
-#[derive(Clone, Debug, Deserialize, FieldCount, Serialize)]
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, Serialize, ParquetRecordWriter,
+)]
 pub struct TableMetadata {
     pub handle: String,
     pub key_type: String,
     pub value_type: String,
+}
+
+impl NamedTable for TableMetadata {
+    const TABLE_NAME: &'static str = "table_metadatas";
+}
+
+impl HasVersion for TableMetadata {
+    fn version(&self) -> i64 {
+        0 // This is a placeholder value to avoid a compile error
+    }
+}
+
+impl GetTimeStamp for TableMetadata {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        #[warn(deprecated)]
+        chrono::NaiveDateTime::default()
+    }
 }
 
 impl TableItem {

--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -26,7 +26,6 @@ use field_count::FieldCount;
 use parquet_derive::ParquetRecordWriter;
 use serde::{Deserialize, Serialize};
 
-
 #[derive(
     Allocative, Clone, Debug, Default, Deserialize, FieldCount, Serialize, ParquetRecordWriter,
 )]

--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -20,11 +20,14 @@ use ahash::AHashMap;
 use allocative_derive::Allocative;
 use aptos_protos::transaction::v1::{
     transaction::{TransactionType, TxnData},
-    Transaction as TransactionPB, TransactionInfo,
+    Transaction as TransactionPB, TransactionInfo, TransactionSizeInfo, WriteOpSizeInfo,
 };
 use field_count::FieldCount;
+use once_cell::sync::Lazy;
 use parquet_derive::ParquetRecordWriter;
 use serde::{Deserialize, Serialize};
+
+static EMPTY_VEC: Lazy<Vec<WriteOpSizeInfo>> = Lazy::new(Vec::new);
 
 #[derive(
     Allocative, Clone, Debug, Default, Deserialize, FieldCount, Serialize, ParquetRecordWriter,
@@ -46,6 +49,7 @@ pub struct Transaction {
     pub event_root_hash: String,
     pub state_checkpoint_hash: Option<String>,
     pub accumulator_root_hash: String,
+    pub txn_total_bytes: i64,
     #[allocative(skip)]
     pub block_timestamp: chrono::NaiveDateTime,
 }
@@ -109,6 +113,7 @@ impl Transaction {
         block_height: i64,
         epoch: i64,
         block_timestamp: chrono::NaiveDateTime,
+        txn_size_info: Option<&TransactionSizeInfo>,
     ) -> Self {
         Self {
             txn_type,
@@ -136,6 +141,8 @@ impl Transaction {
             num_write_set_changes: info.changes.len() as i64,
             epoch,
             payload_type,
+            txn_total_bytes: txn_size_info
+                .map_or(0, |size_info| size_info.transaction_bytes as i64),
             block_timestamp,
         }
     }
@@ -185,6 +192,14 @@ impl Transaction {
         #[allow(deprecated)]
         let block_timestamp = chrono::NaiveDateTime::from_timestamp_opt(timestamp.seconds, 0)
             .expect("Txn Timestamp is invalid!");
+
+        let txn_size_info = transaction.size_info.as_ref();
+        let write_set_size_info: &Vec<WriteOpSizeInfo> = if let Some(size_info) = txn_size_info {
+            size_info.write_op_size_info.as_ref()
+        } else {
+            &EMPTY_VEC
+        };
+
         match txn_data {
             TxnData::User(user_txn) => {
                 let (wsc, wsc_detail) = WriteSetChangeModel::from_write_set_changes(
@@ -192,6 +207,7 @@ impl Transaction {
                     txn_version,
                     block_height,
                     block_timestamp,
+                    write_set_size_info,
                 );
                 let request = &user_txn
                     .request
@@ -219,6 +235,7 @@ impl Transaction {
                         block_height,
                         epoch,
                         block_timestamp,
+                        txn_size_info,
                     ),
                     None,
                     wsc,
@@ -231,6 +248,7 @@ impl Transaction {
                     txn_version,
                     block_height,
                     block_timestamp,
+                    write_set_size_info,
                 );
                 let payload = genesis_txn.payload.as_ref().unwrap();
                 let payload_cleaned = get_clean_writeset(payload, txn_version);
@@ -251,6 +269,7 @@ impl Transaction {
                         block_height,
                         epoch,
                         block_timestamp,
+                        txn_size_info,
                     ),
                     None,
                     wsc,
@@ -263,6 +282,7 @@ impl Transaction {
                     txn_version,
                     block_height,
                     block_timestamp,
+                    write_set_size_info,
                 );
                 (
                     Self::from_transaction_info_with_data(
@@ -275,6 +295,7 @@ impl Transaction {
                         block_height,
                         epoch,
                         block_timestamp,
+                        txn_size_info,
                     ),
                     Some(BlockMetadataTransaction::from_transaction(
                         block_metadata_txn,
@@ -298,6 +319,7 @@ impl Transaction {
                     block_height,
                     epoch,
                     block_timestamp,
+                    txn_size_info,
                 ),
                 None,
                 vec![],
@@ -314,6 +336,7 @@ impl Transaction {
                     block_height,
                     epoch,
                     block_timestamp,
+                    txn_size_info,
                 ),
                 None,
                 vec![],
@@ -330,6 +353,7 @@ impl Transaction {
                     block_height,
                     epoch,
                     block_timestamp,
+                    txn_size_info,
                 ),
                 None,
                 vec![],

--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -20,14 +20,12 @@ use ahash::AHashMap;
 use allocative_derive::Allocative;
 use aptos_protos::transaction::v1::{
     transaction::{TransactionType, TxnData},
-    Transaction as TransactionPB, TransactionInfo, TransactionSizeInfo, WriteOpSizeInfo,
+    Transaction as TransactionPB, TransactionInfo, TransactionSizeInfo,
 };
 use field_count::FieldCount;
-use once_cell::sync::Lazy;
 use parquet_derive::ParquetRecordWriter;
 use serde::{Deserialize, Serialize};
 
-static EMPTY_VEC: Lazy<Vec<WriteOpSizeInfo>> = Lazy::new(Vec::new);
 
 #[derive(
     Allocative, Clone, Debug, Default, Deserialize, FieldCount, Serialize, ParquetRecordWriter,
@@ -194,11 +192,10 @@ impl Transaction {
             .expect("Txn Timestamp is invalid!");
 
         let txn_size_info = transaction.size_info.as_ref();
-        let write_set_size_info: &Vec<WriteOpSizeInfo> = if let Some(size_info) = txn_size_info {
-            size_info.write_op_size_info.as_ref()
-        } else {
-            &EMPTY_VEC
-        };
+        let empty_vec = Vec::new();
+        let write_set_size_info = txn_size_info
+            .as_ref()
+            .map_or(&empty_vec, |size_info| &size_info.write_op_size_info);
 
         match txn_data {
             TxnData::User(user_txn) => {

--- a/rust/processor/src/processors/parquet_processors/mod.rs
+++ b/rust/processor/src/processors/parquet_processors/mod.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 pub mod parquet_default_processor;
 
+pub const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
+
 pub trait UploadIntervalConfig {
     fn parquet_upload_interval_in_secs(&self) -> Duration;
 }


### PR DESCRIPTION
### Description
1. add write_set_size_info to write_set_changes
2. Add txn size info to transaction model
3. migrate move_modules, and table_metadata


### Test Plan
tested locally

txn_total_bytes column added to transaction table
![Screenshot 2024-07-10 at 3 57 20 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/347323d3-02f7-46df-aa4d-47ec8303472f)

table_items table
![Screenshot 2024-07-10 at 4 27 10 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/bfa6d5fb-b99a-4f7e-9a97-83274ce5a1c7)
![Screenshot 2024-07-10 at 4 27 08 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/3c818b09-6b4d-4d36-aa41-c4e27c9b916c)

table_metadata table in testnet
![Screenshot 2024-07-10 at 4 26 24 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/6dedc81d-9ca9-4eb8-9f38-43e4f982183c)
 
![Screenshot 2024-07-10 at 4 26 26 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/01fd140d-a08e-45fe-88d0-a257e38a722a)

write_set_size info added to write_ste_changes table
![Screenshot 2024-07-10 at 3 58 00 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/95fa7191-a85f-4784-a7b1-8dade817d5da)

move_modules 
![Screenshot 2024-07-10 at 4 30 30 PM](https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/ea0428dc-711c-451f-89c7-7e871615b7a6)
