### PR TITLE
Fix current_collection_ownership_v2_view

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-08-16-213505_fix_collections_view/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-16-213505_fix_collections_view/down.sql
@@ -1,0 +1,18 @@
+-- This file should undo anything in `up.sql`
+CREATE OR REPLACE VIEW current_collection_ownership_v2_view as
+select owner_address,
+  creator_address,
+  collection_name,
+  b.collection_id,
+  max(a.last_transaction_version) as last_transaction_version,
+  count(distinct a.token_data_id) as distinct_tokens,
+  min(c.uri) as collection_uri,
+  min(token_uri) as single_token_uri
+from current_token_ownerships_v2 a
+  join token_datas_v2 b on a.token_data_id = b.token_data_id
+  join current_collections_v2 c on b.collection_id = c.collection_id
+where amount > 0
+group by 1,
+  2,
+  3,
+  4;

--- a/rust/processor/src/db/postgres/migrations/2024-08-16-213505_fix_collections_view/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-16-213505_fix_collections_view/up.sql
@@ -1,0 +1,18 @@
+-- Your SQL goes here
+CREATE OR REPLACE VIEW current_collection_ownership_v2_view as
+select owner_address,
+  creator_address,
+  collection_name,
+  b.collection_id,
+  max(a.last_transaction_version) as last_transaction_version,
+  count(distinct a.token_data_id) as distinct_tokens,
+  min(c.uri) as collection_uri,
+  min(token_uri) as single_token_uri
+from current_token_ownerships_v2 a
+  join current_token_datas_v2 b on a.token_data_id = b.token_data_id
+  join current_collections_v2 c on b.collection_id = c.collection_id
+where amount > 0
+group by 1,
+  2,
+  3,
+  4;


### PR DESCRIPTION
## Description 
Fix collections view to use current tables in the join 

## Testing
<img width="1006" alt="Screenshot 2024-08-16 at 2 36 55 PM" src="https://github.com/user-attachments/assets/382f5738-06ca-44a6-96cc-d5481c311199">

Query is fixed in Petra. 