### PR TITLE
skip updating processor status with null values for timestamp

### DIFF
--- a/rust/processor/src/gap_detectors/mod.rs
+++ b/rust/processor/src/gap_detectors/mod.rs
@@ -134,7 +134,7 @@ pub async fn create_gap_detector_status_tracker_loop(
                                 if res.last_transaction_timestamp.is_none() {
                                     // we don't want to update the last processed version if we haven't processed anything
                                     tracing::info!("No transactions processed, skipping update the processor status");
-                                    continue
+                                    continue;
                                 }
 
                                 PARQUET_PROCESSOR_DATA_GAP_COUNT

--- a/rust/processor/src/gap_detectors/mod.rs
+++ b/rust/processor/src/gap_detectors/mod.rs
@@ -131,6 +131,12 @@ pub async fn create_gap_detector_status_tracker_loop(
                     Ok(res) => {
                         match res {
                             GapDetectorResult::ParquetFileGapDetectorResult(res) => {
+                                if res.last_transaction_timestamp.is_none() {
+                                    // we don't want to update the last processed version if we haven't processed anything
+                                    tracing::info!("No transactions processed, skipping update the processor status");
+                                    continue
+                                }
+
                                 PARQUET_PROCESSOR_DATA_GAP_COUNT
                                     .with_label_values(&[processor_name])
                                     .set(res.num_gaps as i64);


### PR DESCRIPTION
### Test Plan
Tested with parquet_ans_processor
when there is no transaction processed, log and do not update. 
![Screenshot 2024-09-16 at 12 59 15 PM](https://github.com/user-attachments/assets/fc6ba8cf-d107-4025-88bd-1dc6d1a081a1)
<img width="2027" alt="Screenshot 2024-09-16 at 12 59 13 PM" src="https://github.com/user-attachments/assets/31ddde8c-f1c2-40e0-be8b-0c51a1336f19">

when there is transaction processed, update the processor status
![Screenshot 2024-09-16 at 1 06 04 PM](https://github.com/user-attachments/assets/22cb5346-009f-432d-8ae4-e21e1440a925)