### PR TITLE
clean up default processor

### DIFF
--- a/rust/indexer-metrics/src/main.rs
+++ b/rust/indexer-metrics/src/main.rs
@@ -84,8 +84,7 @@ impl RunnableConfig for PostProcessorConfig {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = ServerArgs::parse();
-    args.run::<PostProcessorConfig>(tokio::runtime::Handle::current())
-        .await
+    args.run::<PostProcessorConfig>(tokio::runtime::Handle::current()).await
 }
 
 async fn start_fn_fetch(url: String, chain_name: String) {

--- a/rust/indexer-metrics/src/main.rs
+++ b/rust/indexer-metrics/src/main.rs
@@ -81,10 +81,12 @@ impl RunnableConfig for PostProcessorConfig {
     }
 }
 
+#[allow(clippy::needless_return)]
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = ServerArgs::parse();
-    args.run::<PostProcessorConfig>(tokio::runtime::Handle::current()).await
+    args.run::<PostProcessorConfig>(tokio::runtime::Handle::current())
+        .await
 }
 
 async fn start_fn_fetch(url: String, chain_name: String) {
@@ -197,6 +199,7 @@ async fn start_processor_status_fetch(url: String, chain_name: String) {
     }
 }
 
+#[allow(clippy::needless_return)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/rust/integration-tests/src/event_processor/event_processor_tests.rs
+++ b/rust/integration-tests/src/event_processor/event_processor_tests.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::needless_return)]
 #[cfg(test)]
 mod test {
     use crate::{TestContext, TestProcessorConfig};

--- a/rust/processor/src/db/common/models/default_models/transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/transactions.rs
@@ -103,7 +103,7 @@ impl Transaction {
             .collect();
 
         for processed_txn in processed_txns {
-            let (block_metadata, mut wsc_detail_list) = processed_txns;
+            let (block_metadata, mut wsc_detail_list) = processed_txn;
             if let Some(a) = block_metadata {
                 block_metadata_txns.push(a);
             }

--- a/rust/processor/src/db/common/models/default_models/transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/transactions.rs
@@ -13,15 +13,10 @@ use crate::{
     schema::transactions,
     utils::{
         counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
-        util::{
-            get_clean_payload, get_clean_writeset, get_payload_type, standardize_address,
-            u64_to_bigdecimal,
-        },
     },
 };
 use aptos_protos::transaction::v1::{
-    transaction::{TransactionType, TxnData},
-    Transaction as TransactionPB, TransactionInfo,
+    transaction::TxnData, Transaction as TransactionPB,
 };
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
@@ -50,109 +45,10 @@ pub struct Transaction {
     pub payload_type: Option<String>,
 }
 
-impl Default for Transaction {
-    fn default() -> Self {
-        Self {
-            version: 0,
-            block_height: 0,
-            hash: "".to_string(),
-            type_: "".to_string(),
-            payload: None,
-            state_change_hash: "".to_string(),
-            event_root_hash: "".to_string(),
-            state_checkpoint_hash: None,
-            gas_used: BigDecimal::from(0),
-            success: true,
-            vm_status: "".to_string(),
-            accumulator_root_hash: "".to_string(),
-            num_events: 0,
-            num_write_set_changes: 0,
-            epoch: 0,
-            payload_type: None,
-        }
-    }
-}
-
 impl Transaction {
-    fn from_transaction_info(
-        info: &TransactionInfo,
-        version: i64,
-        epoch: i64,
-        block_height: i64,
-    ) -> Self {
-        Self {
-            version,
-            block_height,
-            hash: standardize_address(hex::encode(info.hash.as_slice()).as_str()),
-            state_change_hash: standardize_address(
-                hex::encode(info.state_change_hash.as_slice()).as_str(),
-            ),
-            event_root_hash: standardize_address(
-                hex::encode(info.event_root_hash.as_slice()).as_str(),
-            ),
-            state_checkpoint_hash: info
-                .state_checkpoint_hash
-                .as_ref()
-                .map(|hash| standardize_address(hex::encode(hash).as_str())),
-            gas_used: u64_to_bigdecimal(info.gas_used),
-            success: info.success,
-            vm_status: info.vm_status.clone(),
-            accumulator_root_hash: standardize_address(
-                hex::encode(info.accumulator_root_hash.as_slice()).as_str(),
-            ),
-            num_write_set_changes: info.changes.len() as i64,
-            epoch,
-            ..Default::default()
-        }
-    }
-
-    fn from_transaction_info_with_data(
-        info: &TransactionInfo,
-        payload: Option<serde_json::Value>,
-        payload_type: Option<String>,
-        version: i64,
-        type_: String,
-        num_events: i64,
-        block_height: i64,
-        epoch: i64,
-    ) -> Self {
-        Self {
-            type_,
-            payload,
-            version,
-            block_height,
-            hash: standardize_address(hex::encode(info.hash.as_slice()).as_str()),
-            state_change_hash: standardize_address(
-                hex::encode(info.state_change_hash.as_slice()).as_str(),
-            ),
-            event_root_hash: standardize_address(
-                hex::encode(info.event_root_hash.as_slice()).as_str(),
-            ),
-            state_checkpoint_hash: info
-                .state_checkpoint_hash
-                .as_ref()
-                .map(|hash| standardize_address(hex::encode(hash).as_str())),
-            gas_used: u64_to_bigdecimal(info.gas_used),
-            success: info.success,
-            vm_status: info.vm_status.clone(),
-            accumulator_root_hash: standardize_address(
-                hex::encode(info.accumulator_root_hash.as_slice()).as_str(),
-            ),
-            num_events,
-            num_write_set_changes: info.changes.len() as i64,
-            epoch,
-            payload_type,
-        }
-    }
-
     pub fn from_transaction(
         transaction: &TransactionPB,
-    ) -> (
-        Self,
-        Option<BlockMetadataTransaction>,
-        Vec<WriteSetChangeModel>,
-        Vec<WriteSetChangeDetail>,
-    ) {
+    ) -> (Option<BlockMetadataTransaction>, Vec<WriteSetChangeDetail>) {
         let block_height = transaction.block_height as i64;
         let epoch = transaction.epoch as i64;
         let transaction_info = transaction
@@ -169,97 +65,23 @@ impl Transaction {
                     transaction_version = transaction.version,
                     "Transaction data doesn't exist",
                 );
-                let transaction_out = Self::from_transaction_info(
-                    transaction_info,
-                    transaction.version as i64,
-                    epoch,
-                    block_height,
-                );
-                return (transaction_out, None, Vec::new(), Vec::new());
+                return (None, Vec::new());
             },
         };
         let version = transaction.version as i64;
-        let transaction_type = TransactionType::try_from(transaction.r#type)
-            .expect("Transaction type doesn't exist!")
-            .as_str_name()
-            .to_string();
         let timestamp = transaction
             .timestamp
             .as_ref()
             .expect("Transaction timestamp doesn't exist!");
 
-        let (wsc, wsc_detail) = WriteSetChangeModel::from_write_set_changes(
+        let wsc_detail = WriteSetChangeDetail::from_write_set_changes(
             &transaction_info.changes,
             version,
             block_height,
         );
 
         match txn_data {
-            TxnData::User(user_txn) => {
-                let request = &user_txn
-                    .request
-                    .as_ref()
-                    .expect("Getting user request failed.");
-
-                let (payload_cleaned, payload_type) = match request.payload.as_ref() {
-                    Some(payload) => {
-                        let payload_cleaned = get_clean_payload(payload, version);
-                        (payload_cleaned, Some(get_payload_type(payload)))
-                    },
-                    None => (None, None),
-                };
-
-                (
-                    Self::from_transaction_info_with_data(
-                        transaction_info,
-                        payload_cleaned,
-                        payload_type,
-                        version,
-                        transaction_type,
-                        user_txn.events.len() as i64,
-                        block_height,
-                        epoch,
-                    ),
-                    None,
-                    wsc,
-                    wsc_detail,
-                )
-            },
-            TxnData::Genesis(genesis_txn) => {
-                let payload_cleaned = genesis_txn
-                    .payload
-                    .as_ref()
-                    .map(|payload| get_clean_writeset(payload, version))
-                    .unwrap_or(None);
-                // It's genesis so no big deal
-                let payload_type = None;
-                (
-                    Self::from_transaction_info_with_data(
-                        transaction_info,
-                        payload_cleaned,
-                        payload_type,
-                        version,
-                        transaction_type,
-                        genesis_txn.events.len() as i64,
-                        block_height,
-                        epoch,
-                    ),
-                    None,
-                    wsc,
-                    wsc_detail,
-                )
-            },
             TxnData::BlockMetadata(block_metadata_txn) => (
-                Self::from_transaction_info_with_data(
-                    transaction_info,
-                    None,
-                    None,
-                    version,
-                    transaction_type,
-                    block_metadata_txn.events.len() as i64,
-                    block_height,
-                    epoch,
-                ),
                 Some(BlockMetadataTransaction::from_transaction(
                     block_metadata_txn,
                     version,
@@ -267,68 +89,20 @@ impl Transaction {
                     epoch,
                     timestamp,
                 )),
-                wsc,
                 wsc_detail,
             ),
-            TxnData::StateCheckpoint(_) => (
-                Self::from_transaction_info_with_data(
-                    transaction_info,
-                    None,
-                    None,
-                    version,
-                    transaction_type,
-                    0,
-                    block_height,
-                    epoch,
-                ),
-                None,
-                vec![],
-                vec![],
-            ),
-            TxnData::Validator(_) => (
-                Self::from_transaction_info_with_data(
-                    transaction_info,
-                    None,
-                    None,
-                    version,
-                    transaction_type,
-                    0,
-                    block_height,
-                    epoch,
-                ),
-                None,
-                wsc,
-                wsc_detail,
-            ),
-            TxnData::BlockEpilogue(_) => (
-                Self::from_transaction_info_with_data(
-                    transaction_info,
-                    None,
-                    None,
-                    version,
-                    transaction_type,
-                    0,
-                    block_height,
-                    epoch,
-                ),
-                None,
-                vec![],
-                vec![],
-            ),
+            TxnData::User(_) => (None, wsc_detail),
+            TxnData::Genesis(_) => (None, wsc_detail),
+            TxnData::StateCheckpoint(_) => (None, vec![]),
+            TxnData::Validator(_) => (None, wsc_detail),
+            TxnData::BlockEpilogue(_) => (None, vec![]),
         }
     }
 
     pub fn from_transactions(
         transactions: &[TransactionPB],
-    ) -> (
-        Vec<Self>,
-        Vec<BlockMetadataTransaction>,
-        Vec<WriteSetChangeModel>,
-        Vec<WriteSetChangeDetail>,
-    ) {
-        let mut txns = vec![];
+    ) -> (Vec<BlockMetadataTransaction>, Vec<WriteSetChangeDetail>) {
         let mut block_metadata_txns = vec![];
-        let mut wscs = vec![];
         let mut wsc_details = vec![];
 
         let processed_txns: Vec<_> = transactions
@@ -337,15 +111,13 @@ impl Transaction {
             .collect();
 
         for processed_txn in processed_txns {
-            let (txn, block_metadata, mut wsc_list, mut wsc_detail_list) = processed_txn;
-            txns.push(txn);
+            let (block_metadata, mut wsc_detail_list) = processed_txns;
             if let Some(a) = block_metadata {
                 block_metadata_txns.push(a);
             }
-            wscs.append(&mut wsc_list);
             wsc_details.append(&mut wsc_detail_list);
         }
-        (txns, block_metadata_txns, wscs, wsc_details)
+        (block_metadata_txns, wsc_details)
     }
 }
 

--- a/rust/processor/src/db/common/models/default_models/transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/transactions.rs
@@ -6,18 +6,10 @@
 #![allow(clippy::unused_unit)]
 
 use super::{
-    block_metadata_transactions::BlockMetadataTransaction,
-    write_set_changes::{WriteSetChangeDetail, WriteSetChangeModel},
+    block_metadata_transactions::BlockMetadataTransaction, write_set_changes::WriteSetChangeDetail,
 };
-use crate::{
-    schema::transactions,
-    utils::{
-        counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
-    },
-};
-use aptos_protos::transaction::v1::{
-    transaction::TxnData, Transaction as TransactionPB,
-};
+use crate::{schema::transactions, utils::counters::PROCESSOR_UNKNOWN_TYPE_COUNT};
+use aptos_protos::transaction::v1::{transaction::TxnData, Transaction as TransactionPB};
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use rayon::prelude::*;

--- a/rust/processor/src/db/common/models/default_models/write_set_changes.rs
+++ b/rust/processor/src/db/common/models/default_models/write_set_changes.rs
@@ -9,16 +9,12 @@ use super::{
     move_tables::{CurrentTableItem, TableItem, TableMetadata},
     transactions::Transaction,
 };
-use crate::{
-    schema::write_set_changes,
-};
+use crate::schema::write_set_changes;
 use aptos_protos::transaction::v1::{
-    write_set_change::{Change as WriteSetChangeEnum},
-    WriteSetChange as WriteSetChangePB,
+    write_set_change::Change as WriteSetChangeEnum, WriteSetChange as WriteSetChangePB,
 };
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
-use tracing::error;
 
 #[derive(
     Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize,
@@ -55,39 +51,38 @@ impl WriteSetChangeDetail {
             .expect("WriteSetChange must have a change");
 
         match change {
-            WriteSetChangeEnum::WriteModule(inner) =>
+            WriteSetChangeEnum::WriteModule(inner) => {
                 WriteSetChangeDetail::Module(MoveModule::from_write_module(
                     inner,
                     index,
                     transaction_version,
                     transaction_block_height,
-                )
-                ),
-            WriteSetChangeEnum::DeleteModule(inner) =>
-
+                ))
+            },
+            WriteSetChangeEnum::DeleteModule(inner) => {
                 WriteSetChangeDetail::Module(MoveModule::from_delete_module(
                     inner,
                     index,
                     transaction_version,
                     transaction_block_height,
-                )
-                ),
-            WriteSetChangeEnum::WriteResource(inner) =>
+                ))
+            },
+            WriteSetChangeEnum::WriteResource(inner) => {
                 WriteSetChangeDetail::Resource(MoveResource::from_write_resource(
                     inner,
                     index,
                     transaction_version,
                     transaction_block_height,
-                )
-                ),
-            WriteSetChangeEnum::DeleteResource(inner) =>
+                ))
+            },
+            WriteSetChangeEnum::DeleteResource(inner) => {
                 WriteSetChangeDetail::Resource(MoveResource::from_delete_resource(
                     inner,
                     index,
                     transaction_version,
                     transaction_block_height,
-                )
-                ),
+                ))
+            },
             WriteSetChangeEnum::WriteTableItem(inner) => {
                 let (ti, cti) = TableItem::from_write_table_item(
                     inner,
@@ -131,27 +126,6 @@ impl WriteSetChangeDetail {
                 )
             })
             .collect::<Vec<WriteSetChangeDetail>>()
