### PR TITLE
Yuunlimm/parquet fa migrate

### DIFF
--- a/rust/processor/src/processors/mod.rs
+++ b/rust/processor/src/processors/mod.rs
@@ -39,6 +39,9 @@ use crate::{
         parquet_ans_processor::{ParquetAnsProcessor, ParquetAnsProcessorConfig},
         parquet_default_processor::{ParquetDefaultProcessor, ParquetDefaultProcessorConfig},
         parquet_events_processor::{ParquetEventsProcessor, ParquetEventsProcessorConfig},
+        parquet_fungible_asset_activities_processor::{
+            ParquetFungibleAssetActivitiesProcessor, ParquetFungibleAssetActivitiesProcessorConfig,
+        },
         parquet_fungible_asset_processor::{
             ParquetFungibleAssetProcessor, ParquetFungibleAssetProcessorConfig,
         },
@@ -58,7 +61,6 @@ use aptos_protos::transaction::v1::Transaction as ProtoTransaction;
 use async_trait::async_trait;
 use diesel::{pg::upsert::excluded, ExpressionMethods};
 use enum_dispatch::enum_dispatch;
-use parquet_processors::parquet_fungible_asset_activities_processor::ParquetFungibleAssetActivitiesProcessorConfig;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -226,6 +228,7 @@ impl ProcessorConfig {
                 | ProcessorConfig::ParquetAnsProcessor(_)
                 | ProcessorConfig::ParquetEventsProcessor(_)
                 | ProcessorConfig::ParquetTokenV2Processor(_)
+                | ProcessorConfig::ParquetFungibleAssetActivitiesProcessor(_)
         )
     }
 }
@@ -265,6 +268,7 @@ pub enum Processor {
     // Parquet processors
     ParquetDefaultProcessor,
     ParquetFungibleAssetProcessor,
+    ParquetFungibleAssetActivitiesProcessor,
     ParquetTransactionMetadataProcessor,
     ParquetAnsProcessor,
     ParquetEventsProcessor,

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -22,6 +22,7 @@ use crate::{
             parquet_ans_processor::ParquetAnsProcessor,
             parquet_default_processor::ParquetDefaultProcessor,
             parquet_events_processor::ParquetEventsProcessor,
+            parquet_fungible_asset_activities_processor::ParquetFungibleAssetActivitiesProcessor,
             parquet_fungible_asset_processor::ParquetFungibleAssetProcessor,
             parquet_token_v2_processor::ParquetTokenV2Processor,
             parquet_transaction_metadata_processor::ParquetTransactionMetadataProcessor,
@@ -1004,5 +1005,12 @@ pub fn build_processor(
             config.clone(),
             gap_detector_sender.expect("Parquet processor requires a gap detector sender"),
         )),
+        ProcessorConfig::ParquetFungibleAssetActivitiesProcessor(config) => {
+            Processor::from(ParquetFungibleAssetActivitiesProcessor::new(
+                db_pool,
+                config.clone(),
+                gap_detector_sender.expect("Parquet processor requires a gap detector sender"),
+            ))
+        },
     }
 }


### PR DESCRIPTION
Validated locally using parser.yaml like below:

```
# This is a template yaml for the indexer processor. It assumes you have a data service
# running locally, for example as part of local testnet you ran with this command:
# aptos node run-local-testnet
health_check_port: 8084
server_config:
  processor_config:
    type: parquet_fungible_asset_activities_processor
    bucket_name: "etl-yuunnet"
    bucket_root: "local-airflow-teerst"
    parquet_handler_response_channel_size: 100
    max_buffer_size: 30000000
    parquet_upload_interval: 30
  parquet_gap_detection_batch_size: 10000000
  postgres_connection_string: postgresql://postgres:@localhost:5432/postgres
  indexer_grpc_data_service_address: "https://grpc.testnet.aptoslabs.com:443"
  auth_token: auth_token
  number_concurrent_processing_tasks: 1
  starting_version: 0

```

![Screenshot 2024-09-16 at 11 56 51 AM](https://github.com/user-attachments/assets/ce41ff74-f889-4e35-bce2-f5ef5254c19b)
<img width="932" alt="Screenshot 2024-09-16 at 11 56 49 AM" src="https://github.com/user-attachments/assets/06de98bc-345c-4b37-bb94-13cfa1e7366e">
![Screenshot 2024-09-16 at 12 04 53 PM](https://github.com/user-attachments/assets/22815c2b-96a1-4981-927b-654b3391c98a)
