### PR TITLE
add missing index causing query to timeout

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-07-22-221813_create_missinh_idx/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-07-22-221813_create_missinh_idx/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+SELECT 1;
+--DROP INDEX IF EXISTS to2_insat_index;
+--DROP INDEX IF EXISTS fab_insat_index;
+--DROP INDEX IF EXISTS o_insat_idx;

--- a/rust/processor/src/db/postgres/migrations/2024-07-22-221813_create_missinh_idx/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-07-22-221813_create_missinh_idx/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+SELECT 1;
+--CREATE INDEX CONCURRENTLY IF NOT EXISTS to2_insat_index ON token_ownerships_v2 (inserted_at);
+--CREATE INDEX CONCURRENTLY IF NOT EXISTS fab_insat_index ON fungible_asset_balances (inserted_at);
+--CREATE INDEX CONCURRENTLY IF NOT EXISTS o_insat_idx ON objects (inserted_at);


### PR DESCRIPTION
### Description

There were sevs for missing data in the analytics pipeline, and it was due to that query was timing out. The query failing due to that indices were missing. 

### Test Plan
We are running this outside of diesel migration to avoid locks. 