-    }
-
-    fn get_write_set_change_type(t: &WriteSetChangePB, index: i64, txn_version: i64) -> String {
-        match WriteSetChangeTypeEnum::try_from(t.r#type)
-            .expect("WriteSetChange must have a valid type.")
-        {
-            WriteSetChangeTypeEnum::DeleteModule => "delete_module".to_string(),
-            WriteSetChangeTypeEnum::DeleteResource => "delete_resource".to_string(),
-            WriteSetChangeTypeEnum::DeleteTableItem => "delete_table_item".to_string(),
-            WriteSetChangeTypeEnum::WriteModule => "write_module".to_string(),
-            WriteSetChangeTypeEnum::WriteResource => "write_resource".to_string(),
-            WriteSetChangeTypeEnum::WriteTableItem => "write_table_item".to_string(),
-            WriteSetChangeTypeEnum::Unspecified => {
-                error!(
-                    wsc_index = index,
-                    txn_version = txn_version,
-                    "Encountered Unspecified WriteSetChange type. "
-                );
-                panic!("WriteSetChange type must be specified.")
-            },
-        }
     }
 }
 

--- a/rust/processor/src/gap_detectors/gap_detector.rs
+++ b/rust/processor/src/gap_detectors/gap_detector.rs
@@ -70,6 +70,7 @@ impl DefaultGapDetector {
     }
 }
 
