### PR TITLE
fix parquet to start from where it left off when it's re-deployed

### DIFF
--- a/rust/processor/src/bq_analytics/gcs_handler.rs
+++ b/rust/processor/src/bq_analytics/gcs_handler.rs
@@ -65,7 +65,10 @@ pub async fn upload_parquet_to_gcs(
 
         match upload_result {
             Ok(Ok(result)) => {
-                info!("File uploaded successfully to GCS: {}", result.name);
+                info!(
+                    table_name = table_name,
+                    "File uploaded successfully to GCS: {}", result.name
+                );
                 return Ok(());
             },
             Ok(Err(e)) => {

--- a/rust/processor/src/bq_analytics/gcs_handler.rs
+++ b/rust/processor/src/bq_analytics/gcs_handler.rs
@@ -67,7 +67,9 @@ pub async fn upload_parquet_to_gcs(
             Ok(Ok(result)) => {
                 info!(
                     table_name = table_name,
-                    "File uploaded successfully to GCS: {}", result.name
+                    uploaded_time_iso = now.to_rfc3339(),
+                    "File uploaded successfully to GCS: {}",
+                    result.name
                 );
                 return Ok(());
             },

--- a/rust/processor/src/bq_analytics/gcs_handler.rs
+++ b/rust/processor/src/bq_analytics/gcs_handler.rs
@@ -1,7 +1,4 @@
-use crate::{
-    bq_analytics::ParquetProcessorError,
-    utils::counters::{PARQUET_BUFFER_SIZE, PARQUET_BUFFER_SIZE_AFTER_UPLOAD},
-};
+use crate::{bq_analytics::ParquetProcessorError, utils::counters::PARQUET_BUFFER_SIZE};
 use anyhow::{Context, Result};
 use chrono::{Datelike, Timelike};
 use google_cloud_storage::{
@@ -18,7 +15,7 @@ const INITIAL_DELAY_MS: u64 = 500;
 const TIMEOUT_SECONDS: u64 = 300;
 pub async fn upload_parquet_to_gcs(
     client: &GCSClient,
-    mut buffer: Vec<u8>,
+    buffer: Vec<u8>,
     table_name: &str,
     bucket_name: &str,
     bucket_root: &Path,
@@ -81,10 +78,6 @@ pub async fn upload_parquet_to_gcs(
                     file_name = result.name,
                     "File uploaded successfully to GCS",
                 );
-                buffer.clear();
-                PARQUET_BUFFER_SIZE_AFTER_UPLOAD
-                    .with_label_values(&[table_name])
-                    .set(buffer.len() as i64);
                 return Ok(());
             },
             Ok(Err(e)) => {

--- a/rust/processor/src/bq_analytics/generic_parquet_processor.rs
+++ b/rust/processor/src/bq_analytics/generic_parquet_processor.rs
@@ -140,7 +140,7 @@ where
             self.buffer.push(parquet_struct);
 
             if self.buffer_size_bytes >= self.max_buffer_size {
-                info!(
+                debug!(
                     table_name = ParquetType::TABLE_NAME,
                     buffer_size = self.buffer_size_bytes,
                     max_buffer_size = self.max_buffer_size,
@@ -175,8 +175,9 @@ where
     }
 
     async fn upload_buffer(&mut self, gcs_client: &GCSClient) -> Result<()> {
+        // This is to cover the case when interval duration has passed but buffer is empty
         if self.buffer.is_empty() {
-            info!("Buffer is empty, skipping upload.");
+            debug!("Buffer is empty, skipping upload.");
             return Ok(());
         }
         let start_version = self
@@ -212,12 +213,6 @@ where
             .into_inner()
             .context("Failed to get inner buffer")?;
 
-        debug!(
-            table_name = ParquetType::TABLE_NAME,
-            start_version = start_version,
-            end_version = end_version,
-            "Max buffer size reached, uploading to GCS."
-        );
         let bucket_root = PathBuf::from(&self.bucket_root);
 
         upload_parquet_to_gcs(

--- a/rust/processor/src/bq_analytics/generic_parquet_processor.rs
+++ b/rust/processor/src/bq_analytics/generic_parquet_processor.rs
@@ -3,7 +3,9 @@ use crate::{
     bq_analytics::gcs_handler::upload_parquet_to_gcs,
     gap_detectors::ProcessingResult,
     utils::{
-        counters::{PARQUET_HANDLER_BUFFER_SIZE, PARQUET_STRUCT_SIZE},
+        counters::{
+            NUM_TRANSACTIONS_PROCESSED_COUNT, PARQUET_HANDLER_BUFFER_SIZE, PARQUET_STRUCT_SIZE,
+        },
         util::naive_datetime_to_timestamp,
     },
 };
@@ -166,17 +168,10 @@ where
             .with_label_values(&[ParquetType::TABLE_NAME])
             .set(self.buffer.len() as i64);
 
-        // TODO: Add more metrics
-        // NUM_TRANSACTIONS_PROCESSED_COUNT
-        //     .with_label_values(&[
-        //         processor_name,
-        //         step,
-        //         label,
-        //         &task_index_str,
-        //     ])
-        //     .inc_by(num_processed);
-        //
+        // Memory Usage
+        // Current Buffer Size per table
 
+        // Size of File
         Ok(())
     }
 

--- a/rust/processor/src/bq_analytics/generic_parquet_processor.rs
+++ b/rust/processor/src/bq_analytics/generic_parquet_processor.rs
@@ -149,16 +149,12 @@ where
             }
         }
 
-        info!(
-                "Time has elapsed more than {} since last upload. for table {}",
-                self.last_upload_time.elapsed().as_secs(),
-                ParquetType::TABLE_NAME
-        );
         if self.last_upload_time.elapsed() >= self.upload_interval {
             info!(
-                    "Time has elapsed more than {} since last upload.",
-                    self.upload_interval.as_secs()
-                );
+                "Time has elapsed more than {} since last upload for {}",
+                self.upload_interval.as_secs(),
+                ParquetType::TABLE_NAME
+            );
             if let Err(e) = self.upload_buffer(gcs_client).await {
                 error!("Failed to upload buffer: {}", e);
                 return Err(e);
@@ -169,6 +165,18 @@ where
         PARQUET_HANDLER_BUFFER_SIZE
             .with_label_values(&[ParquetType::TABLE_NAME])
             .set(self.buffer.len() as i64);
+
+        // TODO: Add more metrics
+        // NUM_TRANSACTIONS_PROCESSED_COUNT
+        //     .with_label_values(&[
+        //         processor_name,
+        //         step,
+        //         label,
+        //         &task_index_str,
+        //     ])
+        //     .inc_by(num_processed);
+        //
+
         Ok(())
     }
 

--- a/rust/processor/src/bq_analytics/mod.rs
+++ b/rust/processor/src/bq_analytics/mod.rs
@@ -30,7 +30,10 @@ pub struct ParquetProcessingResult {
     pub start_version: i64,
     pub end_version: i64,
     pub last_transaction_timestamp: Option<aptos_protos::util::timestamp::Timestamp>,
-    pub txn_version_to_struct_count: AHashMap<i64, i64>,
+    pub txn_version_to_struct_count: Option<AHashMap<i64, i64>>,
+    // This is used to store the processed structs in the parquet file
+    pub parquet_processed_structs: Option<AHashMap<i64, i64>>,
+    pub table_name: String,
 }
 
 #[derive(Debug)]

--- a/rust/processor/src/bq_analytics/mod.rs
+++ b/rust/processor/src/bq_analytics/mod.rs
@@ -23,7 +23,7 @@ use std::{
     sync::Arc,
 };
 use tokio::{io, time::Duration};
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ParquetProcessingResult {
@@ -142,11 +142,11 @@ where
 
                     match result {
                         Ok(_) => {
-                            info!(
-                                processor_name = processor_name.clone(),
-                                service_type = PROCESSOR_SERVICE_TYPE,
-                                "[Parquet Handler] Successfully processed structs to buffer",
-                            );
+                            // info!(
+                            //     processor_name = processor_name.clone(),
+                            //     service_type = PROCESSOR_SERVICE_TYPE,
+                            //     "[Parquet Handler] Successfully processed structs to buffer",
+                            // );
                         },
                         Err(e) => {
                             error!(

--- a/rust/processor/src/bq_analytics/mod.rs
+++ b/rust/processor/src/bq_analytics/mod.rs
@@ -23,7 +23,7 @@ use std::{
     sync::Arc,
 };
 use tokio::{io, time::Duration};
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ParquetProcessingResult {
@@ -143,11 +143,11 @@ where
 
                     match result {
                         Ok(_) => {
-                            // info!(
-                            //     processor_name = processor_name.clone(),
-                            //     service_type = PROCESSOR_SERVICE_TYPE,
-                            //     "[Parquet Handler] Successfully processed structs to buffer",
-                            // );
+                            info!(
+                                processor_name = processor_name.clone(),
+                                service_type = PROCESSOR_SERVICE_TYPE,
+                                "[Parquet Handler] Successfully processed structs to buffer",
+                            );
                         },
                         Err(e) => {
                             error!(

--- a/rust/processor/src/bq_analytics/mod.rs
+++ b/rust/processor/src/bq_analytics/mod.rs
@@ -118,13 +118,14 @@ where
         "[Parquet Handler] Starting parquet handler loop",
     );
 
-    let mut parquet_manager = GenericParquetHandler::new(
+    let mut parquet_handler = GenericParquetHandler::new(
         bucket_name.clone(),
         bucket_root.clone(),
         new_gap_detector_sender.clone(),
         ParquetType::schema(),
         upload_interval,
         max_buffer_size,
+        processor_name.clone(),
     )
     .expect("Failed to create parquet manager");
 
@@ -138,7 +139,7 @@ where
         loop {
             match parquet_receiver.recv().await {
                 Ok(txn_pb_res) => {
-                    let result = parquet_manager.handle(&gcs_client, txn_pb_res).await;
+                    let result = parquet_handler.handle(&gcs_client, txn_pb_res).await;
 
                     match result {
                         Ok(_) => {

--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -384,15 +384,15 @@ impl Transaction {
 
             if let Some(a) = block_metadata {
                 block_metadata_txns.push(a.clone());
-                // transaction_version_to_struct_count.entry(a.version).and_modify(|e| *e += 1);
             }
-            wscs.append(&mut wsc_list);
 
             if !wsc_list.is_empty() {
                 transaction_version_to_struct_count
-                    .entry(wsc_list[0].txn_version)
+                    .entry(txn.txn_version)
                     .and_modify(|e| *e += wsc_list.len() as i64);
             }
+            wscs.append(&mut wsc_list);
+
             wsc_details.append(&mut wsc_detail_list);
         }
         (txns, block_metadata_txns, wscs, wsc_details)

--- a/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/parquet_transactions.rs
@@ -389,7 +389,8 @@ impl Transaction {
             if !wsc_list.is_empty() {
                 transaction_version_to_struct_count
                     .entry(txn.txn_version)
-                    .and_modify(|e| *e += wsc_list.len() as i64);
+                    .and_modify(|e| *e += wsc_list.len() as i64)
+                    .or_insert(wsc_list.len() as i64);
             }
             wscs.append(&mut wsc_list);
 

--- a/rust/processor/src/gap_detectors/gap_detector.rs
+++ b/rust/processor/src/gap_detectors/gap_detector.rs
@@ -8,6 +8,7 @@ use crate::{
 use ahash::AHashMap;
 use anyhow::Result;
 
+#[derive(Clone)]
 pub struct DefaultGapDetector {
     next_version_to_process: u64,
     seen_versions: AHashMap<u64, DefaultProcessingResult>,

--- a/rust/processor/src/gap_detectors/mod.rs
+++ b/rust/processor/src/gap_detectors/mod.rs
@@ -142,11 +142,11 @@ pub async fn create_gap_detector_status_tracker_loop(
                                 // we need a new gap detection batch size
                                 if res.num_gaps >= gap_detection_batch_size {
                                     tracing::warn!(
-                                    processor_name,
+                                        processor_name,
                                         gap_start_version = res.next_version_to_process,
                                         num_gaps = res.num_gaps,
                                         "[Parser] Processed batches with a gap",
-                                        );
+                                    );
                                     // We don't panic as everything downstream will panic if it doesn't work/receive
                                 }
 

--- a/rust/processor/src/gap_detectors/mod.rs
+++ b/rust/processor/src/gap_detectors/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bq_analytics::ParquetProcessingResult,
     gap_detectors::{
         gap_detector::{DefaultGapDetector, DefaultGapDetectorResult},
-        parquet_gap_detector::{ParquetFileGapDetector, ParquetFileGapDetectorResult},
+        parquet_gap_detector::{ParquetFileGapDetectorInner, ParquetFileGapDetectorResult},
     },
     processors::{DefaultProcessingResult, Processor, ProcessorTrait},
     utils::counters::{PARQUET_PROCESSOR_DATA_GAP_COUNT, PROCESSOR_DATA_GAP_COUNT},
@@ -11,7 +11,8 @@ use crate::{
 use anyhow::Result;
 use enum_dispatch::enum_dispatch;
 use kanal::AsyncReceiver;
-use tracing::{error, info};
+use std::sync::{Arc, Mutex};
+
 pub mod gap_detector;
 pub mod parquet_gap_detector;
 
@@ -21,9 +22,10 @@ pub const DEFAULT_GAP_DETECTION_BATCH_SIZE: u64 = 500;
 const UPDATE_PROCESSOR_STATUS_SECS: u64 = 1;
 
 #[enum_dispatch(GapDetectorTrait)]
+#[derive(Clone)]
 pub enum GapDetector {
     DefaultGapDetector,
-    ParquetFileGapDetector,
+    ParquetFileGapDetector(Arc<Mutex<ParquetFileGapDetectorInner>>), // made this singleton to avoid cloning structs to count map for every parquet handler
 }
 
 pub enum GapDetectorResult {
@@ -48,6 +50,7 @@ pub trait GapDetectorTrait: Send {
     fn process_versions(&mut self, result: ProcessingResult) -> Result<GapDetectorResult>;
 }
 
+#[derive(Debug, Clone)]
 pub enum ProcessingResult {
     DefaultProcessingResult(DefaultProcessingResult),
     ParquetProcessingResult(ParquetProcessingResult),
@@ -60,7 +63,7 @@ pub async fn create_gap_detector_status_tracker_loop(
     gap_detection_batch_size: u64,
 ) {
     let processor_name = processor.name();
-    info!(
+    tracing::info!(
         processor_name = processor_name,
         service_type = PROCESSOR_SERVICE_TYPE,
         "[Parser] Starting gap detector task",
@@ -111,7 +114,7 @@ pub async fn create_gap_detector_status_tracker_loop(
                         }
                     },
                     Err(e) => {
-                        error!(
+                        tracing::error!(
                         processor_name,
                         service_type = PROCESSOR_SERVICE_TYPE,
                         error = ?e,
@@ -122,7 +125,7 @@ pub async fn create_gap_detector_status_tracker_loop(
                 }
             },
             Ok(ProcessingResult::ParquetProcessingResult(result)) => {
-                info!(
+                tracing::info!(
                     processor_name,
                     service_type = PROCESSOR_SERVICE_TYPE,
                     "[ParquetGapDetector] received parquet gap detector task",
@@ -138,7 +141,7 @@ pub async fn create_gap_detector_status_tracker_loop(
                                     .set(res.num_gaps as i64);
                                 // we need a new gap detection batch size
                                 if res.num_gaps >= gap_detection_batch_size {
-                                    tracing::debug!(
+                                    tracing::warn!(
                                     processor_name,
                                         gap_start_version = res.next_version_to_process,
                                         num_gaps = res.num_gaps,
@@ -150,10 +153,13 @@ pub async fn create_gap_detector_status_tracker_loop(
                                 if last_update_time.elapsed().as_secs()
                                     >= UPDATE_PROCESSOR_STATUS_SECS
                                 {
-                                    tracing::info!("Updating last processed version");
+                                    tracing::info!(
+                                        last_processed_version = res.next_version_to_process,
+                                        "Updating last processed version"
+                                    );
                                     processor
                                         .update_last_processed_version(
-                                            res.start_version,
+                                            res.next_version_to_process,
                                             res.last_transaction_timestamp,
                                         )
                                         .await
@@ -169,7 +175,7 @@ pub async fn create_gap_detector_status_tracker_loop(
                         }
                     },
                     Err(e) => {
-                        error!(
+                        tracing::error!(
                             processor_name,
                             service_type = PROCESSOR_SERVICE_TYPE,
                             error = ?e,
@@ -180,7 +186,7 @@ pub async fn create_gap_detector_status_tracker_loop(
                 }
             },
             Err(e) => {
-                info!(
+                tracing::info!(
                     processor_name,
                     service_type = PROCESSOR_SERVICE_TYPE,
                     error = ?e,

--- a/rust/processor/src/gap_detectors/mod.rs
+++ b/rust/processor/src/gap_detectors/mod.rs
@@ -145,7 +145,7 @@ pub async fn create_gap_detector_status_tracker_loop(
                                     processor_name,
                                         gap_start_version = res.next_version_to_process,
                                         num_gaps = res.num_gaps,
-                                        "[Parser] Processed {gap_detection_batch_size} batches with a gap",
+                                        "[Parser] Processed batches with a gap",
                                         );
                                     // We don't panic as everything downstream will panic if it doesn't work/receive
                                 }

--- a/rust/processor/src/gap_detectors/parquet_gap_detector.rs
+++ b/rust/processor/src/gap_detectors/parquet_gap_detector.rs
@@ -2,54 +2,72 @@
 // // SPDX-License-Identifier: Apache-2.0
 
 use crate::gap_detectors::{GapDetectorResult, GapDetectorTrait, ProcessingResult};
-use ahash::AHashMap;
-use anyhow::Result;
-use std::cmp::max;
-use tracing::{debug, info};
+use ahash::{AHashMap, AHashSet};
+use anyhow::{Context, Result};
+use std::{
+    cmp::max,
+    sync::{Arc, Mutex},
+};
+use tracing::info;
 
-pub struct ParquetFileGapDetector {
+impl GapDetectorTrait for Arc<Mutex<ParquetFileGapDetectorInner>> {
+    fn process_versions(&mut self, result: ProcessingResult) -> Result<GapDetectorResult> {
+        let mut detector = self.lock().unwrap();
+        detector.process_versions(result)
+    }
+}
+
+#[derive(Clone)]
+pub struct ParquetFileGapDetectorInner {
     next_version_to_process: i64,
     version_counters: AHashMap<i64, i64>,
+    seen_versions: AHashSet<i64>,
     max_version: i64,
 }
 
 pub struct ParquetFileGapDetectorResult {
     pub next_version_to_process: u64,
     pub num_gaps: u64,
-    pub start_version: u64,
     pub last_transaction_timestamp: Option<aptos_protos::util::timestamp::Timestamp>,
 }
 
-impl ParquetFileGapDetector {
+impl ParquetFileGapDetectorInner {
     pub fn new(starting_version: u64) -> Self {
         Self {
             next_version_to_process: starting_version as i64,
             version_counters: AHashMap::new(),
+            seen_versions: AHashSet::new(),
             max_version: 0,
         }
     }
-}
-impl GapDetectorTrait for ParquetFileGapDetector {
-    fn process_versions(&mut self, result: ProcessingResult) -> Result<GapDetectorResult> {
-        // Update counts of structures for each transaction version
-        let result = match result {
-            ProcessingResult::ParquetProcessingResult(r) => r,
-            _ => panic!("Invalid result type"),
-        };
-        for (version, count) in result.txn_version_to_struct_count.iter() {
+
+    pub fn update_struct_map(
+        &mut self,
+        txn_version_to_struct_count: AHashMap<i64, i64>,
+        start_version: i64,
+        end_version: i64,
+    ) {
+        for (version, count) in txn_version_to_struct_count.iter() {
             if !self.version_counters.contains_key(version) {
-                // info!("Inserting version {} with count {} into parquet gap detector", version, count);
                 self.version_counters.insert(*version, *count);
+            } else {
+                // there is an edge case where file gets uploaded before it gets processed here, so we need to add the count to the existing count.
+                *self.version_counters.get_mut(version).unwrap() += *count;
             }
+
             self.max_version = max(self.max_version, *version);
-
-            *self.version_counters.entry(*version).or_default() -= 1;
         }
+        self.update_next_version_to_process(start_version, end_version);
+    }
 
-        // Update next version to process and move forward
-        let mut current_version = result.start_version;
+    /// This function updates the next version to process based on the current version counters.
+    /// It will increment the next version to process if the current version is fully processed.
+    /// It will also remove the version from the version counters if it is fully processed.
+    /// what it means to be fully processed is that all the structs for that version processed, i.e. count = 0.
+    pub fn update_next_version_to_process(&mut self, start_version: i64, end_version: i64) {
+        let mut current_version = start_version;
 
-        while current_version <= result.end_version {
+        while current_version <= end_version {
             match self.version_counters.get_mut(&current_version) {
                 Some(count) => {
                     if *count == 0 && current_version == self.next_version_to_process {
@@ -57,9 +75,10 @@ impl GapDetectorTrait for ParquetFileGapDetector {
                             self.version_counters.get(&self.next_version_to_process)
                         {
                             if count == 0 {
+                                info!("Version {} fully processed. Next version to process updated to {}", self.next_version_to_process, self.next_version_to_process + 1);
                                 self.version_counters.remove(&self.next_version_to_process); // Remove the fully processed version
-                                self.next_version_to_process += 1; // Increment to the next version
-                                info!("Version {} fully processed. Next version to process updated to {}", self.next_version_to_process - 1, self.next_version_to_process);
+                                self.seen_versions.insert(self.next_version_to_process);
+                                self.next_version_to_process += 1;
                             } else {
                                 break;
                             }
@@ -68,18 +87,53 @@ impl GapDetectorTrait for ParquetFileGapDetector {
                 },
                 None => {
                     // TODO: validate this that we shouldn't reach this b/c we already added default count.
-                    // or it could mean that we have duplicates.
-                    debug!("No struct count found for version {}", current_version);
+                    if self.seen_versions.contains(&current_version) {
+                        info!(
+                            "Version {} already processed, skipping and current next_version{} ",
+                            current_version, self.next_version_to_process
+                        );
+                        self.next_version_to_process =
+                            max(self.next_version_to_process, current_version + 1);
+                    } else {
+                        // this is the case where we haven't updated the map yet, while the file gets uploaded first. the bigger file size we will have,
+                        // the less chance we will see this as upload takes longer time. And map population is done before the upload.
+                        info!(
+                            current_version = current_version,
+                            "No struct count found for version, it will be processed later"
+                        );
+                    }
                 },
             }
             current_version += 1; // Move to the next version in sequence
         }
+    }
+}
+
+impl GapDetectorTrait for ParquetFileGapDetectorInner {
+    fn process_versions(&mut self, result: ProcessingResult) -> Result<GapDetectorResult> {
+        let result = match result {
+            ProcessingResult::ParquetProcessingResult(r) => r,
+            _ => panic!("Invalid result type"),
+        };
+        let parquet_processed_transactions = result
+            .parquet_processed_structs
+            .context("Missing parquet processed transactions")?;
+
+        for (version, count) in parquet_processed_transactions.iter() {
+            if let Some(entry) = self.version_counters.get_mut(version) {
+                *entry -= count;
+            } else {
+                // if not hasn't been updated, we can populate this count with the negative value and pass through
+                self.version_counters.insert(*version, -count);
+            }
+        }
+
+        self.update_next_version_to_process(result.start_version, result.end_version);
 
         Ok(GapDetectorResult::ParquetFileGapDetectorResult(
             ParquetFileGapDetectorResult {
                 next_version_to_process: self.next_version_to_process as u64,
                 num_gaps: (self.max_version - self.next_version_to_process) as u64,
-                start_version: result.start_version as u64,
                 last_transaction_timestamp: result.last_transaction_timestamp,
             },
         ))

--- a/rust/processor/src/gap_detectors/parquet_gap_detector.rs
+++ b/rust/processor/src/gap_detectors/parquet_gap_detector.rs
@@ -88,7 +88,9 @@ impl ParquetFileGapDetectorInner {
         info!(
             table_name = table_name,
             "Updating next version to process from {} to {} for table {}",
-            current_version, end_version, table_name
+            current_version,
+            end_version,
+            table_name
         );
         while current_version <= end_version {
             //
@@ -167,6 +169,10 @@ impl GapDetectorTrait for ParquetFileGapDetectorInner {
         }
 
         self.update_next_version_to_process(result.end_version, &result.table_name);
+
+        // TODO: Add metrics for
+        // Map Size in gap detector
+        // parquet processed version per table
 
         // we still have to process
         Ok(GapDetectorResult::ParquetFileGapDetectorResult(

--- a/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
@@ -201,26 +201,20 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             .await
             .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
 
-        let t_parquet_data = ParquetDataGeneric {
-            data: transactions,
-        };
+        let t_parquet_data = ParquetDataGeneric { data: transactions };
         self.transaction_sender
             .send(t_parquet_data)
             .await
             .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
 
-        let ti_parquet_data = ParquetDataGeneric {
-            data: table_items,
-        };
+        let ti_parquet_data = ParquetDataGeneric { data: table_items };
 
         self.table_item_sender
             .send(ti_parquet_data)
             .await
             .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
 
-        let mm_parquet_data = ParquetDataGeneric {
-            data: move_modules,
-        };
+        let mm_parquet_data = ParquetDataGeneric { data: move_modules };
 
         self.move_module_sender
             .send(mm_parquet_data)

--- a/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
@@ -9,7 +9,7 @@ use crate::{
     db::common::models::default_models::{
         parquet_move_modules::MoveModule,
         parquet_move_resources::MoveResource,
-        parquet_move_tables::{CurrentTableItem, TableItem, TableMetadata},
+        parquet_move_tables::{TableItem, TableMetadata},
         parquet_transactions::{Transaction as ParquetTransaction, TransactionModel},
         parquet_write_set_changes::{WriteSetChangeDetail, WriteSetChangeModel},
     },
@@ -186,7 +186,6 @@ impl ProcessorTrait for ParquetDefaultProcessor {
 
         let mr_parquet_data = ParquetDataGeneric {
             data: move_resources,
-            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
         };
 
         self.move_resource_sender
@@ -196,7 +195,6 @@ impl ProcessorTrait for ParquetDefaultProcessor {
 
         let wsc_parquet_data = ParquetDataGeneric {
             data: write_set_changes,
-            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
         };
         self.wsc_sender
             .send(wsc_parquet_data)
@@ -205,7 +203,6 @@ impl ProcessorTrait for ParquetDefaultProcessor {
 
         let t_parquet_data = ParquetDataGeneric {
             data: transactions,
-            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
         };
         self.transaction_sender
             .send(t_parquet_data)
@@ -214,7 +211,6 @@ impl ProcessorTrait for ParquetDefaultProcessor {
 
         let ti_parquet_data = ParquetDataGeneric {
             data: table_items,
-            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
         };
 
         self.table_item_sender
@@ -224,7 +220,6 @@ impl ProcessorTrait for ParquetDefaultProcessor {
 
         let mm_parquet_data = ParquetDataGeneric {
             data: move_modules,
-            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
         };
 
         self.move_module_sender
@@ -234,7 +229,6 @@ impl ProcessorTrait for ParquetDefaultProcessor {
 
         let tm_parquet_data = ParquetDataGeneric {
             data: table_metadata,
-            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
         };
 
         self.table_metadata_sender
@@ -247,7 +241,9 @@ impl ProcessorTrait for ParquetDefaultProcessor {
                 start_version: start_version as i64,
                 end_version: end_version as i64,
                 last_transaction_timestamp: last_transaction_timestamp.clone(),
-                txn_version_to_struct_count: AHashMap::new(),
+                txn_version_to_struct_count: Some(transaction_version_to_struct_count),
+                parquet_processed_structs: None,
+                table_name: "".to_string(),
             },
         ))
     }
@@ -280,7 +276,6 @@ pub fn process_transactions(
     let mut move_modules = vec![];
     let mut move_resources = vec![];
     let mut table_items = vec![];
-    let mut current_table_items = AHashMap::new();
     let mut table_metadata: AHashMap<String, TableMetadata> = AHashMap::new();
 
     for detail in wsc_details {
@@ -297,22 +292,13 @@ pub fn process_transactions(
                     .and_modify(|e| *e += 1);
                 move_resources.push(resource);
             },
-            WriteSetChangeDetail::Table(item, current_item, metadata) => {
+            WriteSetChangeDetail::Table(item, _current_item, metadata) => {
                 let txn_version = item.txn_version;
 
                 transaction_version_to_struct_count
                     .entry(txn_version)
                     .and_modify(|e| *e += 1);
                 table_items.push(item);
-
-                current_table_items.insert(
-                    (
-                        current_item.table_handle.clone(),
-                        current_item.key_hash.clone(),
-                    ),
-                    current_item,
-                );
-                // transaction_version_to_struct_count.entry(current_item.last_transaction_version).and_modify(|e| *e += 1); // TODO: uncomment in Tranche2
 
                 if let Some(meta) = metadata {
                     table_metadata.insert(meta.handle.clone(), meta);
@@ -324,14 +310,8 @@ pub fn process_transactions(
         }
     }
 
-    // Getting list of values and sorting by pk in order to avoid postgres deadlock since we're doing multi threaded db writes
-    let mut current_table_items = current_table_items
-        .into_values()
-        .collect::<Vec<CurrentTableItem>>();
     let mut table_metadata = table_metadata.into_values().collect::<Vec<TableMetadata>>();
     // Sort by PK
-    current_table_items
-        .sort_by(|a, b| (&a.table_handle, &a.key_hash).cmp(&(&b.table_handle, &b.key_hash)));
     table_metadata.sort_by(|a, b| a.handle.cmp(&b.handle));
 
     (

--- a/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
@@ -222,7 +222,7 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
 
         let tm_parquet_data = ParquetDataGeneric {
-            data: table_metadata
+            data: table_metadata,
         };
 
         self.table_metadata_sender
@@ -276,7 +276,6 @@ pub fn process_transactions(
         match detail {
             WriteSetChangeDetail::Module(module) => {
                 move_modules.push(module.clone());
-                // tracing::info!("adding module to move_modules: {:?} for version {:?}", module, module.txn_version);
                 transaction_version_to_struct_count
                     .entry(module.txn_version)
                     .and_modify(|e| *e += 1)
@@ -290,7 +289,6 @@ pub fn process_transactions(
             },
             WriteSetChangeDetail::Table(item, _current_item, metadata) => {
                 let txn_version = item.txn_version;
-
                 transaction_version_to_struct_count
                     .entry(txn_version)
                     .and_modify(|e| *e += 1);

--- a/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
@@ -222,7 +222,7 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             .map_err(|e| anyhow!("Failed to send to parquet manager: {}", e))?;
 
         let tm_parquet_data = ParquetDataGeneric {
-            data: table_metadata,
+            data: table_metadata
         };
 
         self.table_metadata_sender
@@ -276,9 +276,11 @@ pub fn process_transactions(
         match detail {
             WriteSetChangeDetail::Module(module) => {
                 move_modules.push(module.clone());
+                // tracing::info!("adding module to move_modules: {:?} for version {:?}", module, module.txn_version);
                 transaction_version_to_struct_count
                     .entry(module.txn_version)
-                    .and_modify(|e| *e += 1);
+                    .and_modify(|e| *e += 1)
+                    .or_insert(1);
             },
             WriteSetChangeDetail::Resource(resource) => {
                 transaction_version_to_struct_count

--- a/rust/processor/src/processors/parquet_processors/parquet_fungible_asset_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_fungible_asset_processor.rs
@@ -120,9 +120,7 @@ impl ProcessorTrait for ParquetFungibleAssetProcessor {
         let (fungible_asset_balances, coin_supply) =
             parse_v2_coin(&transactions, &mut transaction_version_to_struct_count).await;
 
-        let parquet_coin_supply = ParquetDataGeneric {
-            data: coin_supply,
-        };
+        let parquet_coin_supply = ParquetDataGeneric { data: coin_supply };
 
         self.coin_supply_sender
             .send(parquet_coin_supply)

--- a/rust/processor/src/processors/parquet_processors/parquet_fungible_asset_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_fungible_asset_processor.rs
@@ -122,7 +122,6 @@ impl ProcessorTrait for ParquetFungibleAssetProcessor {
 
         let parquet_coin_supply = ParquetDataGeneric {
             data: coin_supply,
-            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
         };
 
         self.coin_supply_sender
@@ -132,7 +131,6 @@ impl ProcessorTrait for ParquetFungibleAssetProcessor {
 
         let parquet_fungible_asset_balances = ParquetDataGeneric {
             data: fungible_asset_balances,
-            transaction_version_to_struct_count: transaction_version_to_struct_count.clone(),
         };
 
         self.fungible_asset_balances_sender
@@ -145,7 +143,9 @@ impl ProcessorTrait for ParquetFungibleAssetProcessor {
                 start_version: start_version as i64,
                 end_version: end_version as i64,
                 last_transaction_timestamp: last_transaction_timestamp.clone(),
-                txn_version_to_struct_count: AHashMap::new(),
+                txn_version_to_struct_count: Some(transaction_version_to_struct_count),
+                parquet_processed_structs: None,
+                table_name: "".to_string(),
             },
         ))
     }

--- a/rust/processor/src/utils/counters.rs
+++ b/rust/processor/src/utils/counters.rs
@@ -268,17 +268,28 @@ pub static PROCESSOR_UNKNOWN_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
 /// Parquet struct size
 pub static PARQUET_STRUCT_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!("indexer_parquet_struct_size", "Parquet struct size", &[
+        "processor_name",
         "parquet_type"
     ])
     .unwrap()
 });
 
 /// Parquet handler buffer size
-pub static PARQUET_HANDLER_BUFFER_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+pub static PARQUET_HANDLER_CURRENT_BUFFER_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "indexer_parquet_handler_buffer_size",
         "Parquet handler buffer size",
-        &["parquet_type"] // TODO: add something like task_index
+        &["processor_name", "parquet_type"]
+    )
+    .unwrap()
+});
+
+/// Size of the parquet file
+pub static PARQUET_BUFFER_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "indexer_parquet_size",
+        "Size of Parquet buffer to upload",
+        &["processor_name", "parquet_type"]
     )
     .unwrap()
 });

--- a/rust/processor/src/utils/counters.rs
+++ b/rust/processor/src/utils/counters.rs
@@ -293,13 +293,3 @@ pub static PARQUET_BUFFER_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
-
-/// Size of parquet buffer after upload
-pub static PARQUET_BUFFER_SIZE_AFTER_UPLOAD: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
-        "indexer_parquet_size_after_upload",
-        "Size of Parquet buffer after upload",
-        &["parquet_type"]
-    )
-    .unwrap()
-});

--- a/rust/processor/src/utils/counters.rs
+++ b/rust/processor/src/utils/counters.rs
@@ -293,3 +293,13 @@ pub static PARQUET_BUFFER_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// Size of parquet buffer after upload
+pub static PARQUET_BUFFER_SIZE_AFTER_UPLOAD: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "indexer_parquet_size_after_upload",
+        "Size of Parquet buffer after upload",
+        &["parquet_type"]
+    )
+    .unwrap()
+});

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -6,7 +6,7 @@ use crate::{
     db::common::models::{ledger_info::LedgerInfo, processor_status::ProcessorStatusQuery},
     gap_detectors::{
         create_gap_detector_status_tracker_loop, gap_detector::DefaultGapDetector,
-        parquet_gap_detector::ParquetFileGapDetector, GapDetector, ProcessingResult,
+        parquet_gap_detector::ParquetFileGapDetectorInner, GapDetector, ProcessingResult,
     },
     grpc_stream::TransactionsPBResponse,
     processors::{
@@ -51,7 +51,10 @@ use anyhow::{Context, Result};
 use aptos_moving_average::MovingAverage;
 use bitflags::bitflags;
 use kanal::AsyncSender;
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info};
 use url::Url;
@@ -327,14 +330,17 @@ impl Worker {
         );
 
         let gap_detector = if is_parquet_processor {
-            GapDetector::ParquetFileGapDetector(ParquetFileGapDetector::new(starting_version))
+            GapDetector::ParquetFileGapDetector(Arc::new(Mutex::new(
+                ParquetFileGapDetectorInner::new(starting_version),
+            )))
         } else {
             GapDetector::DefaultGapDetector(DefaultGapDetector::new(starting_version))
         };
+        let gap_detector_clone = gap_detector.clone();
 
         tokio::spawn(async move {
             create_gap_detector_status_tracker_loop(
-                gap_detector,
+                gap_detector_clone,
                 gap_detector_receiver,
                 processor,
                 gap_detection_batch_size,
@@ -360,7 +366,12 @@ impl Worker {
         let mut processor_tasks = vec![fetcher_task];
         for task_index in 0..concurrent_tasks {
             let join_handle: JoinHandle<()> = self
-                .launch_processor_task(task_index, receiver.clone(), gap_detector_sender.clone())
+                .launch_processor_task(
+                    task_index,
+                    receiver.clone(),
+                    gap_detector_sender.clone(),
+                    gap_detector.clone(),
+                )
                 .await;
             processor_tasks.push(join_handle);
         }
@@ -384,6 +395,7 @@ impl Worker {
         task_index: usize,
         receiver: kanal::AsyncReceiver<TransactionsPBResponse>,
         gap_detector_sender: AsyncSender<ProcessingResult>,
+        mut gap_detector: GapDetector,
     ) -> JoinHandle<()> {
         let processor_name = self.processor_config.name();
         let stream_address = self.indexer_grpc_data_service_address.to_string();
@@ -629,8 +641,24 @@ impl Worker {
                                     .await
                                     .expect("[Parser] Failed to send versions to gap detector");
                             },
-                            ProcessingResult::ParquetProcessingResult(_) => {
-                                debug!("parquet processing result doesn't need to be handled here");
+                            ProcessingResult::ParquetProcessingResult(processing_result) => {
+                                // we need to pupulate the map here so then we don't have to pass multiple times
+                                let parquet_gap_detector = match &mut gap_detector {
+                                    GapDetector::ParquetFileGapDetector(gap_detector) => {
+                                        gap_detector
+                                    },
+                                    _ => panic!("Invalid gap detector type"),
+                                };
+                                if let Some(txn_version_to_struct_count) =
+                                    processing_result.txn_version_to_struct_count
+                                {
+                                    let mut detector = parquet_gap_detector.lock().unwrap();
+                                    detector.update_struct_map(
+                                        txn_version_to_struct_count,
+                                        processing_result.start_version,
+                                        processing_result.end_version,
+                                    );
+                                }
                             },
                         }
                     },

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -649,6 +649,18 @@ impl Worker {
                                     },
                                     _ => panic!("Invalid gap detector type"),
                                 };
+
+                                let num_processed = (last_txn_version - first_txn_version) + 1;
+
+                                NUM_TRANSACTIONS_PROCESSED_COUNT
+                                    .with_label_values(&[
+                                        processor_name,
+                                        step,
+                                        label,
+                                        &task_index_str,
+                                    ])
+                                    .inc_by(num_processed);
+
                                 if let Some(txn_version_to_struct_count) =
                                     processing_result.txn_version_to_struct_count
                                 {

--- a/rust/server-framework/src/lib.rs
+++ b/rust/server-framework/src/lib.rs
@@ -9,6 +9,7 @@ use prometheus::{Encoder, TextEncoder};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(target_os = "linux")]
 use std::convert::Infallible;
+#[allow(deprecated)]
 use std::{fs::File, io::Read, panic::PanicInfo, path::PathBuf, process};
 use tokio::runtime::Handle;
 use tracing::error;
@@ -110,6 +111,7 @@ pub struct CrashInfo {
 /// Tokio's default behavior is to catch panics and ignore them.  Invoking this function will
 /// ensure that all subsequent thread panics (even Tokio threads) will report the
 /// details/backtrace and then exit.
+#[allow(deprecated)]
 pub fn setup_panic_handler() {
     std::panic::set_hook(Box::new(move |pi: &PanicInfo<'_>| {
         handle_panic(pi);
@@ -117,6 +119,7 @@ pub fn setup_panic_handler() {
 }
 
 // Formats and logs panic information
+#[allow(deprecated)]
 fn handle_panic(panic_info: &PanicInfo<'_>) {
     // The Display formatter for a PanicInfo contains the message, payload and location.
     let details = format!("{}", panic_info);


### PR DESCRIPTION
## Context 

There was a gap issue within the analytics pipeline. The new deployment restarted parquet processors, and it started from version stored in the `processor_status` alloydb table. however it wasn't working correctly b/c the table gets updated whenever the new parquet file gets uploaded to GCS, and the problem is that each table has a different frequency of uploads.  For example, for `move_resources`, because its size is bigger than any other structs, it gets uplaoded very frequency whereas move_modules reaches its max buffer size once every 30mins. and each file includes different rage of txn versions so that `processor status` is flaky. the version can go back and forth.  


Example failing scenario:
- last parquet file for `transactions` table hold a version 0-100000 -> file 1
- last parquet file for `move_resources` table hold a version 120000-150000. - file 2

1. file 1 uploaded at 12:00
2. processor-status now has a last_success_version: 100000
3. file 2 uplaoaded at 12
4. processor-status now has a last_success_version: 150000
5. new deployment kicks in
6. it reads the  last_success_version from db, which is 150000 and starts processing from 150000

ends up having a gap of 100001 - 149999.

### Previous behavior
parquet processors
- sends parquet data along with transaction_version_to_struct_count to channel that each table handler polls data from. this is where it clones maps N times (N = num of tables processor writes to)
- returns processing result, which wasn't handled anywhere 

parquet_gap_detector
- adde

generic parquet processor


### New behavior
parquet processors
- sends parquet data along with transaction_version_to_struct_count to channel that each table handler polls data from. this is where it clones maps N times (N = num of tables processor writes to)
- returns processing result with transaction_version_to_struct_count. and gap_detector in worker.rs updates its own map which is shared by all parquet handles per table 

parquet_gap_detector
- added a new function to update its version_counters, which is used to handle the processing_result returned from the parquet processor after sending all data over to channels.
- refactored out a function `update_next_version_to_process` which is responsible for updating `next_version_to_process`

generic parquet processor


### other changes
- removed tables that are not in scope like current)table_items from parquet_default_prcoessor
- added `parquet_processed_structs` and `table_name` to `ParquetProcessingResult` 
- added metrics. 


### Test Plan
GCS bucket used for devnet: https://console.cloud.google.com/storage/browser/aptos-indexer-data-etl-parquet-devnet/devnet-airflow-backfill?project=aptos-data-staging&supportedpurview=project&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))
load test resulting doc: https://www.notion.so/aptoslabs/Parquet-Load-Test-Plan-ac4e090c1210483a98d49cfdb65a26bf?pvs=4
Dashboard: https://aptoslabs.grafana.net/d/ads9cvy5s47pcc/indexer-parquet-processors-debug?from=now-30m&to=now&timezone=America%2FLos_Angeles&var-chain_name=devnet&var-processor_name=$__all&var-job=$__all&orgId=1&refresh=auto

- verified locally that `processor_status` now holds the min(max(txn_version) for `transactions`, max(txn_version) for `move_resources`, max(txn_version) for `write_set_changes`...) 
- verified that when we restart the processor with starting_version not specified, it picks up the version above. 

![Screenshot 2024-07-18 a
![Screenshot 2024-07-18 at 1 45 36 PM](https://github.com/user-attachments/assets/166aa935-8f18-40e9-a030-9c0e3f7153da)
t 1 45 27 PM](https://github.com/user-attachments/assets/0c19c02c-ddc5-450d-985e-052c1ef6139c)
