### PR TITLE
add uui to workflow job name

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,5 +1,5 @@
 name: Run Integration Tests
-
+run-name: Run Integration Tests for commit ${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash || 'main' }} by @${{ github.actor }}
 on:
   repository_dispatch:
     types: [test-txn-json-change-detected]  # Custom event type to trigger the workflow


### PR DESCRIPTION
### Description
Currently, when aptos-core repo triggers processor integration tests,  there is no simple way for source repo to wait without having to poll the workflow jobs. However, the git api doesn't return payload or run_id that could be used to identify the actual triggered job. 

This is a workaround by adding a commit_hash to the run so that we can identify the job properly from aptos-core workflow. 


### Test Plan
https://github.com/aptos-labs/aptos-indexer-processors/actions/runs/11153523032/job/31001187434