### PR TITLE
[parquet] add user transactions table to parquet

### DIFF
--- a/rust/processor/src/db/common/models/user_transactions_models/mod.rs
+++ b/rust/processor/src/db/common/models/user_transactions_models/mod.rs
@@ -5,3 +5,4 @@ pub mod signatures;
 pub mod user_transactions;
 // parquet models
 pub mod parquet_signatures;
+pub mod parquet_user_transactions;

--- a/rust/processor/src/db/common/models/user_transactions_models/parquet_signatures.rs
+++ b/rust/processor/src/db/common/models/user_transactions_models/parquet_signatures.rs
@@ -3,10 +3,21 @@
 
 #![allow(clippy::extra_unused_lifetimes)]
 
-use field_count::FieldCount;
+use crate::utils::{counters::PROCESSOR_UNKNOWN_TYPE_COUNT, util::standardize_address};
+use anyhow::{Context, Result};
+use aptos_protos::transaction::v1::{
+    account_signature::Signature as AccountSignatureEnum,
+    any_signature::{SignatureVariant, Type as AnySignatureTypeEnumPb},
+    signature::Signature as SignatureEnum,
+    AccountSignature as ProtoAccountSignature, Ed25519Signature as Ed25519SignaturePB,
+    FeePayerSignature as ProtoFeePayerSignature, MultiAgentSignature as ProtoMultiAgentSignature,
+    MultiEd25519Signature as MultiEd25519SignaturePb, MultiKeySignature as MultiKeySignaturePb,
+    Signature as TransactionSignaturePb, SingleKeySignature as SingleKeySignaturePb,
+    SingleSender as SingleSenderPb,
+};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, FieldCount, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Signature {
     pub txn_version: i64,
     pub multi_agent_index: i64,
@@ -18,5 +29,512 @@ pub struct Signature {
     pub public_key: String,
     pub signature: String,
     pub threshold: i64,
-    pub public_key_indices: String,
+}
+
+impl Signature {
+    /// Returns a flattened list of signatures. If signature is a Ed25519Signature, then return a vector of 1 signature
+    pub fn from_user_transaction(
+        s: &TransactionSignaturePb,
+        sender: &String,
+        transaction_version: i64,
+        transaction_block_height: i64,
+    ) -> Result<Vec<Self>> {
+        match s.signature.as_ref().unwrap() {
+            SignatureEnum::Ed25519(sig) => Ok(vec![Self::parse_ed25519_signature(
+                sig,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                true,
+                0,
+                None,
+            )]),
+            SignatureEnum::MultiEd25519(sig) => Ok(Self::parse_multi_ed25519_signature(
+                sig,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                true,
+                0,
+                None,
+            )),
+            SignatureEnum::MultiAgent(sig) => Self::parse_multi_agent_signature(
+                sig,
+                sender,
+                transaction_version,
+                transaction_block_height,
+            ),
+            SignatureEnum::FeePayer(sig) => Self::parse_fee_payer_signature(
+                sig,
+                sender,
+                transaction_version,
+                transaction_block_height,
+            ),
+            SignatureEnum::SingleSender(s) => Ok(Self::parse_single_sender(
+                s,
+                sender,
+                transaction_version,
+                transaction_block_height,
+            )),
+        }
+    }
+
+    pub fn get_signature_type(t: &TransactionSignaturePb) -> String {
+        match t.signature.as_ref().unwrap() {
+            SignatureEnum::Ed25519(_) => String::from("ed25519_signature"),
+            SignatureEnum::MultiEd25519(_) => String::from("multi_ed25519_signature"),
+            SignatureEnum::MultiAgent(_) => String::from("multi_agent_signature"),
+            SignatureEnum::FeePayer(_) => String::from("fee_payer_signature"),
+            SignatureEnum::SingleSender(sender) => {
+                let account_signature = sender.sender.as_ref().unwrap();
+                let signature = account_signature.signature.as_ref().unwrap();
+                match signature {
+                    AccountSignatureEnum::Ed25519(_) => String::from("ed25519_signature"),
+                    AccountSignatureEnum::MultiEd25519(_) => {
+                        String::from("multi_ed25519_signature")
+                    },
+                    AccountSignatureEnum::SingleKeySignature(_) => {
+                        String::from("single_key_signature")
+                    },
+                    AccountSignatureEnum::MultiKeySignature(_) => {
+                        String::from("multi_key_signature")
+                    },
+                }
+            },
+        }
+    }
+
+    pub fn get_fee_payer_address(
+        t: &TransactionSignaturePb,
+        transaction_version: i64,
+    ) -> Option<String> {
+        let sig = t.signature.as_ref().unwrap_or_else(|| {
+            tracing::error!(
+                transaction_version = transaction_version,
+                "Transaction signature is missing"
+            );
+            panic!("Transaction signature is missing");
+        });
+        match sig {
+            SignatureEnum::FeePayer(sig) => Some(standardize_address(&sig.fee_payer_address)),
+            _ => None,
+        }
+    }
+
+    fn parse_ed25519_signature(
+        s: &Ed25519SignaturePB,
+        sender: &String,
+        transaction_version: i64,
+        transaction_block_height: i64,
+        is_sender_primary: bool,
+        multi_agent_index: i64,
+        override_address: Option<&String>,
+    ) -> Self {
+        let signer = standardize_address(override_address.unwrap_or(sender));
+        Self {
+            txn_version: transaction_version,
+            transaction_block_height,
+            signer,
+            is_sender_primary,
+            type_: String::from("ed25519_signature"),
+            public_key: format!("0x{}", hex::encode(s.public_key.as_slice())),
+            threshold: 1,
+            signature: format!("0x{}", hex::encode(s.signature.as_slice())),
+            multi_agent_index,
+            multi_sig_index: 0,
+        }
+    }
+
+    fn parse_multi_ed25519_signature(
+        s: &MultiEd25519SignaturePb,
+        sender: &String,
+        transaction_version: i64,
+        transaction_block_height: i64,
+        is_sender_primary: bool,
+        multi_agent_index: i64,
+        override_address: Option<&String>,
+    ) -> Vec<Self> {
+        let mut signatures = Vec::default();
+        let signer = standardize_address(override_address.unwrap_or(sender));
+
+        let public_key_indices: Vec<usize> = s
+            .public_key_indices
+            .iter()
+            .map(|index| *index as usize)
+            .collect();
+        for (index, signature) in s.signatures.iter().enumerate() {
+            let public_key = s
+                .public_keys
+                .get(public_key_indices.clone()[index])
+                .unwrap()
+                .clone();
+            signatures.push(Self {
+                txn_version: transaction_version,
+                transaction_block_height,
+                signer: signer.clone(),
+                is_sender_primary,
+                type_: String::from("multi_ed25519_signature"),
+                public_key: format!("0x{}", hex::encode(public_key.as_slice())),
+                threshold: s.threshold as i64,
+                signature: format!("0x{}", hex::encode(signature.as_slice())),
+                multi_agent_index,
+                multi_sig_index: index as i64,
+            });
+        }
+        signatures
+    }
+
+    fn parse_multi_agent_signature(
+        s: &ProtoMultiAgentSignature,
+        sender: &String,
+        transaction_version: i64,
+        transaction_block_height: i64,
+    ) -> Result<Vec<Self>> {
+        let mut signatures = Vec::default();
+        // process sender signature
+        signatures.append(&mut Self::parse_multi_agent_signature_helper(
+            s.sender.as_ref().unwrap(),
+            sender,
+            transaction_version,
+            transaction_block_height,
+            true,
+            0,
+            None,
+        ));
+        for (index, address) in s.secondary_signer_addresses.iter().enumerate() {
+            let secondary_sig = s.secondary_signers.get(index).context(format!(
+                "Failed to parse index {} for multi agent secondary signers",
+                index
+            ))?;
+            signatures.append(&mut Self::parse_multi_agent_signature_helper(
+                secondary_sig,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                false,
+                index as i64,
+                Some(&address.to_string()),
+            ));
+        }
+        Ok(signatures)
+    }
+
+    fn parse_fee_payer_signature(
+        s: &ProtoFeePayerSignature,
+        sender: &String,
+        transaction_version: i64,
+        transaction_block_height: i64,
+    ) -> Result<Vec<Self>> {
+        let mut signatures = Vec::default();
+        // process sender signature
+        signatures.append(&mut Self::parse_multi_agent_signature_helper(
+            s.sender.as_ref().unwrap(),
+            sender,
+            transaction_version,
+            transaction_block_height,
+            true,
+            0,
+            None,
+        ));
+        for (index, address) in s.secondary_signer_addresses.iter().enumerate() {
+            let secondary_sig = s.secondary_signers.get(index).context(format!(
+                "Failed to parse index {} for multi agent secondary signers",
+                index
+            ))?;
+            signatures.append(&mut Self::parse_multi_agent_signature_helper(
+                secondary_sig,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                false,
+                index as i64,
+                Some(&address.to_string()),
+            ));
+        }
+        Ok(signatures)
+    }
+
+    fn parse_multi_agent_signature_helper(
+        s: &ProtoAccountSignature,
+        sender: &String,
+        transaction_version: i64,
+        transaction_block_height: i64,
+        is_sender_primary: bool,
+        multi_agent_index: i64,
+        override_address: Option<&String>,
+    ) -> Vec<Self> {
+        let signature = s.signature.as_ref().unwrap();
+        match signature {
+            AccountSignatureEnum::Ed25519(sig) => vec![Self::parse_ed25519_signature(
+                sig,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                is_sender_primary,
+                multi_agent_index,
+                override_address,
+            )],
+            AccountSignatureEnum::MultiEd25519(sig) => Self::parse_multi_ed25519_signature(
+                sig,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                is_sender_primary,
+                multi_agent_index,
+                override_address,
+            ),
+            AccountSignatureEnum::SingleKeySignature(sig) => {
+                vec![Self::parse_single_key_signature(
+                    sig,
+                    sender,
+                    transaction_version,
+                    transaction_block_height,
+                    is_sender_primary,
+                    multi_agent_index,
+                    override_address,
+                )]
+            },
+            AccountSignatureEnum::MultiKeySignature(sig) => Self::parse_multi_key_signature(
+                sig,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                is_sender_primary,
+                multi_agent_index,
+                override_address,
+            ),
+        }
+    }
+
+    #[allow(deprecated)]
+    fn parse_single_key_signature(
+        s: &SingleKeySignaturePb,
+        sender: &String,
+        transaction_version: i64,
+        transaction_block_height: i64,
+        is_sender_primary: bool,
+        multi_agent_index: i64,
+        override_address: Option<&String>,
+    ) -> Self {
+        let signer = standardize_address(override_address.unwrap_or(sender));
+        let signature = s.signature.as_ref().unwrap();
+        let signature_bytes =
+            Self::get_any_signature_bytes(&signature.signature_variant, transaction_version)
+                // old way of getting signature bytes prior to node 1.10
+                .unwrap_or(signature.signature.clone());
+        let type_ = if let Some(t) =
+            Self::get_any_signature_type(&signature.signature_variant, true, transaction_version)
+        {
+            t
+        } else {
+            // old way of getting signature type prior to node 1.10
+            match AnySignatureTypeEnumPb::try_from(signature.r#type) {
+                Ok(AnySignatureTypeEnumPb::Ed25519) => String::from("single_key_ed25519_signature"),
+                Ok(AnySignatureTypeEnumPb::Secp256k1Ecdsa) => {
+                    String::from("single_key_secp256k1_ecdsa_signature")
+                },
+                wildcard => {
+                    tracing::warn!(
+                        transaction_version = transaction_version,
+                        "Unspecified signature type or un-recognized type is not supported: {:?}",
+                        wildcard
+                    );
+                    PROCESSOR_UNKNOWN_TYPE_COUNT
+                        .with_label_values(&["unspecified_signature_type"])
+                        .inc();
+                    "".to_string()
+                },
+            }
+        };
+        Self {
+            txn_version: transaction_version,
+            transaction_block_height,
+            signer,
+            is_sender_primary,
+            type_,
+            public_key: format!(
+                "0x{}",
+                hex::encode(s.public_key.as_ref().unwrap().public_key.as_slice())
+            ),
+            threshold: 1,
+            signature: format!("0x{}", hex::encode(signature_bytes.as_slice())),
+            multi_agent_index,
+            multi_sig_index: 0,
+        }
+    }
+
+    #[allow(deprecated)]
+    fn parse_multi_key_signature(
+        s: &MultiKeySignaturePb,
+        sender: &String,
+        transaction_version: i64,
+        transaction_block_height: i64,
+        is_sender_primary: bool,
+        multi_agent_index: i64,
+        override_address: Option<&String>,
+    ) -> Vec<Self> {
+        let signer = standardize_address(override_address.unwrap_or(sender));
+        let mut signatures = Vec::default();
+
+        for (index, signature) in s.signatures.iter().enumerate() {
+            let public_key = s
+                .public_keys
+                .as_slice()
+                .get(index)
+                .unwrap()
+                .public_key
+                .clone();
+            let signature_bytes = Self::get_any_signature_bytes(
+                &signature.signature.as_ref().unwrap().signature_variant,
+                transaction_version,
+            )
+            // old way of getting signature bytes prior to node 1.10
+            .unwrap_or(signature.signature.as_ref().unwrap().signature.clone());
+
+            let type_ = if let Some(t) = Self::get_any_signature_type(
+                &signature.signature.as_ref().unwrap().signature_variant,
+                false,
+                transaction_version,
+            ) {
+                t
+            } else {
+                // old way of getting signature type prior to node 1.10
+                match AnySignatureTypeEnumPb::try_from(signature.signature.as_ref().unwrap().r#type)
+                {
+                    Ok(AnySignatureTypeEnumPb::Ed25519) => {
+                        String::from("multi_key_ed25519_signature")
+                    },
+                    Ok(AnySignatureTypeEnumPb::Secp256k1Ecdsa) => {
+                        String::from("multi_key_secp256k1_ecdsa_signature")
+                    },
+                    wildcard => {
+                        tracing::warn!(
+                            transaction_version = transaction_version,
+                            "Unspecified signature type or un-recognized type is not supported: {:?}",
+                            wildcard
+                        );
+                        PROCESSOR_UNKNOWN_TYPE_COUNT
+                            .with_label_values(&["unspecified_signature_type"])
+                            .inc();
+                        "unknown".to_string()
+                    },
+                }
+            };
+            signatures.push(Self {
+                txn_version: transaction_version,
+                transaction_block_height,
+                signer: signer.clone(),
+                is_sender_primary,
+                type_,
+                public_key: format!("0x{}", hex::encode(public_key.as_slice())),
+                threshold: s.signatures_required as i64,
+                signature: format!("0x{}", hex::encode(signature_bytes.as_slice())),
+                multi_agent_index,
+                multi_sig_index: index as i64,
+            });
+        }
+        signatures
+    }
+
+    fn get_any_signature_bytes(
+        signature_variant: &Option<SignatureVariant>,
+        transaction_version: i64,
+    ) -> Option<Vec<u8>> {
+        match signature_variant {
+            Some(SignatureVariant::Ed25519(sig)) => Some(sig.signature.clone()),
+            Some(SignatureVariant::Keyless(sig)) => Some(sig.signature.clone()),
+            Some(SignatureVariant::Webauthn(sig)) => Some(sig.signature.clone()),
+            Some(SignatureVariant::Secp256k1Ecdsa(sig)) => Some(sig.signature.clone()),
+            None => {
+                PROCESSOR_UNKNOWN_TYPE_COUNT
+                    .with_label_values(&["SignatureVariant"])
+                    .inc();
+                tracing::warn!(
+                    transaction_version = transaction_version,
+                    "Signature variant doesn't exist",
+                );
+                None
+            },
+        }
+    }
+
+    fn get_any_signature_type(
+        signature_variant: &Option<SignatureVariant>,
+        is_single_sender: bool,
+        transaction_version: i64,
+    ) -> Option<String> {
+        let prefix = if is_single_sender {
+            "single_sender"
+        } else {
+            "multi_key"
+        };
+        match signature_variant {
+            Some(SignatureVariant::Ed25519(_)) => Some(format!("{}_ed25519_signature", prefix)),
+            Some(SignatureVariant::Keyless(_)) => Some(format!("{}_keyless_signature", prefix)),
+            Some(SignatureVariant::Webauthn(_)) => Some(format!("{}_webauthn_signature", prefix)),
+            Some(SignatureVariant::Secp256k1Ecdsa(_)) => {
+                Some(format!("{}_secp256k1_ecdsa_signature", prefix))
+            },
+            None => {
+                PROCESSOR_UNKNOWN_TYPE_COUNT
+                    .with_label_values(&["SignatureVariant"])
+                    .inc();
+                tracing::warn!(
+                    transaction_version = transaction_version,
+                    "Signature variant doesn't exist",
+                );
+                None
+            },
+        }
+    }
+
+    fn parse_single_sender(
+        s: &SingleSenderPb,
+        sender: &String,
+        transaction_version: i64,
+        transaction_block_height: i64,
+    ) -> Vec<Self> {
+        let signature = s.sender.as_ref().unwrap();
+        match signature.signature.as_ref() {
+            Some(AccountSignatureEnum::SingleKeySignature(s)) => {
+                vec![Self::parse_single_key_signature(
+                    s,
+                    sender,
+                    transaction_version,
+                    transaction_block_height,
+                    true,
+                    0,
+                    None,
+                )]
+            },
+            Some(AccountSignatureEnum::MultiKeySignature(s)) => Self::parse_multi_key_signature(
+                s,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                true,
+                0,
+                None,
+            ),
+            Some(AccountSignatureEnum::Ed25519(s)) => vec![Self::parse_ed25519_signature(
+                s,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                true,
+                0,
+                None,
+            )],
+            Some(AccountSignatureEnum::MultiEd25519(s)) => Self::parse_multi_ed25519_signature(
+                s,
+                sender,
+                transaction_version,
+                transaction_block_height,
+                true,
+                0,
+                None,
+            ),
+            None => vec![],
+        }
+    }
 }

--- a/rust/processor/src/db/common/models/user_transactions_models/parquet_user_transactions.rs
+++ b/rust/processor/src/db/common/models/user_transactions_models/parquet_user_transactions.rs
@@ -39,7 +39,7 @@ pub struct UserTransaction {
     pub gas_fee_payer_address: Option<String>,
     pub gas_used_octa: u64,
     pub gas_unit_price: u64,
-    pub max_gas_amount: u64,
+    pub max_gas_octa: u64,
     pub storage_refund_octa: u64,
     pub is_transaction_success: bool,
     pub num_signatures: i64,
@@ -94,7 +94,7 @@ impl UserTransaction {
                 .unwrap_or_default(),
             sender: standardize_address(&user_request.sender),
             sequence_number: user_request.sequence_number as i64,
-            max_gas_amount: user_request.max_gas_amount,
+            max_gas_octa: user_request.max_gas_amount,
             expiration_timestamp_secs: user_request
                 .expiration_timestamp_secs
                 .as_ref()

--- a/rust/processor/src/db/common/models/user_transactions_models/parquet_user_transactions.rs
+++ b/rust/processor/src/db/common/models/user_transactions_models/parquet_user_transactions.rs
@@ -1,0 +1,133 @@
+// Copyright © Aptos Foundation
+
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::parquet_signatures::Signature;
+use crate::{
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
+    db::common::models::fungible_asset_models::v2_fungible_asset_utils::FeeStatement,
+    utils::util::{get_entry_function_from_user_request, parse_timestamp, standardize_address},
+};
+use allocative::Allocative;
+use anyhow::Result;
+use aptos_protos::{
+    transaction::v1::{
+        TransactionInfo, UserTransaction as UserTransactionPB, UserTransactionRequest,
+    },
+    util::timestamp::Timestamp,
+};
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
+pub struct UserTransaction {
+    pub txn_version: i64,
+    pub block_height: i64,
+    pub parent_signature_type: String,
+    pub sender: String,
+    pub sequence_number: i64,
+    pub max_gas_amount: u64,
+    pub expiration_timestamp_secs: u64,
+    pub gas_unit_price: u64,
+    pub gas_used: u64,
+    #[allocative(skip)]
+    pub timestamp: chrono::NaiveDateTime,
+    pub entry_function_id_str: String,
+    pub epoch: i64,
+    pub gas_fee_payer_address: Option<String>,
+    pub is_transaction_success: bool,
+    pub storage_refund_amount: u64,
+    pub num_signatures: i64,
+}
+
+impl NamedTable for UserTransaction {
+    const TABLE_NAME: &'static str = "user_transactions";
+}
+
+impl HasVersion for UserTransaction {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl GetTimeStamp for UserTransaction {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.timestamp
+    }
+}
+
+impl UserTransaction {
+    pub fn from_transaction(
+        txn: &UserTransactionPB,
+        txn_info: &TransactionInfo,
+        fee_statement: Option<FeeStatement>,
+        timestamp: &Timestamp,
+        block_height: i64,
+        epoch: i64,
+        version: i64,
+    ) -> Self {
+        let user_request = txn
+            .request
+            .as_ref()
+            .expect("Sends is not present in user txn");
+        let gas_fee_payer_address = match user_request.signature.as_ref() {
+            Some(signature) => Signature::get_fee_payer_address(signature, version),
+            None => None,
+        };
+        let num_signatures = Self::get_signatures(user_request, version, block_height).len() as i64;
+
+        Self {
+            txn_version: version,
+            block_height,
+            parent_signature_type: txn
+                .request
+                .as_ref()
+                .unwrap()
+                .signature
+                .as_ref()
+                .map(Signature::get_signature_type)
+                .unwrap_or_default(),
+            sender: standardize_address(&user_request.sender),
+            sequence_number: user_request.sequence_number as i64,
+            max_gas_amount: user_request.max_gas_amount,
+            expiration_timestamp_secs: user_request
+                .expiration_timestamp_secs
+                .as_ref()
+                .expect("Expiration timestamp is not present in user txn")
+                .seconds as u64,
+            gas_unit_price: user_request.gas_unit_price,
+            timestamp: parse_timestamp(timestamp, version),
+            entry_function_id_str: get_entry_function_from_user_request(user_request)
+                .unwrap_or_default(),
+            epoch,
+            gas_used: txn_info.gas_used,
+            gas_fee_payer_address,
+            is_transaction_success: txn_info.success,
+            storage_refund_amount: fee_statement
+                .map(|fs| fs.storage_fee_refund_octas)
+                .unwrap_or(0),
+            num_signatures,
+        }
+    }
+
+    /// Empty vec if signature is None
+    pub fn get_signatures(
+        user_request: &UserTransactionRequest,
+        version: i64,
+        block_height: i64,
+    ) -> Vec<Signature> {
+        user_request
+            .signature
+            .as_ref()
+            .map(|s| {
+                Signature::from_user_transaction(s, &user_request.sender, version, block_height)
+                    .unwrap()
+            })
+            .unwrap_or_default()
+    }
+}

--- a/rust/processor/src/db/common/models/user_transactions_models/parquet_user_transactions.rs
+++ b/rust/processor/src/db/common/models/user_transactions_models/parquet_user_transactions.rs
@@ -28,20 +28,20 @@ use serde::{Deserialize, Serialize};
 pub struct UserTransaction {
     pub txn_version: i64,
     pub block_height: i64,
-    pub parent_signature_type: String,
+    #[allocative(skip)]
+    pub block_timestamp: chrono::NaiveDateTime,
+    pub epoch: i64,
     pub sender: String,
     pub sequence_number: i64,
-    pub max_gas_amount: u64,
-    pub expiration_timestamp_secs: u64,
-    pub gas_unit_price: u64,
-    pub gas_used: u64,
-    #[allocative(skip)]
-    pub timestamp: chrono::NaiveDateTime,
     pub entry_function_id_str: String,
-    pub epoch: i64,
+    pub expiration_timestamp_secs: u64,
+    pub parent_signature_type: String,
     pub gas_fee_payer_address: Option<String>,
+    pub gas_used_octa: u64,
+    pub gas_unit_price: u64,
+    pub max_gas_amount: u64,
+    pub storage_refund_octa: u64,
     pub is_transaction_success: bool,
-    pub storage_refund_amount: u64,
     pub num_signatures: i64,
 }
 
@@ -57,7 +57,7 @@ impl HasVersion for UserTransaction {
 
 impl GetTimeStamp for UserTransaction {
     fn get_timestamp(&self) -> chrono::NaiveDateTime {
-        self.timestamp
+        self.block_timestamp
     }
 }
 
@@ -101,14 +101,14 @@ impl UserTransaction {
                 .expect("Expiration timestamp is not present in user txn")
                 .seconds as u64,
             gas_unit_price: user_request.gas_unit_price,
-            timestamp: parse_timestamp(timestamp, version),
+            block_timestamp: parse_timestamp(timestamp, version),
             entry_function_id_str: get_entry_function_from_user_request(user_request)
                 .unwrap_or_default(),
             epoch,
-            gas_used: txn_info.gas_used,
+            gas_used_octa: txn_info.gas_used,
             gas_fee_payer_address,
             is_transaction_success: txn_info.success,
-            storage_refund_amount: fee_statement
+            storage_refund_octa: fee_statement
                 .map(|fs| fs.storage_fee_refund_octas)
                 .unwrap_or(0),
             num_signatures,

--- a/rust/processor/src/processors/mod.rs
+++ b/rust/processor/src/processors/mod.rs
@@ -49,6 +49,9 @@ use crate::{
         parquet_transaction_metadata_processor::{
             ParquetTransactionMetadataProcessor, ParquetTransactionMetadataProcessorConfig,
         },
+        parquet_user_transactions_processor::{
+            ParquetUserTransactionsProcessor, ParquetUserTransactionsProcessorConfig,
+        },
     },
     schema::processor_status,
     utils::{
@@ -211,6 +214,7 @@ pub enum ProcessorConfig {
     ParquetAnsProcessor(ParquetAnsProcessorConfig),
     ParquetEventsProcessor(ParquetEventsProcessorConfig),
     ParquetTokenV2Processor(ParquetTokenV2ProcessorConfig),
+    ParquetUserTransactionsProcessor(ParquetUserTransactionsProcessorConfig),
 }
 
 impl ProcessorConfig {
@@ -230,6 +234,7 @@ impl ProcessorConfig {
                 | ProcessorConfig::ParquetEventsProcessor(_)
                 | ProcessorConfig::ParquetTokenV2Processor(_)
                 | ProcessorConfig::ParquetFungibleAssetActivitiesProcessor(_)
+                | ProcessorConfig::ParquetUserTransactionsProcessor(_)
         )
     }
 }
@@ -274,6 +279,7 @@ pub enum Processor {
     ParquetAnsProcessor,
     ParquetEventsProcessor,
     ParquetTokenV2Processor,
+    ParquetUserTransactionsProcessor,
 }
 
 #[cfg(test)]

--- a/rust/processor/src/processors/parquet_processors/mod.rs
+++ b/rust/processor/src/processors/parquet_processors/mod.rs
@@ -7,6 +7,7 @@ pub mod parquet_fungible_asset_activities_processor;
 pub mod parquet_fungible_asset_processor;
 pub mod parquet_token_v2_processor;
 pub mod parquet_transaction_metadata_processor;
+pub mod parquet_user_transactions_processor;
 
 const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
 

--- a/rust/processor/src/processors/parquet_processors/parquet_user_transactions_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_user_transactions_processor.rs
@@ -1,0 +1,163 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    bq_analytics::{
+        create_parquet_handler_loop, generic_parquet_processor::ParquetDataGeneric,
+        ParquetProcessingResult,
+    },
+    db::common::models::{
+        fungible_asset_models::v2_fungible_asset_utils::FeeStatement,
+        user_transactions_models::parquet_user_transactions::UserTransaction,
+    },
+    gap_detectors::ProcessingResult,
+    processors::{parquet_processors::ParquetProcessorTrait, ProcessorName, ProcessorTrait},
+    utils::{counters::PROCESSOR_UNKNOWN_TYPE_COUNT, database::ArcDbPool},
+};
+use ahash::AHashMap;
+use anyhow::Context;
+use aptos_protos::transaction::v1::{transaction::TxnData, Transaction};
+use async_trait::async_trait;
+use kanal::AsyncSender;
+use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, time::Duration};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ParquetUserTransactionsProcessorConfig {
+    pub google_application_credentials: Option<String>,
+    pub bucket_name: String,
+    pub bucket_root: String,
+    pub parquet_handler_response_channel_size: usize,
+    pub max_buffer_size: usize,
+    pub parquet_upload_interval: u64,
+}
+
+impl ParquetProcessorTrait for ParquetUserTransactionsProcessorConfig {
+    fn parquet_upload_interval_in_secs(&self) -> Duration {
+        Duration::from_secs(self.parquet_upload_interval)
+    }
+}
+
+pub struct ParquetUserTransactionsProcessor {
+    connection_pool: ArcDbPool,
+    user_transactions_sender: AsyncSender<ParquetDataGeneric<UserTransaction>>,
+}
+
+impl ParquetUserTransactionsProcessor {
+    pub fn new(
+        connection_pool: ArcDbPool,
+        config: ParquetUserTransactionsProcessorConfig,
+        new_gap_detector_sender: AsyncSender<ProcessingResult>,
+    ) -> Self {
+        config.set_google_credentials(config.google_application_credentials.clone());
+
+        let user_transactions_sender: AsyncSender<ParquetDataGeneric<UserTransaction>> =
+            create_parquet_handler_loop::<UserTransaction>(
+                new_gap_detector_sender.clone(),
+                ProcessorName::ParquetUserTransactionsProcessor.into(),
+                config.bucket_name.clone(),
+                config.bucket_root.clone(),
+                config.parquet_handler_response_channel_size,
+                config.max_buffer_size,
+                config.parquet_upload_interval_in_secs(),
+            );
+
+        Self {
+            connection_pool,
+            user_transactions_sender,
+        }
+    }
+}
+
+impl Debug for ParquetUserTransactionsProcessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ParquetProcessor {{ capacity of user transactions channel: {:?} }}",
+            &self.user_transactions_sender.capacity(),
+        )
+    }
+}
+
+#[async_trait]
+impl ProcessorTrait for ParquetUserTransactionsProcessor {
+    fn name(&self) -> &'static str {
+        ProcessorName::ParquetUserTransactionsProcessor.into()
+    }
+
+    async fn process_transactions(
+        &self,
+        transactions: Vec<Transaction>,
+        start_version: u64,
+        end_version: u64,
+        _: Option<u64>,
+    ) -> anyhow::Result<ProcessingResult> {
+        let last_transaction_timestamp = transactions.last().unwrap().timestamp.clone();
+        let mut transaction_version_to_struct_count: AHashMap<i64, i64> = AHashMap::new();
+
+        let mut user_transactions = vec![];
+        for txn in &transactions {
+            let txn_version = txn.version as i64;
+            let block_height = txn.block_height as i64;
+            let transaction_info = txn.info.as_ref().expect("Transaction info doesn't exist!");
+
+            let txn_data = match txn.txn_data.as_ref() {
+                Some(txn_data) => txn_data,
+                None => {
+                    PROCESSOR_UNKNOWN_TYPE_COUNT
+                        .with_label_values(&["UserTransactionProcessor"])
+                        .inc();
+                    tracing::warn!(
+                        transaction_version = txn_version,
+                        "Transaction data doesn't exist"
+                    );
+                    continue;
+                },
+            };
+            if let TxnData::User(inner) = txn_data {
+                let fee_statement = inner.events.iter().find_map(|event| {
+                    let event_type = event.type_str.as_str();
+                    FeeStatement::from_event(event_type, &event.data, txn_version)
+                });
+                let user_transaction = UserTransaction::from_transaction(
+                    inner,
+                    transaction_info,
+                    fee_statement,
+                    txn.timestamp.as_ref().unwrap(),
+                    block_height,
+                    txn.epoch as i64,
+                    txn_version,
+                );
+                transaction_version_to_struct_count
+                    .entry(txn_version)
+                    .and_modify(|e| *e += 1)
+                    .or_insert(1);
+                user_transactions.push(user_transaction);
+            }
+        }
+
+        let user_transaction_parquet_data = ParquetDataGeneric {
+            data: user_transactions,
+        };
+
+        self.user_transactions_sender
+            .send(user_transaction_parquet_data)
+            .await
+            .context("Failed to send to parquet manager")?;
+
+        Ok(ProcessingResult::ParquetProcessingResult(
+            ParquetProcessingResult {
+                start_version: start_version as i64,
+                end_version: end_version as i64,
+                last_transaction_timestamp: last_transaction_timestamp.clone(),
+                txn_version_to_struct_count: Some(transaction_version_to_struct_count),
+                parquet_processed_structs: None,
+                table_name: "".to_string(),
+            },
+        ))
+    }
+
+    fn connection_pool(&self) -> &ArcDbPool {
+        &self.connection_pool
+    }
+}

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -26,6 +26,7 @@ use crate::{
             parquet_fungible_asset_processor::ParquetFungibleAssetProcessor,
             parquet_token_v2_processor::ParquetTokenV2Processor,
             parquet_transaction_metadata_processor::ParquetTransactionMetadataProcessor,
+            parquet_user_transactions_processor::ParquetUserTransactionsProcessor,
         },
         stake_processor::StakeProcessor,
         token_v2_processor::TokenV2Processor,