+#[allow(clippy::needless_return)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/rust/processor/src/processors/default_processor.rs
+++ b/rust/processor/src/processors/default_processor.rs
@@ -9,7 +9,7 @@ use crate::{
         move_resources::MoveResource,
         move_tables::{CurrentTableItem, TableItem, TableMetadata},
         transactions::TransactionModel,
-        write_set_changes::{WriteSetChangeDetail, WriteSetChangeModel},
+        write_set_changes::WriteSetChangeDetail,
     },
     gap_detectors::ProcessingResult,
     schema,
@@ -65,12 +65,8 @@ async fn insert_to_db(
     name: &'static str,
     start_version: u64,
     end_version: u64,
-    txns: &[TransactionModel],
     block_metadata_transactions: &[BlockMetadataTransactionModel],
-    wscs: &[WriteSetChangeModel],
-    (move_modules, move_resources, table_items, current_table_items, table_metadata): (
-        &[MoveModule],
-        &[MoveResource],
+    (table_items, current_table_items, table_metadata): (
         &[TableItem],
         &[CurrentTableItem],
         &[TableMetadata],
@@ -84,13 +80,6 @@ async fn insert_to_db(
         "Inserting to db",
     );
 
-    let txns_res = execute_in_chunks(
-        conn.clone(),
-        insert_transactions_query,
-        txns,
-        get_config_table_chunk_size::<TransactionModel>("transactions", per_table_chunk_sizes),
-    );
-
     let bmt_res = execute_in_chunks(
         conn.clone(),
         insert_block_metadata_transactions_query,
@@ -99,30 +88,6 @@ async fn insert_to_db(
             "block_metadata_transactions",
             per_table_chunk_sizes,
         ),
-    );
-
-    let wst_res = execute_in_chunks(
-        conn.clone(),
-        insert_write_set_changes_query,
-        wscs,
-        get_config_table_chunk_size::<WriteSetChangeModel>(
-            "write_set_changes",
-            per_table_chunk_sizes,
-        ),
-    );
-
-    let mm_res = execute_in_chunks(
-        conn.clone(),
-        insert_move_modules_query,
-        move_modules,
-        get_config_table_chunk_size::<MoveModule>("move_modules", per_table_chunk_sizes),
-    );
-
-    let mr_res = execute_in_chunks(
-        conn.clone(),
-        insert_move_resources_query,
-        move_resources,
-        get_config_table_chunk_size::<MoveResource>("move_resources", per_table_chunk_sizes),
     );
 
     let ti_res = execute_in_chunks(
@@ -149,37 +114,13 @@ async fn insert_to_db(
         get_config_table_chunk_size::<TableMetadata>("table_metadatas", per_table_chunk_sizes),
     );
 
-    let (txns_res, wst_res, bmt_res, mm_res, mr_res, ti_res, cti_res, tm_res) =
-        join!(txns_res, wst_res, bmt_res, mm_res, mr_res, ti_res, cti_res, tm_res);
+    let (bmt_res, ti_res, cti_res, tm_res) = join!(bmt_res, ti_res, cti_res, tm_res);
 
-    for res in [
-        txns_res, wst_res, bmt_res, mm_res, mr_res, ti_res, cti_res, tm_res,
-    ] {
+    for res in [bmt_res, ti_res, cti_res, tm_res] {
         res?;
     }
 
     Ok(())
-}
-
-fn insert_transactions_query(
-    items_to_insert: Vec<TransactionModel>,
-) -> (
-    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
-    Option<&'static str>,
-) {
-    use schema::transactions::dsl::*;
-
-    (
-        diesel::insert_into(schema::transactions::table)
-            .values(items_to_insert)
-            .on_conflict(version)
-            .do_update()
-            .set((
-                inserted_at.eq(excluded(inserted_at)),
-                payload_type.eq(excluded(payload_type)),
-            )),
-        None,
-    )
 }
 
 fn insert_block_metadata_transactions_query(
@@ -194,57 +135,6 @@ fn insert_block_metadata_transactions_query(
         diesel::insert_into(schema::block_metadata_transactions::table)
             .values(items_to_insert)
             .on_conflict(version)
-            .do_nothing(),
-        None,
-    )
-}
-
-fn insert_write_set_changes_query(
-    items_to_insert: Vec<WriteSetChangeModel>,
-) -> (
-    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
-    Option<&'static str>,
-) {
-    use schema::write_set_changes::dsl::*;
-
-    (
-        diesel::insert_into(schema::write_set_changes::table)
-            .values(items_to_insert)
-            .on_conflict((transaction_version, index))
-            .do_nothing(),
-        None,
-    )
-}
-
-fn insert_move_modules_query(
-    items_to_insert: Vec<MoveModule>,
-) -> (
-    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
-    Option<&'static str>,
-) {
-    use schema::move_modules::dsl::*;
-
-    (
-        diesel::insert_into(schema::move_modules::table)
-            .values(items_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
-            .do_nothing(),
-        None,
-    )
-}
-
-fn insert_move_resources_query(
-    items_to_insert: Vec<MoveResource>,
-) -> (
-    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
-    Option<&'static str>,
-) {
-    use schema::move_resources::dsl::*;
-
-    (
-        diesel::insert_into(schema::move_resources::table)
-            .values(items_to_insert)
-            .on_conflict((transaction_version, write_set_change_index))
             .do_nothing(),
         None,
     )
@@ -325,14 +215,10 @@ impl ProcessorTrait for DefaultProcessor {
         let processing_start = std::time::Instant::now();
         let last_transaction_timestamp = transactions.last().unwrap().timestamp.clone();
         let flags = self.deprecated_tables;
-        let (
-            txns,
-            block_metadata_transactions,
-            write_set_changes,
-            (move_modules, move_resources, table_items, current_table_items, table_metadata),
-        ) = tokio::task::spawn_blocking(move || process_transactions(transactions, flags))
-            .await
-            .expect("Failed to spawn_blocking for TransactionModel::from_transactions");
+        let (block_metadata_transactions, (table_items, current_table_items, table_metadata)) =
+            tokio::task::spawn_blocking(move || process_transactions(transactions, flags))
+                .await
+                .expect("Failed to spawn_blocking for TransactionModel::from_transactions");
         let processing_duration_in_secs = processing_start.elapsed().as_secs_f64();
         let db_insertion_start = std::time::Instant::now();
 
@@ -341,16 +227,8 @@ impl ProcessorTrait for DefaultProcessor {
             self.name(),
             start_version,
             end_version,
-            &txns,
             &block_metadata_transactions,
-            &write_set_changes,
-            (
-                &move_modules,
-                &move_resources,
-                &table_items,
-                &current_table_items,
-                &table_metadata,
-            ),
+            (&table_items, &current_table_items, &table_metadata),
             &self.per_table_chunk_sizes,
         )
         .await;
@@ -358,11 +236,7 @@ impl ProcessorTrait for DefaultProcessor {
         // These vectors could be super large and take a lot of time to drop, move to background to
         // make it faster.
         tokio::task::spawn(async move {
-            drop(txns);
             drop(block_metadata_transactions);
-            drop(write_set_changes);
-            drop(move_modules);
-            drop(move_resources);
             drop(table_items);
             drop(current_table_items);
             drop(table_metadata);
@@ -401,32 +275,23 @@ fn process_transactions(
     transactions: Vec<Transaction>,
     flags: TableFlags,
 ) -> (
-    Vec<crate::db::common::models::default_models::transactions::Transaction>,
     Vec<BlockMetadataTransaction>,
-    Vec<WriteSetChangeModel>,
     (
-        Vec<MoveModule>,
-        Vec<MoveResource>,
         Vec<TableItem>,
         Vec<CurrentTableItem>,
         Vec<TableMetadata>,
     ),
 ) {
-    let (mut txns, block_metadata_txns, mut write_set_changes, wsc_details) =
-        TransactionModel::from_transactions(&transactions);
+    let (block_metadata_txns, wsc_details) = TransactionModel::from_transactions(&transactions);
     let mut block_metadata_transactions = vec![];
     for block_metadata_txn in block_metadata_txns {
         block_metadata_transactions.push(block_metadata_txn);
     }
-    let mut move_modules = vec![];
-    let mut move_resources = vec![];
     let mut table_items = vec![];
     let mut current_table_items = AHashMap::new();
     let mut table_metadata = AHashMap::new();
     for detail in wsc_details {
         match detail {
-            WriteSetChangeDetail::Module(module) => move_modules.push(module),
-            WriteSetChangeDetail::Resource(resource) => move_resources.push(resource),
             WriteSetChangeDetail::Table(item, current_item, metadata) => {
                 table_items.push(item);
                 current_table_items.insert(
@@ -440,6 +305,7 @@ fn process_transactions(
                     table_metadata.insert(meta.handle.clone(), meta);
                 }
             },
+            _ => (),
         }
     }
 
@@ -453,35 +319,15 @@ fn process_transactions(
         .sort_by(|a, b| (&a.table_handle, &a.key_hash).cmp(&(&b.table_handle, &b.key_hash)));
     table_metadata.sort_by(|a, b| a.handle.cmp(&b.handle));
 
-    if flags.contains(TableFlags::MOVE_RESOURCES) {
-        move_resources.clear();
-    }
-    if flags.contains(TableFlags::TRANSACTIONS) {
-        txns.clear();
-    }
-    if flags.contains(TableFlags::WRITE_SET_CHANGES) {
-        write_set_changes.clear();
-    }
     if flags.contains(TableFlags::TABLE_ITEMS) {
         table_items.clear();
     }
     if flags.contains(TableFlags::TABLE_METADATAS) {
         table_metadata.clear();
     }
-    if flags.contains(TableFlags::MOVE_MODULES) {
-        move_modules.clear();
-    }
 
     (
-        txns,
         block_metadata_transactions,
-        write_set_changes,
-        (
-            move_modules,
-            move_resources,
-            table_items,
-            current_table_items,
-            table_metadata,
-        ),
+        (table_items, current_table_items, table_metadata),
     )
 }

--- a/rust/processor/src/processors/default_processor.rs
+++ b/rust/processor/src/processors/default_processor.rs
@@ -274,11 +274,7 @@ fn process_transactions(
     flags: TableFlags,
 ) -> (
     Vec<BlockMetadataTransaction>,
-    (
-        Vec<TableItem>,
-        Vec<CurrentTableItem>,
-        Vec<TableMetadata>,
-    ),
+    (Vec<TableItem>, Vec<CurrentTableItem>, Vec<TableMetadata>),
 ) {
     let (block_metadata_txns, wsc_details) = TransactionModel::from_transactions(&transactions);
     let mut block_metadata_transactions = vec![];

--- a/rust/processor/src/processors/default_processor.rs
+++ b/rust/processor/src/processors/default_processor.rs
@@ -5,8 +5,6 @@ use super::{DefaultProcessingResult, ProcessorName, ProcessorTrait};
 use crate::{
     db::common::models::default_models::{
         block_metadata_transactions::{BlockMetadataTransaction, BlockMetadataTransactionModel},
-        move_modules::MoveModule,
-        move_resources::MoveResource,
         move_tables::{CurrentTableItem, TableItem, TableMetadata},
         transactions::TransactionModel,
         write_set_changes::WriteSetChangeDetail,
@@ -291,21 +289,18 @@ fn process_transactions(
     let mut current_table_items = AHashMap::new();
     let mut table_metadata = AHashMap::new();
     for detail in wsc_details {
-        match detail {
-            WriteSetChangeDetail::Table(item, current_item, metadata) => {
-                table_items.push(item);
-                current_table_items.insert(
-                    (
-                        current_item.table_handle.clone(),
-                        current_item.key_hash.clone(),
-                    ),
-                    current_item,
-                );
-                if let Some(meta) = metadata {
-                    table_metadata.insert(meta.handle.clone(), meta);
-                }
-            },
-            _ => (),
+        if let WriteSetChangeDetail::Table(item, current_item, metadata) = detail {
+            table_items.push(item);
+            current_table_items.insert(
+                (
+                    current_item.table_handle.clone(),
+                    current_item.key_hash.clone(),
+                ),
+                current_item,
+            );
+            if let Some(meta) = metadata {
+                table_metadata.insert(meta.handle.clone(), meta);
+            }
         }
     }
 


### PR DESCRIPTION
### Description
We stopped writing some tables in default processor, this is to clean up the parsing logic and remove dead code. 


### Test Plan

Ran a processor locally against testnet and verified that the numbers of rows written for the remaining tables are same as ones from testnet. checked using the SDM. 
![Screenshot 2024-09-13 at 2 03 04 PM](https://github.com/user-attachments/assets/1635a41b-b764-49d5-ad27-6e6d5b962005)
![Screenshot 2024-09-13 at 2 02 28 PM](https://github.com/user-attachments/assets/c201f299-85d5-49e1-a238-96fc7d8982a6)
![Screenshot 2024-09-13 at 2 02 22 PM](https://github.com/user-attachments/assets/b726811f-fb44-45c0-910f-e79a44f33304)
![Screenshot 2024-09-13 at 2 02 18 PM](https://github.com/user-attachments/assets/492d2e99-31d4-4277-84ec-2565d82f5bf4)
![Screenshot 2024-09-13 at 2 02 13 PM](https://github.com/user-attachments/assets/8754f8dd-2e0b-4635-a1cf-733d39067bcb)
