### PR TITLE
[2/2][FA migration] Complete fa migration and rename table

### DIFF
--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -15,7 +15,7 @@ use crate::{
         token_v2_models::v2_token_utils::{TokenStandard, V2_STANDARD},
     },
     schema::{
-        current_fungible_asset_balances, current_unified_fungible_asset_balances_to_be_renamed,
+        current_fungible_asset_balances, current_fungible_asset_balances_legacy,
         fungible_asset_balances,
     },
     utils::util::{
@@ -53,7 +53,7 @@ pub struct FungibleAssetBalance {
 
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(storage_id))]
-#[diesel(table_name = current_fungible_asset_balances)]
+#[diesel(table_name = current_fungible_asset_balances_legacy)]
 pub struct CurrentFungibleAssetBalance {
     pub storage_id: String,
     pub owner_address: String,
@@ -66,9 +66,11 @@ pub struct CurrentFungibleAssetBalance {
     pub token_standard: String,
 }
 
+/// Note that this used to be called current_unified_fungible_asset_balances_to_be_renamed
+/// and was renamed to current_fungible_asset_balances to facilitate migration
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, Default)]
 #[diesel(primary_key(storage_id))]
-#[diesel(table_name = current_unified_fungible_asset_balances_to_be_renamed)]
+#[diesel(table_name = current_fungible_asset_balances)]
 #[diesel(treat_none_as_null = true)]
 pub struct CurrentUnifiedFungibleAssetBalance {
     pub storage_id: String,

--- a/rust/processor/src/db/postgres/migrations/2024-08-28-015552_fa_migration_fix_2/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-28-015552_fa_migration_fix_2/down.sql
@@ -1,0 +1,7 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE current_fungible_asset_balances
+  RENAME TO current_unified_fungible_asset_balances_to_be_renamed;
+ALTER TABLE current_fungible_asset_balances_legacy
+  RENAME TO current_fungible_asset_balances;
+ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed DROP COLUMN IF EXISTS asset_type;
+ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed DROP COLUMN IF EXISTS token_standard;

--- a/rust/processor/src/db/postgres/migrations/2024-08-28-015552_fa_migration_fix_2/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-28-015552_fa_migration_fix_2/up.sql
@@ -1,0 +1,14 @@
+-- Your SQL goes here
+ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
+ADD COLUMN IF NOT EXISTS asset_type VARCHAR(1000) GENERATED ALWAYS AS (COALESCE(asset_type_v1, asset_type_v2)) STORED;
+ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
+ADD COLUMN IF NOT EXISTS token_standard VARCHAR(10) GENERATED ALWAYS AS (
+    CASE
+      WHEN asset_type_v1 IS NOT NULL THEN 'v1'
+      ELSE 'v2'
+    END
+  ) STORED;
+ALTER TABLE current_fungible_asset_balances
+  RENAME TO current_fungible_asset_balances_legacy;
+ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
+  RENAME TO current_fungible_asset_balances;

--- a/rust/processor/src/db/postgres/migrations/2024-08-28-015552_fa_migration_fix_2/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-28-015552_fa_migration_fix_2/up.sql
@@ -1,9 +1,9 @@
 -- Your SQL goes here
 ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
-ADD COLUMN IF NOT EXISTS asset_type VARCHAR(1000) GENERATED ALWAYS AS (COALESCE(asset_type_v1, asset_type_v2)) STORED;
+ADD COLUMN IF NOT EXISTS asset_type VARCHAR(1000) NOT NULL GENERATED ALWAYS AS (COALESCE(asset_type_v1, asset_type_v2)) STORED;
 CREATE INDEX IF NOT EXISTS cufab_owner_at_index ON current_unified_fungible_asset_balances_to_be_renamed (owner_address, asset_type);
 ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
-ADD COLUMN IF NOT EXISTS token_standard VARCHAR(10) GENERATED ALWAYS AS (
+ADD COLUMN IF NOT EXISTS token_standard VARCHAR(10) NOT NULL GENERATED ALWAYS AS (
     CASE
       WHEN asset_type_v1 IS NOT NULL THEN 'v1'
       ELSE 'v2'

--- a/rust/processor/src/db/postgres/migrations/2024-08-28-015552_fa_migration_fix_2/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-08-28-015552_fa_migration_fix_2/up.sql
@@ -1,6 +1,7 @@
 -- Your SQL goes here
 ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
 ADD COLUMN IF NOT EXISTS asset_type VARCHAR(1000) GENERATED ALWAYS AS (COALESCE(asset_type_v1, asset_type_v2)) STORED;
+CREATE INDEX IF NOT EXISTS cufab_owner_at_index ON current_unified_fungible_asset_balances_to_be_renamed (owner_address, asset_type);
 ALTER TABLE current_unified_fungible_asset_balances_to_be_renamed
 ADD COLUMN IF NOT EXISTS token_standard VARCHAR(10) GENERATED ALWAYS AS (
     CASE

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -427,6 +427,35 @@ diesel::table! {
         storage_id -> Varchar,
         #[max_length = 66]
         owner_address -> Varchar,
+        #[max_length = 66]
+        asset_type_v2 -> Nullable<Varchar>,
+        #[max_length = 1000]
+        asset_type_v1 -> Nullable<Varchar>,
+        is_primary -> Nullable<Bool>,
+        is_frozen -> Bool,
+        amount_v1 -> Nullable<Numeric>,
+        amount_v2 -> Nullable<Numeric>,
+        amount -> Nullable<Numeric>,
+        last_transaction_version_v1 -> Nullable<Int8>,
+        last_transaction_version_v2 -> Nullable<Int8>,
+        last_transaction_version -> Nullable<Int8>,
+        last_transaction_timestamp_v1 -> Nullable<Timestamp>,
+        last_transaction_timestamp_v2 -> Nullable<Timestamp>,
+        last_transaction_timestamp -> Nullable<Timestamp>,
+        inserted_at -> Timestamp,
+        #[max_length = 1000]
+        asset_type -> Nullable<Varchar>,
+        #[max_length = 10]
+        token_standard -> Nullable<Varchar>,
+    }
+}
+
+diesel::table! {
+    current_fungible_asset_balances_legacy (storage_id) {
+        #[max_length = 66]
+        storage_id -> Varchar,
+        #[max_length = 66]
+        owner_address -> Varchar,
         #[max_length = 1000]
         asset_type -> Varchar,
         is_primary -> Bool,
@@ -647,31 +676,6 @@ diesel::table! {
         #[max_length = 66]
         state_key_hash -> Varchar,
         last_transaction_version -> Int8,
-        inserted_at -> Timestamp,
-    }
-}
-
-diesel::table! {
-    current_unified_fungible_asset_balances_to_be_renamed (storage_id) {
-        #[max_length = 66]
-        storage_id -> Varchar,
-        #[max_length = 66]
-        owner_address -> Varchar,
-        #[max_length = 66]
-        asset_type_v2 -> Nullable<Varchar>,
-        #[max_length = 1000]
-        asset_type_v1 -> Nullable<Varchar>,
-        is_primary -> Nullable<Bool>,
-        is_frozen -> Bool,
-        amount_v1 -> Nullable<Numeric>,
-        amount_v2 -> Nullable<Numeric>,
-        amount -> Nullable<Numeric>,
-        last_transaction_version_v1 -> Nullable<Int8>,
-        last_transaction_version_v2 -> Nullable<Int8>,
-        last_transaction_version -> Nullable<Int8>,
-        last_transaction_timestamp_v1 -> Nullable<Timestamp>,
-        last_transaction_timestamp_v2 -> Nullable<Timestamp>,
-        last_transaction_timestamp -> Nullable<Timestamp>,
         inserted_at -> Timestamp,
     }
 }
@@ -1300,6 +1304,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_delegated_voter,
     current_delegator_balances,
     current_fungible_asset_balances,
+    current_fungible_asset_balances_legacy,
     current_objects,
     current_staking_pool_voter,
     current_table_items,
@@ -1310,7 +1315,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_token_pending_claims,
     current_token_royalty_v1,
     current_token_v2_metadata,
-    current_unified_fungible_asset_balances_to_be_renamed,
     delegated_staking_activities,
     delegated_staking_pool_balances,
     delegated_staking_pools,

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -444,9 +444,9 @@ diesel::table! {
         last_transaction_timestamp -> Nullable<Timestamp>,
         inserted_at -> Timestamp,
         #[max_length = 1000]
-        asset_type -> Nullable<Varchar>,
+        asset_type -> Varchar,
         #[max_length = 10]
-        token_standard -> Nullable<Varchar>,
+        token_standard -> Varchar,
     }
 }
 

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -245,10 +245,10 @@ fn insert_current_fungible_asset_balances_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::current_fungible_asset_balances::dsl::*;
+    use schema::current_fungible_asset_balances_legacy::dsl::*;
 
     (
-        diesel::insert_into(schema::current_fungible_asset_balances::table)
+        diesel::insert_into(schema::current_fungible_asset_balances_legacy::table)
             .values(items_to_insert)
             .on_conflict(storage_id)
             .do_update()
@@ -265,7 +265,7 @@ fn insert_current_fungible_asset_balances_query(
                     inserted_at.eq(excluded(inserted_at)),
                 )
             ),
-        Some(" WHERE current_fungible_asset_balances.last_transaction_version <= excluded.last_transaction_version "),
+        Some(" WHERE current_fungible_asset_balances_legacy.last_transaction_version <= excluded.last_transaction_version "),
     )
 }
 
@@ -275,10 +275,10 @@ fn insert_current_unified_fungible_asset_balances_v1_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::current_unified_fungible_asset_balances_to_be_renamed::dsl::*;
+    use schema::current_fungible_asset_balances::dsl::*;
 
     (
-        diesel::insert_into(schema::current_unified_fungible_asset_balances_to_be_renamed::table)
+        diesel::insert_into(schema::current_fungible_asset_balances::table)
             .values(items_to_insert)
             .on_conflict(storage_id)
             .do_update()
@@ -293,8 +293,8 @@ fn insert_current_unified_fungible_asset_balances_v1_query(
                     inserted_at.eq(excluded(inserted_at)),
                 )
             ),
-        Some(" WHERE current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v1 IS NULL \
-        OR current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v1 <= excluded.last_transaction_version_v1"),
+        Some(" WHERE current_fungible_asset_balances.last_transaction_version_v1 IS NULL \
+        OR current_fungible_asset_balances.last_transaction_version_v1 <= excluded.last_transaction_version_v1"),
     )
 }
 
