### PR TITLE
Improve logging for indexer models and processors

### DIFF
--- a/rust/processor/src/db/common/models/coin_models/coin_activities.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_activities.rs
@@ -149,18 +149,19 @@ impl CoinActivity {
         }
 
         // Need coin info from move resources
-        for wsc in &transaction_info.changes {
+        for (wsc_index, wsc) in transaction_info.changes.iter().enumerate() {
             let (maybe_coin_info, maybe_coin_balance_data) =
                 if let WriteSetChangeEnum::WriteResource(write_resource) =
                     &wsc.change.as_ref().unwrap()
                 {
                     (
-                        CoinInfo::from_write_resource(write_resource, txn_version, txn_timestamp)
+                        CoinInfo::from_write_resource(write_resource, txn_version, txn_timestamp, wsc_index as i64)
                             .unwrap(),
                         CoinBalance::from_write_resource(
                             write_resource,
                             txn_version,
                             txn_timestamp,
+                            wsc_index as i64
                         )
                         .unwrap(),
                     )

--- a/rust/processor/src/db/common/models/coin_models/coin_activities.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_activities.rs
@@ -155,13 +155,18 @@ impl CoinActivity {
                     &wsc.change.as_ref().unwrap()
                 {
                     (
-                        CoinInfo::from_write_resource(write_resource, txn_version, txn_timestamp, wsc_index as i64)
-                            .unwrap(),
+                        CoinInfo::from_write_resource(
+                            write_resource,
+                            txn_version,
+                            txn_timestamp,
+                            wsc_index as i64,
+                        )
+                        .unwrap(),
                         CoinBalance::from_write_resource(
                             write_resource,
                             txn_version,
                             txn_timestamp,
-                            wsc_index as i64
+                            wsc_index as i64,
                         )
                         .unwrap(),
                     )

--- a/rust/processor/src/db/common/models/coin_models/coin_balances.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_balances.rs
@@ -49,7 +49,7 @@ impl CoinBalance {
         write_resource: &WriteResource,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
-        wsc_index: i64
+        wsc_index: i64,
     ) -> anyhow::Result<Option<(Self, CurrentCoinBalance, EventToCoinType)>> {
         match &CoinResource::from_write_resource(write_resource, txn_version)? {
             Some(CoinResource::CoinStoreResource(inner)) => {
@@ -57,7 +57,7 @@ impl CoinBalance {
                     &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     write_resource.type_str.as_ref(),
                     txn_version,
-                    wsc_index
+                    wsc_index,
                 );
                 let owner_address = standardize_address(write_resource.address.as_str());
                 let coin_balance = Self {

--- a/rust/processor/src/db/common/models/coin_models/coin_balances.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_balances.rs
@@ -49,6 +49,7 @@ impl CoinBalance {
         write_resource: &WriteResource,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
+        wsc_index: i64
     ) -> anyhow::Result<Option<(Self, CurrentCoinBalance, EventToCoinType)>> {
         match &CoinResource::from_write_resource(write_resource, txn_version)? {
             Some(CoinResource::CoinStoreResource(inner)) => {
@@ -56,6 +57,7 @@ impl CoinBalance {
                     &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     write_resource.type_str.as_ref(),
                     txn_version,
+                    wsc_index
                 );
                 let owner_address = standardize_address(write_resource.address.as_str());
                 let coin_balance = Self {

--- a/rust/processor/src/db/common/models/coin_models/coin_infos.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_infos.rs
@@ -33,6 +33,7 @@ impl CoinInfo {
         write_resource: &WriteResource,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
+        wsc_index: i64
     ) -> anyhow::Result<Option<Self>> {
         match &CoinResource::from_write_resource(write_resource, txn_version)? {
             Some(CoinResource::CoinInfoResource(inner)) => {
@@ -40,6 +41,7 @@ impl CoinInfo {
                     &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     write_resource.type_str.as_ref(),
                     txn_version,
+                    wsc_index
                 );
                 let (supply_aggregator_table_handle, supply_aggregator_table_key) = inner
                     .get_aggregator_metadata()

--- a/rust/processor/src/db/common/models/coin_models/coin_infos.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_infos.rs
@@ -33,7 +33,7 @@ impl CoinInfo {
         write_resource: &WriteResource,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
-        wsc_index: i64
+        wsc_index: i64,
     ) -> anyhow::Result<Option<Self>> {
         match &CoinResource::from_write_resource(write_resource, txn_version)? {
             Some(CoinResource::CoinInfoResource(inner)) => {
@@ -41,7 +41,7 @@ impl CoinInfo {
                     &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     write_resource.type_str.as_ref(),
                     txn_version,
-                    wsc_index
+                    wsc_index,
                 );
                 let (supply_aggregator_table_handle, supply_aggregator_table_key) = inner
                     .get_aggregator_metadata()

--- a/rust/processor/src/db/common/models/coin_models/coin_utils.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_utils.rs
@@ -169,12 +169,13 @@ impl CoinInfoType {
     /// get creator address from move_type, and get coin type from move_type_str
     /// Since move_type_str will contain things we don't need, e.g. 0x1::coin::CoinInfo<T>. We will use
     /// regex to extract T.
-    pub fn from_move_type(move_type: &MoveType, move_type_str: &str, txn_version: i64) -> Self {
+    pub fn from_move_type(move_type: &MoveType, move_type_str: &str, txn_version: i64, wsc_index: i64) -> Self {
         if let Content::Struct(struct_tag) = move_type.content.as_ref().unwrap() {
             let matched = RE.captures(move_type_str).unwrap_or_else(|| {
                 error!(
                     txn_version = txn_version,
                     move_type_str = move_type_str,
+                    wsc_index = wsc_index,
                     "move_type should look like 0x1::coin::CoinInfo<T>"
                 );
                 panic!();

--- a/rust/processor/src/db/common/models/coin_models/coin_utils.rs
+++ b/rust/processor/src/db/common/models/coin_models/coin_utils.rs
@@ -169,7 +169,12 @@ impl CoinInfoType {
     /// get creator address from move_type, and get coin type from move_type_str
     /// Since move_type_str will contain things we don't need, e.g. 0x1::coin::CoinInfo<T>. We will use
     /// regex to extract T.
-    pub fn from_move_type(move_type: &MoveType, move_type_str: &str, txn_version: i64, wsc_index: i64) -> Self {
+    pub fn from_move_type(
+        move_type: &MoveType,
+        move_type_str: &str,
+        txn_version: i64,
+        wsc_index: i64,
+    ) -> Self {
         if let Content::Struct(struct_tag) = move_type.content.as_ref().unwrap() {
             let matched = RE.captures(move_type_str).unwrap_or_else(|| {
                 error!(

--- a/rust/processor/src/db/common/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/db/common/models/default_models/write_set_changes.rs
@@ -3,7 +3,6 @@
 
 #![allow(clippy::extra_unused_lifetimes)]
 
-use tracing::log::error;
 use super::{
     move_modules::MoveModule,
     move_resources::MoveResource,
@@ -20,6 +19,7 @@ use aptos_protos::transaction::v1::{
 };
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
+use tracing::log::error;
 
 #[derive(
     Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize,
@@ -191,7 +191,10 @@ impl WriteSetChange {
             WriteSetChangeTypeEnum::WriteResource => "write_resource".to_string(),
             WriteSetChangeTypeEnum::WriteTableItem => "write_table_item".to_string(),
             WriteSetChangeTypeEnum::Unspecified => {
-                error!("Encountered Unspecified WriteSetChange type. Transaction Version: {}", txn_version);
+                error!(
+                    "Encountered Unspecified WriteSetChange type. Transaction Version: {}",
+                    txn_version
+                );
                 panic!("WriteSetChange type must be specified.")
             },
         }

--- a/rust/processor/src/db/common/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/db/common/models/default_models/write_set_changes.rs
@@ -3,6 +3,7 @@
 
 #![allow(clippy::extra_unused_lifetimes)]
 
+use tracing::log::error;
 use super::{
     move_modules::MoveModule,
     move_resources::MoveResource,
@@ -42,7 +43,7 @@ impl WriteSetChange {
         transaction_version: i64,
         transaction_block_height: i64,
     ) -> (Self, WriteSetChangeDetail) {
-        let type_ = Self::get_write_set_change_type(write_set_change);
+        let type_ = Self::get_write_set_change_type(write_set_change, transaction_version);
         let change = write_set_change
             .change
             .as_ref()
@@ -179,7 +180,7 @@ impl WriteSetChange {
             .unzip()
     }
 
-    fn get_write_set_change_type(t: &WriteSetChangePB) -> String {
+    fn get_write_set_change_type(t: &WriteSetChangePB, txn_version: i64) -> String {
         match WriteSetChangeTypeEnum::try_from(t.r#type)
             .expect("WriteSetChange must have a valid type.")
         {
@@ -190,6 +191,7 @@ impl WriteSetChange {
             WriteSetChangeTypeEnum::WriteResource => "write_resource".to_string(),
             WriteSetChangeTypeEnum::WriteTableItem => "write_table_item".to_string(),
             WriteSetChangeTypeEnum::Unspecified => {
+                error!("Encountered Unspecified WriteSetChange type. Transaction Version: {}", txn_version);
                 panic!("WriteSetChange type must be specified.")
             },
         }

--- a/rust/processor/src/db/common/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/db/common/models/default_models/write_set_changes.rs
@@ -19,7 +19,7 @@ use aptos_protos::transaction::v1::{
 };
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
-use tracing::log::error;
+use tracing::error;
 
 #[derive(
     Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize,
@@ -43,7 +43,7 @@ impl WriteSetChange {
         transaction_version: i64,
         transaction_block_height: i64,
     ) -> (Self, WriteSetChangeDetail) {
-        let type_ = Self::get_write_set_change_type(write_set_change, transaction_version);
+        let type_ = Self::get_write_set_change_type(write_set_change, index, transaction_version);
         let change = write_set_change
             .change
             .as_ref()
@@ -180,7 +180,7 @@ impl WriteSetChange {
             .unzip()
     }
 
-    fn get_write_set_change_type(t: &WriteSetChangePB, txn_version: i64) -> String {
+    fn get_write_set_change_type(t: &WriteSetChangePB, index: i64, txn_version: i64) -> String {
         match WriteSetChangeTypeEnum::try_from(t.r#type)
             .expect("WriteSetChange must have a valid type.")
         {
@@ -192,8 +192,9 @@ impl WriteSetChange {
             WriteSetChangeTypeEnum::WriteTableItem => "write_table_item".to_string(),
             WriteSetChangeTypeEnum::Unspecified => {
                 error!(
-                    "Encountered Unspecified WriteSetChange type. Transaction Version: {}",
-                    txn_version
+                    wsc_index = index, 
+                    txn_version = txn_version,
+                    "Encountered Unspecified WriteSetChange type. "
                 );
                 panic!("WriteSetChange type must be specified.")
             },

--- a/rust/processor/src/db/common/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/db/common/models/default_models/write_set_changes.rs
@@ -192,7 +192,7 @@ impl WriteSetChange {
             WriteSetChangeTypeEnum::WriteTableItem => "write_table_item".to_string(),
             WriteSetChangeTypeEnum::Unspecified => {
                 error!(
-                    wsc_index = index, 
+                    wsc_index = index,
                     txn_version = txn_version,
                     "Encountered Unspecified WriteSetChange type. "
                 );

--- a/rust/processor/src/db/common/models/fungible_asset_models/parquet_v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/parquet_v2_fungible_asset_balances.rs
@@ -139,7 +139,7 @@ impl FungibleAssetBalance {
                 &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 delete_resource.type_str.as_ref(),
                 txn_version,
-                write_set_change_index
+                write_set_change_index,
             );
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(delete_resource.address.as_str());
@@ -193,7 +193,7 @@ impl FungibleAssetBalance {
                 &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 write_resource.type_str.as_ref(),
                 txn_version,
-                write_set_change_index
+                write_set_change_index,
             );
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(write_resource.address.as_str());

--- a/rust/processor/src/db/common/models/fungible_asset_models/parquet_v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/parquet_v2_fungible_asset_balances.rs
@@ -139,6 +139,7 @@ impl FungibleAssetBalance {
                 &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 delete_resource.type_str.as_ref(),
                 txn_version,
+                write_set_change_index
             );
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(delete_resource.address.as_str());
@@ -192,6 +193,7 @@ impl FungibleAssetBalance {
                 &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 write_resource.type_str.as_ref(),
                 txn_version,
+                write_set_change_index
             );
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(write_resource.address.as_str());

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -220,6 +220,7 @@ impl FungibleAssetBalance {
                 &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 delete_resource.type_str.as_ref(),
                 txn_version,
+                write_set_change_index
             );
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(delete_resource.address.as_str());
@@ -273,6 +274,7 @@ impl FungibleAssetBalance {
                 &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 write_resource.type_str.as_ref(),
                 txn_version,
+                write_set_change_index
             );
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(write_resource.address.as_str());

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -220,7 +220,7 @@ impl FungibleAssetBalance {
                 &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 delete_resource.type_str.as_ref(),
                 txn_version,
-                write_set_change_index
+                write_set_change_index,
             );
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(delete_resource.address.as_str());
@@ -274,7 +274,7 @@ impl FungibleAssetBalance {
                 &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                 write_resource.type_str.as_ref(),
                 txn_version,
-                write_set_change_index
+                write_set_change_index,
             );
             if let Some(coin_type) = coin_info_type.get_coin_type_below_max() {
                 let owner_address = standardize_address(write_resource.address.as_str());

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -161,7 +161,7 @@ impl FungibleAssetMetadataModel {
                     &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     delete_resource.type_str.as_ref(),
                     txn_version,
-                    write_set_change_index
+                    write_set_change_index,
                 );
                 let (supply_aggregator_table_handle, supply_aggregator_table_key) = inner
                     .get_aggregator_metadata()

--- a/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_metadata.rs
+++ b/rust/processor/src/db/common/models/fungible_asset_models/v2_fungible_metadata.rs
@@ -106,6 +106,7 @@ impl FungibleAssetMetadataModel {
     /// We can find v1 coin info from resources
     pub fn get_v1_from_write_resource(
         write_resource: &WriteResource,
+        write_set_change_index: i64,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
     ) -> anyhow::Result<Option<Self>> {
@@ -115,6 +116,7 @@ impl FungibleAssetMetadataModel {
                     &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     write_resource.type_str.as_ref(),
                     txn_version,
+                    write_set_change_index,
                 );
                 let (supply_aggregator_table_handle, supply_aggregator_table_key) = inner
                     .get_aggregator_metadata()
@@ -149,6 +151,7 @@ impl FungibleAssetMetadataModel {
 
     pub fn get_v1_from_delete_resource(
         delete_resource: &DeleteResource,
+        write_set_change_index: i64,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
     ) -> anyhow::Result<Option<Self>> {
@@ -158,6 +161,7 @@ impl FungibleAssetMetadataModel {
                     &delete_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     delete_resource.type_str.as_ref(),
                     txn_version,
+                    write_set_change_index
                 );
                 let (supply_aggregator_table_handle, supply_aggregator_table_key) = inner
                     .get_aggregator_metadata()

--- a/rust/processor/src/processors/ans_processor.rs
+++ b/rust/processor/src/processors/ans_processor.rs
@@ -583,6 +583,7 @@ fn parse_ans(
                                 error!(
                                     error = ?e,
                                     write_set_change_index = wsc_index,
+                                    transaction_version = txn_version,
                                     "Error parsing ANS v1 name record from write table item"
                                 );
                                 panic!();

--- a/rust/processor/src/processors/ans_processor.rs
+++ b/rust/processor/src/processors/ans_processor.rs
@@ -582,6 +582,7 @@ fn parse_ans(
                             .unwrap_or_else(|e| {
                                 error!(
                                     error = ?e,
+                                    write_set_change_index = wsc_index,
                                     "Error parsing ANS v1 name record from write table item"
                                 );
                                 panic!();
@@ -608,6 +609,7 @@ fn parse_ans(
                                 .unwrap_or_else(|e| {
                                     error!(
                                 error = ?e,
+                                write_set_change_index = wsc_index,
                                 "Error parsing ANS v1 primary name from write table item"
                             );
                                     panic!();

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -689,6 +689,7 @@ async fn parse_v2_coin(
                         if let Some(fa_metadata) =
                             FungibleAssetMetadataModel::get_v1_from_write_resource(
                                 write_resource,
+                                index as i64,
                                 txn_version,
                                 txn_timestamp,
                             )


### PR DESCRIPTION
### Purpose
[Context for onboarding task](https://www.notion.so/aptoslabs/Sean-Onboarding-46a443876035440f8c577a31ef015974?pvs=4#fc60141e2c714ba7bc1d6ccb921f4621)

Additional metadata (`write_set_change_index` and/or `txn_version`) to logs for easier debugging. 
Namely, logs in 
* `coin_utils.rs`
*  `write_set_changes.rs`
*  `ans_processor.rs`
The rest of the diff is just making the appropriate variables available for the logging. 

### Testing
![image](https://github.com/user-attachments/assets/b00cefa3-dd88-471e-8ed0-628760c1857a)
Ran `default_processor` (for wsc.unspecified logging),  `ans_processor` and `fungible_asset_processor` locally.
