### PR TITLE
[indexer] alter public key to use text type.

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-09-03-232100_alter_signature_public_key_to_text/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-09-03-232100_alter_signature_public_key_to_text/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE signatures
+  ALTER COLUMN public_key TYPE VARCHAR(136);

--- a/rust/processor/src/db/postgres/migrations/2024-09-03-232100_alter_signature_public_key_to_text/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-09-03-232100_alter_signature_public_key_to_text/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE signatures
+  ALTER COLUMN public_key TYPE TEXT;

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -963,8 +963,7 @@ diesel::table! {
         is_sender_primary -> Bool,
         #[sql_name = "type"]
         type_ -> Varchar,
-        #[max_length = 136]
-        public_key -> Varchar,
+        public_key -> Text,
         signature -> Text,
         threshold -> Int8,
         public_key_indices -> Jsonb,

--- a/rust/processor/src/processors/mod.rs
+++ b/rust/processor/src/processors/mod.rs
@@ -99,6 +99,7 @@ pub trait ProcessorTrait: Send + Sync + Debug {
 
     /// Gets the connection.
     /// If it was unable to do so (default timeout: 30s), it will keep retrying until it can.
+    #[allow(elided_named_lifetimes)]
     async fn get_conn(&self) -> DbPoolConnection {
         let pool = self.connection_pool();
         loop {


### PR DESCRIPTION
* Fix the long publicKey issue for the indexer processor: change type to `text`

* Example Transaction: https://devnet.aptoslabs.com/v1/transactions/by_version/53778191

![image](https://github.com/user-attachments/assets/99e2d74d-5fd0-41f2-a3cf-c4816d2e6502)

## Testing

* Tested locally and it looks good

![image](https://github.com/user-attachments/assets/2dd8d3ea-e0c0-4939-812a-0a5ef1d49db4)
