### PR TITLE
fix parquet event processor to handle miss-matching events and event …

### DIFF
--- a/rust/processor/src/db/common/models/events_models/parquet_events.rs
+++ b/rust/processor/src/db/common/models/events_models/parquet_events.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use allocative_derive::Allocative;
 use aptos_protos::transaction::v1::{Event as EventPB, EventSizeInfo};
-use itertools::Itertools;
 use parquet_derive::ParquetRecordWriter;
 use serde::{Deserialize, Serialize};
 

--- a/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_events_processor.rs
@@ -119,10 +119,14 @@ impl ProcessorTrait for ParquetEventsProcessor {
                 },
             };
             let default = vec![];
+            let mut is_user_txn_type = false;
             let raw_events = match txn_data {
                 TxnData::BlockMetadata(tx_inner) => &tx_inner.events,
                 TxnData::Genesis(tx_inner) => &tx_inner.events,
-                TxnData::User(tx_inner) => &tx_inner.events,
+                TxnData::User(tx_inner) => {
+                    is_user_txn_type = true;
+                    &tx_inner.events
+                },
                 TxnData::Validator(txn) => &txn.events,
                 _ => &default,
             };
@@ -133,6 +137,7 @@ impl ProcessorTrait for ParquetEventsProcessor {
                 block_height,
                 size_info.event_size_info.as_slice(),
                 block_timestamp,
+                is_user_txn_type,
             );
             transaction_version_to_struct_count
                 .entry(txn_version)


### PR DESCRIPTION
### Description
Backfilling parquert events on testnet and mainnet was failing due to missing events for validator txn type. Initially thought that events are missing b/c fullnode wasn't up to date. However, it wasn't the case. So, we are making a general rule that event_size_info will work for user_transactions, but no promisses on other transactions.

the new behavior is that if we don't have matching events and events_size_info, we are going to panic and investigate. But for other types, they will be defaulted to 0 size_info. for those txns with missing events that are not user_transactions, we can backfill anytime if needed.


[humio log](https://cloud.us.humio.com/k8s/search?columns=%5B%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22%40timestamp%22%2C%22format%22%3A%22datetime%22%2C%22width%22%3A%22content%22%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22message%22%2C%22format%22%3A%22text%22%2C%22width%22%3A1218%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.container_name%22%2C%22format%22%3A%22text%22%2C%22width%22%3A257%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22last_processed_version%22%2C%22format%22%3A%22text%22%2C%22width%22%3A197%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22events_len%22%2C%22format%22%3A%22text%22%2C%22width%22%3A107%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22event_size_info_len%22%2C%22format%22%3A%22text%22%2C%22width%22%3A175%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22txn_version%22%2C%22format%22%3A%22text%22%2C%22width%22%3A115%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22%40rawstring%22%2C%22format%22%3A%22logline%22%7D%5D&dashboardId=7ByeSUZbnsJRwZvwr2w1mJKiPlop00zp&live=false&newestAtBottom=true&query=%7C%20k8s.namespace%20%3D%20%22indexer-v2-mainnet%22%0A%2F%2F%20%7C%20%22k8s.container_name%22%20%3D%20%22parquet-events-processor%22%0A%2F%2F%20%7C%20message%20%3D%20%22*Updating%20last%20processed%20versi*%22%0A%0A%2F%2F%20%7C%20max(%22last_processed_version%22)%0A%2F%2F%20%7C%20message%20!%3D%20%22%5BParser%5D%20Received%20transactions%20from%20GRPC.%20Sending%20transactions%20to%20channel.%22%0A%2F%2F%20%7C%20message%20%3D%20%22itertools%3A%20.zip_eq()%20reached%20end%20of%20one%20iterator%20before%20the%20other%5C%22%5C%22%5C%22%22%0A%7C%20%22k8s.container_name%22%20%3D%20%22backfill-parquet-events-0%22%0A%2F%2F%20%7C%20message%20%3D%20%22%20mismatch%3A%20events%20size%20does%20not%20match%20event_size_info%20*%22%0A%2F%2F%20%7C%20level%20%3D%20error%0Aerror&showOnlyFirstLine=false&start=12h&tz=America%2FLos_Angeles&widgetId=cbcc0d6a-6e8f-4b5c-836f-53e75aab4fdc&widgetType=list-view)


### Test Plan
Running locally aginast testnet endpoint with failing txn vesrion worked. 
![Screenshot 2024-07-26 at 11 25 56 AM](https://github.com/user-attachments/assets/06741618-f758-4809-8be2-ab3f003318c6)
![Uploading Screenshot 2024-07-26 at 11.26.21 AM.png…]()

