### PR TITLE
use runs on for nightly test

### DIFF
--- a/.github/workflows/nightly-integration-tests.yaml
+++ b/.github/workflows/nightly-integration-tests.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   nightly-run:
-    runs-on: ubuntu-latest
+    runs-on: runs-on,runner=2cpu-linux-x64,run-id=${{ github.run_id }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Description
use runs-on instead of dockerhub to avoid rate limit issue. 

https://github.com/aptos-labs/aptos-indexer-processors/pull/490