### PR TITLE
Fix parquet default processor

### DIFF
--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -191,10 +191,6 @@ impl Transaction {
             .expect("Txn Timestamp is invalid!");
 
         let txn_size_info = transaction.size_info.as_ref();
-        let empty_vec = Vec::new();
-        let write_set_size_info = txn_size_info
-            .as_ref()
-            .map_or(&empty_vec, |size_info| &size_info.write_op_size_info);
 
         match txn_data {
             TxnData::User(user_txn) => {
@@ -203,7 +199,6 @@ impl Transaction {
                     txn_version,
                     block_height,
                     block_timestamp,
-                    write_set_size_info,
                 );
                 let request = &user_txn
                     .request
@@ -244,7 +239,6 @@ impl Transaction {
                     txn_version,
                     block_height,
                     block_timestamp,
-                    write_set_size_info,
                 );
                 let payload = genesis_txn.payload.as_ref().unwrap();
                 let payload_cleaned = get_clean_writeset(payload, txn_version);
@@ -278,7 +272,6 @@ impl Transaction {
                     txn_version,
                     block_height,
                     block_timestamp,
-                    write_set_size_info,
                 );
                 (
                     Self::from_transaction_info_with_data(
@@ -327,7 +320,6 @@ impl Transaction {
                     txn_version,
                     block_height,
                     block_timestamp,
-                    write_set_size_info,
                 );
                 (
                     Self::from_transaction_info_with_data(

--- a/rust/processor/src/db/common/models/default_models/parquet_write_set_changes.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_write_set_changes.rs
@@ -259,6 +259,12 @@ impl WriteSetChange {
         timestamp: chrono::NaiveDateTime,
         size_info: &[WriteOpSizeInfo],
     ) -> (Vec<Self>, Vec<WriteSetChangeDetail>) {
+        tracing::info!(
+            "Converting {} write set changes with the {} size_info provided for version {}.",
+            write_set_changes.len(),
+            size_info.len(),
+            txn_version
+        );
         let results: Vec<(Self, WriteSetChangeDetail)> = write_set_changes
             .iter()
             .zip_eq(size_info.iter())


### PR DESCRIPTION
### Description 
- The rootcause of the failure is from wrong mapping between write_set_changes and WriteSetOpSizeInfo, where write_set_size_info is per state_key_hash not per changes
- synced with the team offline, and we are aligned on having a separate table to close this tranche 2. 

### Test Plan
deployed on testnet
![Screenshot 2024-07-15 at 9 44 18 AM](https://github.com/user-attachments/assets/04b69f76-6ec1-45fb-a135-a6b8c231c691)
