### PR TITLE
[DO NOT MERGE] update the proto.

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -295,6 +295,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-protos"
+version = "1.3.1"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=a5560918275edcb126e146ed3cd06a8976fa403e#a5560918275edcb126e146ed3cd06a8976fa403e"
+dependencies = [
+ "futures-core",
+ "pbjson",
+ "prost 0.12.6",
+ "serde",
+ "tonic 0.11.0",
+]
+
+[[package]]
 name = "aptos-system-utils"
 version = "0.1.0"
 source = "git+https://github.com/aptos-labs/aptos-core.git?rev=202bdccff2b2d333a385ae86a4fcf23e89da9f62#202bdccff2b2d333a385ae86a4fcf23e89da9f62"
@@ -2224,7 +2236,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "aptos-indexer-test-transactions",
- "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=a5560918275edcb126e146ed3cd06a8976fa403e)",
  "bigdecimal",
  "diesel",
  "dirs",
@@ -3323,7 +3335,7 @@ dependencies = [
  "anyhow",
  "aptos-indexer-processor-sdk",
  "aptos-moving-average 0.1.0",
- "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=a5560918275edcb126e146ed3cd06a8976fa403e)",
  "async-trait",
  "bcs",
  "bigdecimal",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,7 +30,7 @@ ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.86"
 aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "e1e1bdd9349f0a68c9fc53b7e2cebda9e2ce92b7" }
 aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "e1e1bdd9349f0a68c9fc53b7e2cebda9e2ce92b7" }
-aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
+aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "a5560918275edcb126e146ed3cd06a8976fa403e" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }
 aptos-indexer-test-transactions = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }
 async-trait = "0.1.53"


### PR DESCRIPTION
Note: do not merge because devnet is not stable yet. 

* This is to update the proto to support:
1. https://github.com/aptos-labs/aptos-core/pull/14246
2. https://github.com/aptos-labs/aptos-core/pull/14127

No breaking change but update the dependency only. 