### PR TITLE
allow cross repo workflow trigger (#526)

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,7 +1,14 @@
 name: Run Integration Tests
 
 on:
+  repository_dispatch:
+    types: [json-change-detected]  # Custom event type to trigger the workflow
   workflow_dispatch:
+    inputs:
+      commit_hash:
+          description: 'Commit hash to use for the dependency update'
+          required: true
+          default: 'main'
   push:
     branches:
       - main
@@ -15,10 +22,39 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install Dependencies and Run Linter
-        uses: ./.github/actions/dep_install_and_lint
-        with:
-          working-directory: rust
+#      - name: Install Dependencies and Run Linter
+#        uses: ./.github/actions/dep_install_and_lint
+#        with:
+#          working-directory: rust
+
+      - name: list files
+        run: ls -la
+
+#      update commite haash in the cargo.toml and run tests
+      - name: Show Cargo.toml Before Update
+        run: cat Cargo.toml  # Print the contents of Cargo.toml before the update
+
+        # Update the Cargo.toml with the provided commit hash
+      - name: Update Cargo.toml with new commit hash
+        run: |
+          echo "Updating dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
+          sed -i 's|git = "https://github.com/yuunlimm/test-workflow2.git", rev = ".*"|git = "https://github.com/yuunlimm/test-workflow2.git", rev = "${{ github.event.inputs.commit_hash }}"|g' demo/Cargo.toml
+
+      # Update the aptos-system-utils dependency
+      - name: Update aptos-system-utils dependency
+        run: |
+          echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
+          sed -i '/aptos-system-utils = {/!b;n;s|rev = ".*"|rev = "${{ github.event.inputs.commit_hash }}"|' demo/Cargo.toml
+
+      # Update the aptos-indexer-test-transactions dependency
+      - name: Update aptos-indexer-test-transactions dependency
+        run: |
+          echo "Updating aptos-indexer-test-transactions dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
+          sed -i '/aptos-indexer-test-transactions = {/!b;n;s|rev = ".*"|rev = "${{ github.event.inputs.commit_hash }}"|' demo/Cargo.toml
+
+      - name: Show Cargo.toml After Update
+        run: cat Cargo.toml
+
 
       - name: Run Integration Tests
         run: cargo test --manifest-path integration-tests/Cargo.toml

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -38,10 +38,10 @@ jobs:
           toml set rust/Cargo.toml workspace.dependencies.aptos-system-utils.rev "${{ github.event.inputs.commit_hash }}" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 
       # Update aptos-indexer-test-transactions dependency using toml-cli
-      - name: Update aptos-system-utils dependency
+      - name: Update aptos-indexer-test-transactions dependency
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
         run: |
-          echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
+          echo "Updating aptos-indexer-test-transactions dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
           toml set rust/Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "${{ github.event.inputs.commit_hash }}" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 
       # Show Cargo.toml after the update

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,15 +32,15 @@ jobs:
 
       # Update aptos-system-utils dependency using toml-cli
       - name: Update aptos-system-utils dependency
+        if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
         run: |
-          if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
           echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
           toml set rust/Cargo.toml workspace.dependencies.aptos-system-utils.rev "${{ github.event.inputs.commit_hash }}" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 
-      # Update aptos-system-utils dependency using toml-cli
+      # Update aptos-indexer-test-transactions dependency using toml-cli
       - name: Update aptos-system-utils dependency
+        if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
         run: |
-          if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
           echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
           toml set rust/Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "${{ github.event.inputs.commit_hash }}" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       commit_hash:
-          description: 'Commit hash to use for the dependency update'
-          required: true
-          default: 'main'
+        description: 'Commit hash to use for the dependency update'
+        required: true
+        default: 'main'
   push:
     branches:
       - main
@@ -16,46 +16,44 @@ on:
 
 jobs:
   Integration-tests:
-    runs-on: runs-on,runner=2cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest  # Ensure the correct runner is used
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-#      - name: Install Dependencies and Run Linter
-#        uses: ./.github/actions/dep_install_and_lint
-#        with:
-#          working-directory: rust
+      # Install toml-cli using cargo
+      - name: Install toml-cli
+        run: cargo install toml-cli
 
-      - name: list files
-        run: ls -la
-
-#      update commite haash in the cargo.toml and run tests
+      # Show Cargo.toml Before Update
       - name: Show Cargo.toml Before Update
-        run: cat Cargo.toml  # Print the contents of Cargo.toml before the update
+        run: cat rust/Cargo.toml
 
-        # Update the Cargo.toml with the provided commit hash
-      - name: Update Cargo.toml with new commit hash
-        run: |
-          echo "Updating dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
-          sed -i 's|git = "https://github.com/yuunlimm/test-workflow2.git", rev = ".*"|git = "https://github.com/yuunlimm/test-workflow2.git", rev = "${{ github.event.inputs.commit_hash }}"|g' demo/Cargo.toml
-
-      # Update the aptos-system-utils dependency
+      # Update aptos-system-utils dependency using toml-cli
       - name: Update aptos-system-utils dependency
         run: |
+          if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
           echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
-          sed -i '/aptos-system-utils = {/!b;n;s|rev = ".*"|rev = "${{ github.event.inputs.commit_hash }}"|' demo/Cargo.toml
+          toml set rust/Cargo.toml workspace.dependencies.aptos-system-utils.rev "${{ github.event.inputs.commit_hash }}" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 
-      # Update the aptos-indexer-test-transactions dependency
-      - name: Update aptos-indexer-test-transactions dependency
+      # Update aptos-system-utils dependency using toml-cli
+      - name: Update aptos-system-utils dependency
         run: |
-          echo "Updating aptos-indexer-test-transactions dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
-          sed -i '/aptos-indexer-test-transactions = {/!b;n;s|rev = ".*"|rev = "${{ github.event.inputs.commit_hash }}"|' demo/Cargo.toml
+          if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+          echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash ${{ github.event.inputs.commit_hash }}"
+          toml set rust/Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "${{ github.event.inputs.commit_hash }}" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 
+      # Show Cargo.toml after the update
       - name: Show Cargo.toml After Update
-        run: cat Cargo.toml
+        run: cat rust/Cargo.toml  # Correct path to the Cargo.toml file
 
+      - name: Install Dependencies and Run Linter
+        uses: ./.github/actions/dep_install_and_lint
+        with:
+          working-directory: rust
 
+      # Run Integration Tests
       - name: Run Integration Tests
         run: cargo test --manifest-path integration-tests/Cargo.toml
         working-directory: rust


### PR DESCRIPTION
### description 

this is to allow aptos-core repo to trigger processor intregration test to support a case where json files are updated in aptos-core, we pass in commit hash along with the event, and it updates dependency using toml-cli. 



### Test Plan
PR level test pass: https://github.com/aptos-labs/aptos-indexer-processors/actions/runs/11131978344
dispatch passed: https://github.com/aptos-labs/aptos-indexer-processors/actions/runs/11131969466