### PR TITLE
Add Parquet Events Processor

### DIFF
--- a/rust/processor/src/bq_analytics/mod.rs
+++ b/rust/processor/src/bq_analytics/mod.rs
@@ -23,7 +23,7 @@ use std::{
     sync::Arc,
 };
 use tokio::{io, time::Duration};
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ParquetProcessingResult {
@@ -143,11 +143,11 @@ where
 
                     match result {
                         Ok(_) => {
-                            // info!(
-                            //     processor_name = processor_name.clone(),
-                            //     service_type = PROCESSOR_SERVICE_TYPE,
-                            //     "[Parquet Handler] Successfully processed structs to buffer",
-                            // );
+                            info!(
+                                processor_name = processor_name.clone(),
+                                service_type = PROCESSOR_SERVICE_TYPE,
+                                "[Parquet Handler] Successfully processed structs to buffer",
+                            );
                         },
                         Err(e) => {
                             error!(

--- a/rust/processor/src/bq_analytics/mod.rs
+++ b/rust/processor/src/bq_analytics/mod.rs
@@ -23,7 +23,7 @@ use std::{
     sync::Arc,
 };
 use tokio::{io, time::Duration};
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ParquetProcessingResult {
@@ -143,11 +143,11 @@ where
 
                     match result {
                         Ok(_) => {
-                            info!(
-                                processor_name = processor_name.clone(),
-                                service_type = PROCESSOR_SERVICE_TYPE,
-                                "[Parquet Handler] Successfully processed structs to buffer",
-                            );
+                            // info!(
+                            //     processor_name = processor_name.clone(),
+                            //     service_type = PROCESSOR_SERVICE_TYPE,
+                            //     "[Parquet Handler] Successfully processed structs to buffer",
+                            // );
                         },
                         Err(e) => {
                             error!(

--- a/rust/processor/src/db/common/models/events_models/mod.rs
+++ b/rust/processor/src/db/common/models/events_models/mod.rs
@@ -2,3 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod events;
+
+// parquet model
+pub mod parquet_events;

--- a/rust/processor/src/db/common/models/events_models/parquet_events.rs
+++ b/rust/processor/src/db/common/models/events_models/parquet_events.rs
@@ -18,10 +18,10 @@ const EVENT_TYPE_MAX_LENGTH: usize = 300;
 
 #[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
 pub struct Event {
+    pub txn_version: i64,
+    pub account_address: String,
     pub sequence_number: i64,
     pub creation_number: i64,
-    pub account_address: String,
-    pub txn_version: i64,
     pub block_height: i64,
     pub event_type: String,
     pub data: String,
@@ -29,6 +29,7 @@ pub struct Event {
     pub indexed_type: String,
     pub type_tag_bytes: i64,
     pub total_bytes: i64,
+    pub event_version: i8,
 }
 
 impl NamedTable for Event {
@@ -70,6 +71,7 @@ impl Event {
             indexed_type: truncate_str(event_type, EVENT_TYPE_MAX_LENGTH),
             type_tag_bytes: size_info.type_tag_bytes as i64,
             total_bytes: size_info.total_bytes as i64,
+            event_version: 1i8, // this is for future proofing. TODO: change when events v2 comes
         }
     }
 

--- a/rust/processor/src/db/common/models/events_models/parquet_events.rs
+++ b/rust/processor/src/db/common/models/events_models/parquet_events.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use allocative_derive::Allocative;
 use aptos_protos::transaction::v1::{Event as EventPB, EventSizeInfo};
-use itertools::Itertools;
 use parquet_derive::ParquetRecordWriter;
 use serde::{Deserialize, Serialize};
 
@@ -88,9 +87,14 @@ impl Event {
     ) -> Vec<Self> {
         events
             .iter()
-            .zip_eq(event_size_info.iter())
             .enumerate()
-            .map(|(index, (event, size_info))| {
+            .map(|(index, event)| {
+                let size_info = event_size_info
+                    .get(index)
+                    .unwrap_or_else(|| &EventSizeInfo {
+                        type_tag_bytes: 0,
+                        total_bytes: 0,
+                    });
                 Self::from_event(
                     event,
                     txn_version,

--- a/rust/processor/src/db/common/models/events_models/parquet_events.rs
+++ b/rust/processor/src/db/common/models/events_models/parquet_events.rs
@@ -55,7 +55,7 @@ impl Event {
         event_index: i64,
         size_info: &EventSizeInfo,
     ) -> Self {
-        let t: &str = event.type_str.as_ref();
+        let event_type: &str = event.type_str.as_ref();
         Event {
             account_address: standardize_address(
                 event.key.as_ref().unwrap().account_address.as_str(),
@@ -64,10 +64,10 @@ impl Event {
             sequence_number: event.sequence_number as i64,
             txn_version,
             block_height,
-            event_type: t.to_string(),
+            event_type: event_type.to_string(),
             data: event.data.clone(),
             event_index,
-            indexed_type: truncate_str(t, EVENT_TYPE_MAX_LENGTH),
+            indexed_type: truncate_str(event_type, EVENT_TYPE_MAX_LENGTH),
             type_tag_bytes: size_info.type_tag_bytes as i64,
             total_bytes: size_info.total_bytes as i64,
         }

--- a/rust/processor/src/db/common/models/events_models/parquet_events.rs
+++ b/rust/processor/src/db/common/models/events_models/parquet_events.rs
@@ -89,12 +89,10 @@ impl Event {
             .iter()
             .enumerate()
             .map(|(index, event)| {
-                let size_info = event_size_info
-                    .get(index)
-                    .unwrap_or_else(|| &EventSizeInfo {
-                        type_tag_bytes: 0,
-                        total_bytes: 0,
-                    });
+                let size_info = event_size_info.get(index).unwrap_or(&EventSizeInfo {
+                    type_tag_bytes: 0,
+                    total_bytes: 0,
+                });
                 Self::from_event(
                     event,
                     txn_version,

--- a/rust/processor/src/db/common/models/events_models/parquet_events.rs
+++ b/rust/processor/src/db/common/models/events_models/parquet_events.rs
@@ -1,0 +1,93 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::extra_unused_lifetimes)]
+
+use crate::{
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
+    utils::util::{standardize_address, truncate_str},
+};
+use allocative_derive::Allocative;
+use aptos_protos::transaction::v1::{Event as EventPB, EventSizeInfo};
+use itertools::Itertools;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+// p99 currently is 303 so using 300 as a safe max length
+const EVENT_TYPE_MAX_LENGTH: usize = 300;
+
+#[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
+pub struct Event {
+    pub sequence_number: i64,
+    pub creation_number: i64,
+    pub account_address: String,
+    pub txn_version: i64,
+    pub block_height: i64,
+    pub event_type: String,
+    pub data: String,
+    pub event_index: i64,
+    pub indexed_type: String,
+    pub type_tag_bytes: i64,
+    pub total_bytes: i64,
+}
+
+impl NamedTable for Event {
+    const TABLE_NAME: &'static str = "events";
+}
+
+impl HasVersion for Event {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl GetTimeStamp for Event {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        chrono::NaiveDateTime::default()
+    }
+}
+
+impl Event {
+    pub fn from_event(
+        event: &EventPB,
+        txn_version: i64,
+        block_height: i64,
+        event_index: i64,
+        size_info: &EventSizeInfo,
+    ) -> Self {
+        let t: &str = event.type_str.as_ref();
+        Event {
+            account_address: standardize_address(
+                event.key.as_ref().unwrap().account_address.as_str(),
+            ),
+            creation_number: event.key.as_ref().unwrap().creation_number as i64,
+            sequence_number: event.sequence_number as i64,
+            txn_version,
+            block_height,
+            event_type: t.to_string(),
+            data: event.data.clone(),
+            event_index,
+            indexed_type: truncate_str(t, EVENT_TYPE_MAX_LENGTH),
+            type_tag_bytes: size_info.type_tag_bytes as i64,
+            total_bytes: size_info.total_bytes as i64,
+        }
+    }
+
+    pub fn from_events(
+        events: &[EventPB],
+        txn_version: i64,
+        block_height: i64,
+        event_size_info: &[EventSizeInfo],
+    ) -> Vec<Self> {
+        events
+            .iter()
+            .zip_eq(event_size_info.iter())
+            .enumerate()
+            .map(|(index, (event, size_info))| {
+                Self::from_event(event, txn_version, block_height, index as i64, size_info)
+            })
+            .collect::<Vec<ParquetEventModel>>()
+    }
+}
+
+pub type ParquetEventModel = Event;

--- a/rust/processor/src/processors/mod.rs
+++ b/rust/processor/src/processors/mod.rs
@@ -218,8 +218,7 @@ impl ProcessorConfig {
                 | ProcessorConfig::ParquetFungibleAssetProcessor(_)
                 | ProcessorConfig::ParquetTransactionMetadataProcessor(_)
                 | ProcessorConfig::ParquetAnsProcessor(_)
-                            | ProcessorConfig::ParquetEventsProcessor(_)
-
+                | ProcessorConfig::ParquetEventsProcessor(_)
         )
     }
 }

--- a/rust/processor/src/processors/mod.rs
+++ b/rust/processor/src/processors/mod.rs
@@ -38,6 +38,7 @@ use crate::{
     processors::parquet_processors::{
         parquet_ans_processor::{ParquetAnsProcessor, ParquetAnsProcessorConfig},
         parquet_default_processor::{ParquetDefaultProcessor, ParquetDefaultProcessorConfig},
+        parquet_events_processor::{ParquetEventsProcessor, ParquetEventsProcessorConfig},
         parquet_fungible_asset_processor::{
             ParquetFungibleAssetProcessor, ParquetFungibleAssetProcessorConfig,
         },
@@ -200,6 +201,7 @@ pub enum ProcessorConfig {
     ParquetFungibleAssetProcessor(ParquetFungibleAssetProcessorConfig),
     ParquetTransactionMetadataProcessor(ParquetTransactionMetadataProcessorConfig),
     ParquetAnsProcessor(ParquetAnsProcessorConfig),
+    ParquetEventsProcessor(ParquetEventsProcessorConfig),
 }
 
 impl ProcessorConfig {
@@ -216,6 +218,8 @@ impl ProcessorConfig {
                 | ProcessorConfig::ParquetFungibleAssetProcessor(_)
                 | ProcessorConfig::ParquetTransactionMetadataProcessor(_)
                 | ProcessorConfig::ParquetAnsProcessor(_)
+                            | ProcessorConfig::ParquetEventsProcessor(_)
+
         )
     }
 }
@@ -250,10 +254,12 @@ pub enum Processor {
     TokenV2Processor,
     TransactionMetadataProcessor,
     UserTransactionProcessor,
+    // Parquet processors
     ParquetDefaultProcessor,
     ParquetFungibleAssetProcessor,
     ParquetTransactionMetadataProcessor,
     ParquetAnsProcessor,
+    ParquetEventsProcessor,
 }
 
 #[cfg(test)]

--- a/rust/processor/src/processors/parquet_processors/mod.rs
+++ b/rust/processor/src/processors/parquet_processors/mod.rs
@@ -14,9 +14,6 @@ pub trait ParquetProcessorTrait {
     fn set_google_credentials(&self, credentials: Option<String>) {
         if let Some(credentials) = credentials {
             std::env::set_var(GOOGLE_APPLICATION_CREDENTIALS, credentials);
-        } else {
-            tracing::error!("Google application credentials not set. Please set GOOGLE_APPLICATION_CREDENTIALS environment variable.");
-            panic!();
         }
     }
 }

--- a/rust/processor/src/processors/parquet_processors/mod.rs
+++ b/rust/processor/src/processors/parquet_processors/mod.rs
@@ -8,6 +8,15 @@ pub mod parquet_transaction_metadata_processor;
 
 pub const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
 
-pub trait UploadIntervalConfig {
+pub trait ParquetProcessorTrait {
     fn parquet_upload_interval_in_secs(&self) -> Duration;
+
+    fn set_google_credentials(&self, credentials: Option<String>) {
+        if let Some(credentials) = credentials {
+            std::env::set_var(GOOGLE_APPLICATION_CREDENTIALS, credentials);
+        } else {
+            tracing::error!("Google application credentials not set. Please set GOOGLE_APPLICATION_CREDENTIALS environment variable.");
+            panic!();
+        }
+    }
 }

--- a/rust/processor/src/processors/parquet_processors/mod.rs
+++ b/rust/processor/src/processors/parquet_processors/mod.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 pub mod parquet_ans_processor;
 pub mod parquet_default_processor;
+pub mod parquet_events_processor;
 pub mod parquet_fungible_asset_processor;
 pub mod parquet_transaction_metadata_processor;
 

--- a/rust/processor/src/processors/parquet_processors/parquet_ans_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_ans_processor.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{UploadIntervalConfig, GOOGLE_APPLICATION_CREDENTIALS};
+use super::ParquetProcessorTrait;
 use crate::{
     bq_analytics::{
         create_parquet_handler_loop, generic_parquet_processor::ParquetDataGeneric,
@@ -40,7 +40,7 @@ pub struct ParquetAnsProcessorConfig {
     pub parquet_upload_interval: u64,
 }
 
-impl UploadIntervalConfig for ParquetAnsProcessorConfig {
+impl ParquetProcessorTrait for ParquetAnsProcessorConfig {
     fn parquet_upload_interval_in_secs(&self) -> Duration {
         Duration::from_secs(self.parquet_upload_interval)
     }
@@ -58,9 +58,7 @@ impl ParquetAnsProcessor {
         config: ParquetAnsProcessorConfig,
         new_gap_detector_sender: AsyncSender<ProcessingResult>,
     ) -> Self {
-        if let Some(credentials) = config.google_application_credentials.clone() {
-            std::env::set_var(GOOGLE_APPLICATION_CREDENTIALS, credentials);
-        }
+        config.set_google_credentials(config.google_application_credentials.clone());
 
         let ans_primary_name_v2_sender = create_parquet_handler_loop::<AnsPrimaryNameV2>(
             new_gap_detector_sender.clone(),

--- a/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
@@ -223,7 +223,7 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
 
         let tm_parquet_data = ParquetDataGeneric {
-            data: table_metadata
+            data: table_metadata,
         };
 
         self.table_metadata_sender
@@ -277,7 +277,6 @@ pub fn process_transactions(
         match detail {
             WriteSetChangeDetail::Module(module) => {
                 move_modules.push(module.clone());
-                // tracing::info!("adding module to move_modules: {:?} for version {:?}", module, module.txn_version);
                 transaction_version_to_struct_count
                     .entry(module.txn_version)
                     .and_modify(|e| *e += 1)

--- a/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
@@ -223,7 +223,7 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
 
         let tm_parquet_data = ParquetDataGeneric {
-            data: table_metadata,
+            data: table_metadata
         };
 
         self.table_metadata_sender
@@ -277,6 +277,7 @@ pub fn process_transactions(
         match detail {
             WriteSetChangeDetail::Module(module) => {
                 move_modules.push(module.clone());
+                // tracing::info!("adding module to move_modules: {:?} for version {:?}", module, module.txn_version);
                 transaction_version_to_struct_count
                     .entry(module.txn_version)
                     .and_modify(|e| *e += 1)

--- a/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
@@ -146,10 +146,7 @@ impl ProcessorTrait for ParquetEventsProcessor {
             .send(event_parquet_data)
             .await
             .context("Failed to send to parquet manager")?;
-        tracing::info!(
-            "printing last transaction timestamp: {:?}",
-            last_transaction_timestamp
-        );
+
         Ok(ProcessingResult::ParquetProcessingResult(
             ParquetProcessingResult {
                 start_version: start_version as i64,

--- a/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
@@ -140,7 +140,6 @@ impl ProcessorTrait for ParquetEventsProcessor {
 
         let event_parquet_data = ParquetDataGeneric {
             data: events,
-            transaction_version_to_struct_count: AHashMap::new(),
         };
 
         self.event_sender
@@ -153,7 +152,9 @@ impl ProcessorTrait for ParquetEventsProcessor {
                 start_version: start_version as i64,
                 end_version: end_version as i64,
                 last_transaction_timestamp: last_transaction_timestamp.clone(),
-                txn_version_to_struct_count: AHashMap::new(),
+                txn_version_to_struct_count: Some(transaction_version_to_struct_count),
+                parquet_processed_structs: None,
+                table_name: "".to_string(),
             },
         ))
     }

--- a/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
@@ -138,9 +138,7 @@ impl ProcessorTrait for ParquetEventsProcessor {
             events.extend(txn_events);
         }
 
-        let event_parquet_data = ParquetDataGeneric {
-            data: events,
-        };
+        let event_parquet_data = ParquetDataGeneric { data: events };
 
         self.event_sender
             .send(event_parquet_data)

--- a/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
@@ -117,6 +117,7 @@ impl ProcessorTrait for ParquetEventsProcessor {
                     PROCESSOR_UNKNOWN_TYPE_COUNT
                         .with_label_values(&["ParquetEventsProcessor"])
                         .inc();
+
                     continue;
                 },
             };
@@ -125,6 +126,7 @@ impl ProcessorTrait for ParquetEventsProcessor {
                 TxnData::BlockMetadata(tx_inner) => &tx_inner.events,
                 TxnData::Genesis(tx_inner) => &tx_inner.events,
                 TxnData::User(tx_inner) => &tx_inner.events,
+                TxnData::Validator(txn) => &txn.events,
                 _ => &default,
             };
 

--- a/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
@@ -1,0 +1,166 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    bq_analytics::{
+        create_parquet_handler_loop, generic_parquet_processor::ParquetDataGeneric,
+        ParquetProcessingResult,
+    },
+    db::common::models::events_models::parquet_events::{Event, ParquetEventModel},
+    gap_detectors::ProcessingResult,
+    processors::{parquet_processors::UploadIntervalConfig, ProcessorName, ProcessorTrait},
+    utils::{counters::PROCESSOR_UNKNOWN_TYPE_COUNT, database::ArcDbPool},
+};
+use ahash::AHashMap;
+use anyhow::anyhow;
+use aptos_protos::transaction::v1::{transaction::TxnData, Transaction};
+use async_trait::async_trait;
+use kanal::AsyncSender;
+use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, time::Duration};
+use tracing::warn;
+
+const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ParquetEventsProcessorConfig {
+    pub google_application_credentials: Option<String>,
+    pub bucket_name: String,
+    pub bucket_root: String,
+    pub parquet_handler_response_channel_size: usize,
+    pub max_buffer_size: usize,
+    pub parquet_upload_interval: u64,
+}
+
+impl UploadIntervalConfig for ParquetEventsProcessorConfig {
+    fn parquet_upload_interval_in_secs(&self) -> Duration {
+        Duration::from_secs(self.parquet_upload_interval)
+    }
+}
+
+pub struct ParquetEventsProcessor {
+    connection_pool: ArcDbPool,
+    event_sender: AsyncSender<ParquetDataGeneric<Event>>,
+}
+
+impl ParquetEventsProcessor {
+    pub fn new(
+        connection_pool: ArcDbPool,
+        config: ParquetEventsProcessorConfig,
+        new_gap_detector_sender: AsyncSender<ProcessingResult>,
+    ) -> Self {
+        if let Some(credentials) = config.google_application_credentials.clone() {
+            std::env::set_var(GOOGLE_APPLICATION_CREDENTIALS, credentials);
+        }
+
+        let event_sender = create_parquet_handler_loop::<Event>(
+            new_gap_detector_sender.clone(),
+            ProcessorName::ParquetDefaultProcessor.into(),
+            config.bucket_name.clone(),
+            config.bucket_root.clone(),
+            config.parquet_handler_response_channel_size,
+            config.max_buffer_size,
+            config.parquet_upload_interval_in_secs(),
+        );
+
+        Self {
+            connection_pool,
+            event_sender,
+        }
+    }
+}
+
+impl Debug for ParquetEventsProcessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ParquetProcessor {{ capacity of event channel: {:?}}}",
+            &self.event_sender.capacity(),
+        )
+    }
+}
+
+#[async_trait]
+impl ProcessorTrait for ParquetEventsProcessor {
+    fn name(&self) -> &'static str {
+        ProcessorName::ParquetEventsProcessor.into()
+    }
+
+    async fn process_transactions(
+        &self,
+        transactions: Vec<Transaction>,
+        start_version: u64,
+        end_version: u64,
+        _: Option<u64>,
+    ) -> anyhow::Result<ProcessingResult> {
+        let last_transaction_timestamp = transactions.last().unwrap().timestamp.clone();
+        let mut transaction_version_to_struct_count: AHashMap<i64, i64> = AHashMap::new();
+
+        let mut events = vec![];
+        for txn in &transactions {
+            let txn_version = txn.version as i64;
+            let block_height = txn.block_height as i64;
+            let size_info = match txn.size_info.as_ref() {
+                Some(size_info) => size_info,
+                None => {
+                    warn!(version = txn.version, "Transaction size info not found");
+                    continue;
+                },
+            };
+            let txn_data = match txn.txn_data.as_ref() {
+                Some(data) => data,
+                None => {
+                    tracing::warn!(
+                        transaction_version = txn_version,
+                        "Transaction data doesn't exist"
+                    );
+                    PROCESSOR_UNKNOWN_TYPE_COUNT
+                        .with_label_values(&["ParquetEventsProcessor"])
+                        .inc();
+                    continue;
+                },
+            };
+            let default = vec![];
+            let raw_events = match txn_data {
+                TxnData::BlockMetadata(tx_inner) => &tx_inner.events,
+                TxnData::Genesis(tx_inner) => &tx_inner.events,
+                TxnData::User(tx_inner) => &tx_inner.events,
+                _ => &default,
+            };
+
+            let txn_events = ParquetEventModel::from_events(
+                raw_events,
+                txn_version,
+                block_height,
+                size_info.event_size_info.as_slice(),
+            );
+            transaction_version_to_struct_count
+                .entry(txn_version)
+                .and_modify(|e| *e += txn_events.len() as i64);
+            events.extend(txn_events);
+        }
+
+        let event_parquet_data = ParquetDataGeneric {
+            data: events,
+            transaction_version_to_struct_count: AHashMap::new(),
+        };
+
+        self.event_sender
+            .send(event_parquet_data)
+            .await
+            .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
+
+        Ok(ProcessingResult::ParquetProcessingResult(
+            ParquetProcessingResult {
+                start_version: start_version as i64,
+                end_version: end_version as i64,
+                last_transaction_timestamp: last_transaction_timestamp.clone(),
+                txn_version_to_struct_count: AHashMap::new(),
+            },
+        ))
+    }
+
+    fn connection_pool(&self) -> &ArcDbPool {
+        &self.connection_pool
+    }
+}

--- a/rust/processor/src/processors/parquet_processors/parquet_fungible_asset_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_fungible_asset_processor.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{UploadIntervalConfig, GOOGLE_APPLICATION_CREDENTIALS};
+use super::ParquetProcessorTrait;
 use crate::{
     bq_analytics::{
         create_parquet_handler_loop, generic_parquet_processor::ParquetDataGeneric,
@@ -40,7 +40,7 @@ pub struct ParquetFungibleAssetProcessorConfig {
     pub parquet_upload_interval: u64,
 }
 
-impl UploadIntervalConfig for ParquetFungibleAssetProcessorConfig {
+impl ParquetProcessorTrait for ParquetFungibleAssetProcessorConfig {
     fn parquet_upload_interval_in_secs(&self) -> Duration {
         Duration::from_secs(self.parquet_upload_interval)
     }
@@ -58,9 +58,7 @@ impl ParquetFungibleAssetProcessor {
         config: ParquetFungibleAssetProcessorConfig,
         new_gap_detector_sender: AsyncSender<ProcessingResult>,
     ) -> Self {
-        if let Some(credentials) = config.google_application_credentials.clone() {
-            std::env::set_var(GOOGLE_APPLICATION_CREDENTIALS, credentials);
-        }
+        config.set_google_credentials(config.google_application_credentials.clone());
 
         let coin_supply_sender = create_parquet_handler_loop::<CoinSupply>(
             new_gap_detector_sender.clone(),

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -23,6 +23,7 @@ use crate::{
             parquet_default_processor::ParquetDefaultProcessor,
             parquet_fungible_asset_processor::ParquetFungibleAssetProcessor,
             parquet_transaction_metadata_processor::ParquetTransactionMetadataProcessor,
+            parquet_events_processor::ParquetEventsProcessor,
         },
         stake_processor::StakeProcessor,
         token_v2_processor::TokenV2Processor,
@@ -963,6 +964,13 @@ pub fn build_processor(
         },
         ProcessorConfig::ParquetTransactionMetadataProcessor(config) => {
             Processor::from(ParquetTransactionMetadataProcessor::new(
+                db_pool,
+                config.clone(),
+                gap_detector_sender.expect("Parquet processor requires a gap detector sender"),
+            ))
+        },
+        ProcessorConfig::ParquetEventsProcessor(config) => {
+            Processor::from(ParquetEventsProcessor::new(
                 db_pool,
                 config.clone(),
                 gap_detector_sender.expect("Parquet processor requires a gap detector sender"),

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -21,9 +21,9 @@ use crate::{
         parquet_processors::{
             parquet_ans_processor::ParquetAnsProcessor,
             parquet_default_processor::ParquetDefaultProcessor,
+            parquet_events_processor::ParquetEventsProcessor,
             parquet_fungible_asset_processor::ParquetFungibleAssetProcessor,
             parquet_transaction_metadata_processor::ParquetTransactionMetadataProcessor,
-            parquet_events_processor::ParquetEventsProcessor,
         },
         stake_processor::StakeProcessor,
         token_v2_processor::TokenV2Processor,


### PR DESCRIPTION
### Description
- added parquet events processors that migrates events table which also includes events_size_info (originally written by transaction_metadata_processor)
### Test Plan
<img width="1655" alt="Screenshot 2024-07-11 at 10 19 01 AM" src="https://github.com/aptos-labs/aptos-indexer-processors/assets/38443641/87ea3a38-2510-4bb1-a469-b6e622fa38d4">
