### PR TITLE
allow cross repo workflow trigger

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,6 +1,8 @@
 name: Run Integration Tests
 
 on:
+  repository_dispatch:
+    types: [json-change-detected]  # Custom event type to trigger the workflow
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
### Description
In order to trigger integ test from aptos-core repo, we need to have `repository_dispatch`
