### PR TITLE
Return empty parquet upload result when the buffer is empty that we d…

### DIFF
--- a/rust/processor/src/bq_analytics/generic_parquet_processor.rs
+++ b/rust/processor/src/bq_analytics/generic_parquet_processor.rs
@@ -195,7 +195,6 @@ where
                 .await
                 .expect("[Parser] Failed to send versions to gap detector");
 
-
             return Ok(());
         }
         let start_version = self

--- a/rust/processor/src/bq_analytics/generic_parquet_processor.rs
+++ b/rust/processor/src/bq_analytics/generic_parquet_processor.rs
@@ -178,6 +178,24 @@ where
         // This is to cover the case when interval duration has passed but buffer is empty
         if self.buffer.is_empty() {
             debug!("Buffer is empty, skipping upload.");
+
+            let parquet_processing_result = ParquetProcessingResult {
+                start_version: -1, // this is to indicate that nothing was actually uploaded
+                end_version: -1,
+                last_transaction_timestamp: None,
+                txn_version_to_struct_count: None,
+                parquet_processed_structs: None,
+                table_name: ParquetType::TABLE_NAME.to_string(),
+            };
+
+            self.gap_detector_sender
+                .send(ProcessingResult::ParquetProcessingResult(
+                    parquet_processing_result,
+                ))
+                .await
+                .expect("[Parser] Failed to send versions to gap detector");
+
+
             return Ok(());
         }
         let start_version = self

--- a/rust/processor/src/gap_detectors/parquet_gap_detector.rs
+++ b/rust/processor/src/gap_detectors/parquet_gap_detector.rs
@@ -3,7 +3,7 @@
 
 use crate::gap_detectors::{GapDetectorResult, GapDetectorTrait, ProcessingResult};
 use ahash::{AHashMap, AHashSet};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::{
     cmp::{max, min},
     sync::{Arc, Mutex},

--- a/rust/processor/src/processors/parquet_processors/parquet_ans_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_ans_processor.rs
@@ -82,7 +82,7 @@ impl Debug for ParquetAnsProcessor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ParquetAnsProcessor {{ capacity of trnasactions channel: {:?}}}",
+            "ParquetAnsProcessor {{ capacity of ans_primary_name_v2 channel: {:?}}}",
             &self.ans_primary_name_v2_sender.capacity()
         )
     }

--- a/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
@@ -270,9 +270,10 @@ pub fn process_transactions(
     for detail in wsc_details {
         match detail {
             WriteSetChangeDetail::Module(module) => {
-                move_modules.push(module.clone());
+                let txn_version = module.txn_version;
+                move_modules.push(module);
                 transaction_version_to_struct_count
-                    .entry(module.txn_version)
+                    .entry(txn_version)
                     .and_modify(|e| *e += 1)
                     .or_insert(1);
             },


### PR DESCRIPTION
### Description
parquet-ans-processor was OOM killed. The rootcause was that the version tracker in parquet gap detector keeping too many versions in there due to the fact that there is no structs to be processed until later txn_version in mainnet. 

The workaround I adopted here is to return empty parquet upload result when the buffer is empty that we didn't actually upload to avoid parquet gap detector to use so much memory to keep the map size big until there is an actual upload.
returning empty parquet result meaning we invoke update_processor_status function so that processor_status also gets updated more frequently. 

[Uploading ans-trace.pdf…]()


### Test Plan
tested locally that it now updates processor status early enough. 
![Screenshot 2024-07-30 at 2 50 01 PM](https://github.com/user-attachments/assets/f10ce305-3683-4d26-a93a-f8d4d7c3139c)
