### PR TITLE
[Validator API Fix]support validator txn with its events.

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -160,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aptos-protos"
-version = "1.3.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=d76b5bb423b78b2b9affc72d3853f0d973d3f11f#d76b5bb423b78b2b9affc72d3853f0d973d3f11f"
+version = "1.3.1"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb#5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb"
 dependencies = [
  "futures-core",
  "pbjson",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ aptos-moving-average = { path = "moving-average" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.62"
-aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "d76b5bb423b78b2b9affc72d3853f0d973d3f11f" }
+aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "4541add3fd29826ec57f22658ca286d2d6134b93" }
 async-trait = "0.1.53"
 backtrace = "0.3.58"

--- a/rust/processor/src/db/common/models/account_transaction_models/account_transactions.rs
+++ b/rust/processor/src/db/common/models/account_transaction_models/account_transactions.rs
@@ -71,6 +71,7 @@ impl AccountTransaction {
             ),
             TxnData::Genesis(inner) => (&inner.events, vec![]),
             TxnData::BlockMetadata(inner) => (&inner.events, vec![]),
+            TxnData::Validator(inner) => (&inner.events, vec![]),
             _ => {
                 return AHashMap::new();
             },

--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -321,23 +321,31 @@ impl Transaction {
                 vec![],
                 vec![],
             ),
-            TxnData::Validator(_) => (
-                Self::from_transaction_info_with_data(
-                    transaction_info,
-                    None,
-                    None,
+            TxnData::Validator(inner) => {
+                let (wsc, wsc_detail) = WriteSetChangeModel::from_write_set_changes(
+                    &transaction_info.changes,
                     txn_version,
-                    transaction_type,
-                    0,
                     block_height,
-                    epoch,
                     block_timestamp,
                     txn_size_info,
-                ),
-                None,
-                vec![],
-                vec![],
-            ),
+                );
+                (
+                    Self::from_transaction_info_with_data(
+                        transaction_info,
+                        None,
+                        None,
+                        txn_version,
+                        transaction_type,
+                        inner.events.len() as i64,
+                        block_height,
+                        epoch,
+                        block_timestamp,
+                    ),
+                    None,
+                    wsc,
+                    wsc_detail,
+                )
+            },
             TxnData::BlockEpilogue(_) => (
                 Self::from_transaction_info_with_data(
                     transaction_info,

--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -327,7 +327,7 @@ impl Transaction {
                     txn_version,
                     block_height,
                     block_timestamp,
-                    txn_size_info,
+                    write_set_size_info,
                 );
                 (
                     Self::from_transaction_info_with_data(
@@ -340,6 +340,7 @@ impl Transaction {
                         block_height,
                         epoch,
                         block_timestamp,
+                        txn_size_info,
                     ),
                     None,
                     wsc,

--- a/rust/processor/src/db/common/models/default_models/transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/transactions.rs
@@ -296,8 +296,8 @@ impl Transaction {
                     epoch,
                 ),
                 None,
-                vec![],
-                vec![],
+                wsc,
+                wsc_detail,
             ),
             TxnData::BlockEpilogue(_) => (
                 Self::from_transaction_info_with_data(

--- a/rust/processor/src/db/common/models/stake_models/delegator_activities.rs
+++ b/rust/processor/src/db/common/models/stake_models/delegator_activities.rs
@@ -50,6 +50,7 @@ impl DelegatedStakingActivity {
         let events = match txn_data {
             TxnData::User(txn) => &txn.events,
             TxnData::BlockMetadata(txn) => &txn.events,
+            TxnData::Validator(txn) => &txn.events,
             _ => return Ok(delegator_activities),
         };
         for (index, event) in events.iter().enumerate() {

--- a/rust/processor/src/processors/events_processor.rs
+++ b/rust/processor/src/processors/events_processor.rs
@@ -130,6 +130,7 @@ impl ProcessorTrait for EventsProcessor {
                 TxnData::BlockMetadata(tx_inner) => &tx_inner.events,
                 TxnData::Genesis(tx_inner) => &tx_inner.events,
                 TxnData::User(tx_inner) => &tx_inner.events,
+                TxnData::Validator(tx_inner) => &tx_inner.events,
                 _ => &default,
             };
 

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -482,6 +482,7 @@ async fn parse_v2_coin(
         let default = vec![];
         let (events, user_request, entry_function_id_str) = match txn_data {
             TxnData::BlockMetadata(tx_inner) => (&tx_inner.events, None, None),
+            TxnData::Validator(tx_inner) => (&tx_inner.events, None, None),
             TxnData::Genesis(tx_inner) => (&tx_inner.events, None, None),
             TxnData::User(tx_inner) => {
                 let user_request = tx_inner


### PR DESCRIPTION
## Description

* This is to supports events from validator transactions with events migrated from BlockMetadataTransaction.

### Backfill 
* First validator transaction in mainnet: 554229017
* First validator transaction in testnet: 942054324

## Test Plan

Tested in devnet and looks good. 

![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/112209412/d53dd2bc-c96e-4a78-ae5f-25c3ae280571)

![image](https://github.com/aptos-labs/aptos-indexer-processors/assets/112209412/98e087b2-b4aa-44aa-ac98-5b29a0b3f3fb)
