### PR TITLE
update cargo.lock to fix lint failure

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -54,6 +54,11 @@ jobs:
       - name: Show Cargo.toml After Update
         run: cat rust/Cargo.toml  # Correct path to the Cargo.toml file
 
+      # Ensure Cargo.lock is updated with the latest dependencies
+      - name: Update Dependencies
+        run: cargo update
+        working-directory: rust
+
       - name: Install Dependencies and Run Linter
         uses: ./.github/actions/dep_install_and_lint
         with:


### PR DESCRIPTION
### Description

https://github.com/aptos-labs/aptos-indexer-processors/actions/runs/11153152318/job/31000121810

cargo lock doesn't get updated, so that triggered workflow fails at lint. 

