### PR TITLE
Fix offset issue within parquet gap detector to start with a correct version. 

### DIFF
--- a/rust/processor/src/gap_detectors/mod.rs
+++ b/rust/processor/src/gap_detectors/mod.rs
@@ -138,7 +138,7 @@ pub async fn create_gap_detector_status_tracker_loop(
                                 if res.num_gaps >= gap_detection_batch_size {
                                     tracing::warn!(
                                         processor_name,
-                                        gap_start_version = res.next_version_to_process,
+                                        gap_start_version = res.last_success_version,
                                         num_gaps = res.num_gaps,
                                         "[Parser] Processed batches with a gap",
                                     );
@@ -149,13 +149,13 @@ pub async fn create_gap_detector_status_tracker_loop(
                                     >= UPDATE_PROCESSOR_STATUS_SECS
                                 {
                                     tracing::info!(
-                                        last_processed_version = res.next_version_to_process,
+                                        last_processed_version = res.last_success_version,
                                         processor_name,
                                         "Updating last processed version"
                                     );
                                     processor
                                         .update_last_processed_version(
-                                            res.next_version_to_process,
+                                            res.last_success_version,
                                             res.last_transaction_timestamp,
                                         )
                                         .await

--- a/rust/processor/src/gap_detectors/parquet_gap_detector.rs
+++ b/rust/processor/src/gap_detectors/parquet_gap_detector.rs
@@ -26,7 +26,7 @@ pub struct ParquetFileGapDetectorInner {
 }
 
 pub struct ParquetFileGapDetectorResult {
-    pub next_version_to_process: u64,
+    pub last_success_version: u64,
     pub num_gaps: u64,
     pub last_transaction_timestamp: Option<aptos_protos::util::timestamp::Timestamp>,
 }
@@ -138,7 +138,7 @@ impl GapDetectorTrait for ParquetFileGapDetectorInner {
             self.update_next_version_to_process(self.max_version, &result.table_name);
             return Ok(GapDetectorResult::ParquetFileGapDetectorResult(
                 ParquetFileGapDetectorResult {
-                    next_version_to_process: self.next_version_to_process as u64,
+                    last_success_version: self.next_version_to_process as u64 - 1,
                     num_gaps: (self.max_version - self.next_version_to_process) as u64,
                     last_transaction_timestamp: result.last_transaction_timestamp,
                 },
@@ -164,7 +164,7 @@ impl GapDetectorTrait for ParquetFileGapDetectorInner {
 
         Ok(GapDetectorResult::ParquetFileGapDetectorResult(
             ParquetFileGapDetectorResult {
-                next_version_to_process: self.next_version_to_process as u64,
+                last_success_version: self.next_version_to_process as u64 - 1,
                 num_gaps: (self.max_version - self.next_version_to_process) as u64,
                 last_transaction_timestamp: result.last_transaction_timestamp,
             },


### PR DESCRIPTION
### Description
QC failed due to a missing version at the boundary between parquet files around 9 AM on 8/22. Initially, metrics pointed to a possible grpc connection issue, but it was later discovered that there was a deployment occurred around that time.

![Screenshot 2024-08-23 at 9 22 40 AM](https://github.com/user-attachments/assets/46857908-111c-4f70-a9bf-fa178b190b9e)


tldr;
```
x - 1 = last success version
x = missing version
x + 1 = version it started post deployment
```
After reviewing the logs, I noticed that the parquet processor correctly updated the latest successful version to x just before the deployment. However, post deployment, it started processing from version x + 1. 

The root cause of this issue is a discrepancy between the gap detector and the parquet gap detector. While the worker correctly retrieves the start version by querying last_success_version and adding 1, the parquet gap detector keeps track of next_version_to_process and updates the processor_status table with this value. This mismatch causes a version to be skipped whenever a deployment happens. worker where it's pull the start version [here](https://github.com/aptos-labs/aptos-indexer-processors/blob/6b0c7ceb4b1809a017866bb0c239653ffdb13941/rust/processor/src/worker.rs#L744)."

![Screenshot 2024-08-23 at 11 32 27 AM](https://github.com/user-attachments/assets/62d50cf9-51d1-4505-840b-5261bef51c22)
![Screenshot 2024-08-23 at 11 32 15 AM](https://github.com/user-attachments/assets/70fe8c3f-f78c-4f95-8f9b-2870ac3994ca)


Fix:
I updated the ParquetFileGapDetectorResult by changing the field from next_version_to_process to last_success_version. This field is now set to next_version_to_process - 1 to ensure it aligns with the intended purpose of the table.

Test Plan
![Screenshot 2024-08-23 at 12 24 56 PM](https://github.com/user-attachments/assets/d5dee433-e140-4b47-ad66-83260ec7231c)
![Screenshot 2024-08-23 at 12 24 30 PM](https://github.com/user-attachments/assets/300e9831-42af-498e-bd07-1c0d13de81a9)
![Screenshot 2024-08-23 at 12 24 24 PM](https://github.com/user-attachments/assets/aae4c576-c7c8-439b-b2c5-1db45874c21d)

