### PR TITLE
[Processor] Use multiple threads to speed up FA processor.

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3006,6 +3006,7 @@ dependencies = [
  "postgres-native-tls",
  "prometheus",
  "prost 0.12.3",
+ "rayon",
  "regex",
  "serde",
  "serde_json",

--- a/rust/processor/Cargo.toml
+++ b/rust/processor/Cargo.toml
@@ -46,6 +46,7 @@ num_cpus = { workspace = true }
 once_cell = { workspace = true }
 prometheus = { workspace = true }
 prost = { workspace = true }
+rayon = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_activities.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_activities.rs
@@ -59,7 +59,7 @@ pub struct FungibleAssetActivity {
 }
 
 impl FungibleAssetActivity {
-    pub async fn get_v2_from_event(
+    pub fn get_v2_from_event(
         event: &Event,
         txn_version: i64,
         block_height: i64,

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -148,7 +148,7 @@ impl From<&CurrentFungibleAssetBalance> for CurrentUnifiedFungibleAssetBalance {
 
 impl FungibleAssetBalance {
     /// Basically just need to index FA Store, but we'll need to look up FA metadata
-    pub async fn get_v2_from_write_resource(
+    pub fn get_v2_from_write_resource(
         write_resource: &WriteResource,
         write_set_change_index: i64,
         txn_version: i64,


### PR DESCRIPTION
Most part of this PR is just from auto-formatter.

This PR is trying to use rayon to process transactions in multiple threads. I moved all the hashmaps inside the loop (so assumption here is everything txn can be processed independently), and produces per txn output. The output is merged together at the very end.

The performance improvement depends on the machine spec. On my dev machine processing p2p transfer data is 10x+ faster.