@@ -304,9 +304,9 @@ fn insert_current_unified_fungible_asset_balances_v2_query(
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
     Option<&'static str>,
 ) {
-    use schema::current_unified_fungible_asset_balances_to_be_renamed::dsl::*;
+    use schema::current_fungible_asset_balances::dsl::*;
     (
-        diesel::insert_into(schema::current_unified_fungible_asset_balances_to_be_renamed::table)
+        diesel::insert_into(schema::current_fungible_asset_balances::table)
             .values(items_to_insert)
             .on_conflict(storage_id)
             .do_update()
@@ -322,8 +322,8 @@ fn insert_current_unified_fungible_asset_balances_v2_query(
                     inserted_at.eq(excluded(inserted_at)),
                 )
             ),
-        Some(" WHERE current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v2 IS NULL \
-        OR current_unified_fungible_asset_balances_to_be_renamed.last_transaction_version_v2 <= excluded.last_transaction_version_v2 "),
+        Some(" WHERE current_fungible_asset_balances.last_transaction_version_v2 IS NULL \
+        OR current_fungible_asset_balances.last_transaction_version_v2 <= excluded.last_transaction_version_v2 "),
     )
 }
 


### PR DESCRIPTION
1. Swap Hasura to use `current_unified_fungible_asset_balances`
2. Add a killswitch on `current_unified_fungible_asset_balances_to_be_renamed` 
    1. In addition, make a migration dropping columns. We want to split dropping columns separately from adding columns back so that we can add the columns without going through diesel migration again. 
    2. Deploy the change with KS turned on. This should create no downtime since column dropping is quick.


**[This PR]**
3. Add generated columns back in dbeaver
4. Create new migration with added columns. Then remove KS. 
5. Rename `current_fungible_asset_balances` to `current_fungible_asset_balances_legacy` 
6. Rename `current_unified_fungible_asset_balances_to_be_renamed` to `current_fungible_asset_balances`