### PR TITLE
add a logic to clear coin supply in fa processor as it's deprecated

### DIFF
--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -365,7 +365,7 @@ impl ProcessorTrait for FungibleAssetProcessor {
             mut fungible_asset_balances,
             mut current_fungible_asset_balances,
             current_unified_fungible_asset_balances,
-            coin_supply,
+            mut coin_supply,
         ) = parse_v2_coin(&transactions).await;
 
         let processing_duration_in_secs = processing_start.elapsed().as_secs_f64();
@@ -387,6 +387,10 @@ impl ProcessorTrait for FungibleAssetProcessor {
             .contains(TableFlags::CURRENT_FUNGIBLE_ASSET_BALANCES)
         {
             current_fungible_asset_balances.clear();
+        }
+
+        if self.deprecated_tables.contains(TableFlags::COIN_SUPPLY) {
+            coin_supply.clear();
         }
 
         let tx_result = insert_to_db(


### PR DESCRIPTION
### Description
there is missing logic for filtering coin_supply out from db writes.


### Test Plan
tested locally that it's being filtered.
![Screenshot 2024-07-31 at 10 58 43 AM](https://github.com/user-attachments/assets/baeafc8b-b0f5-49c8-8d8f-f9e4d7f7a29e)