@@ -1007,6 +1008,13 @@ pub fn build_processor(
         )),
         ProcessorConfig::ParquetFungibleAssetActivitiesProcessor(config) => {
             Processor::from(ParquetFungibleAssetActivitiesProcessor::new(
+                db_pool,
+                config.clone(),
+                gap_detector_sender.expect("Parquet processor requires a gap detector sender"),
+            ))
+        },
+        ProcessorConfig::ParquetUserTransactionsProcessor(config) => {
+            Processor::from(ParquetUserTransactionsProcessor::new(
                 db_pool,
                 config.clone(),
                 gap_detector_sender.expect("Parquet processor requires a gap detector sender"),


### PR DESCRIPTION
Modified schema based on feedback from https://github.com/aptos-labs/aptos-indexer-processors/pull/513

New schema: 
```
    pub txn_version: i64,
    pub block_height: i64,
    pub parent_signature_type: String,
    pub sender: String,
    pub sequence_number: i64,
    pub max_gas_amount: u64,
    pub expiration_timestamp_secs: u64,
    pub gas_unit_price: u64,
    pub gas_used: u64,
    #[allocative(skip)]
    pub timestamp: chrono::NaiveDateTime,
    pub entry_function_id_str: String,
    pub epoch: i64,
    pub gas_fee_payer_address: Option<String>,
    pub is_transaction_success: bool,
    pub storage_refund_amount: u64,
    pub num_signatures: i64,
```