### PR TITLE
[gha/docker] build with branch name; also cleanup

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -33,4 +33,12 @@ jobs:
         with:
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      - run: ./scripts/build-and-push-images.sh ${{ matrix.example }}
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+      - name: Build and push images
+        run: ./scripts/build-and-push-images.sh ${{ matrix.example }}
+        env:
+          GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+      

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -6,10 +6,6 @@ on:
   push:
     branches:
       - main
-      # aptos-indexer-processors network-specific release branches
-      - aptos-indexer-processors-devnet
-      - aptos-indexer-processors-testnet
-      - aptos-indexer-processors-mainnet
 
 # cancel redundant builds
 concurrency:

--- a/.github/workflows/copy-processor-images-to-dockerhub-release.yaml
+++ b/.github/workflows/copy-processor-images-to-dockerhub-release.yaml
@@ -1,11 +1,6 @@
 name: Copy images to dockerhub on release
 on:
   push:
-    branches:
-      # aptos-indexer-processors network-specific release branches
-      - aptos-indexer-processors-devnet
-      - aptos-indexer-processors-testnet
-      - aptos-indexer-processors-mainnet
     tags:
       - aptos-indexer-processors-v*
 


### PR DESCRIPTION
Builds off of special branches like `main` get image tags now in the form:
* `<branch_name>`
* `<branch_name>_<git_sha>`

This is useful for Forge, which by default should use the latest stable processors version. Currently it's pinned to some recent commit hash

Also general cleanup of branch push triggers

## Test plan

Canary runs on push to PR branch. It pushes all the expected tags
```
INFO[0237] Pushing image to us-docker.pkg.dev/aptos-registry/docker/indexer-client-examples/rust:dbd773c4d0c6c4bac21bc210dadd87eb0b11863c 
INFO[0240] Pushed us-docker.pkg.dev/aptos-registry/docker/indexer-client-examples/rust@sha256:6776a413b25dd4ec6a632a34719376ff36366e192f2999c4704d2b3200431481 
INFO[0240] Pushing image to us-docker.pkg.dev/aptos-registry/docker/indexer-client-examples/rust:rustielin-branch-prefix-build 
INFO[0241] Pushed us-docker.pkg.dev/aptos-registry/docker/indexer-client-examples/rust@sha256:6776a413b25dd4ec6a632a34719376ff36366e192f2999c4704d2b3200431481 
INFO[0241] Pushing image to us-docker.pkg.dev/aptos-registry/docker/indexer-client-examples/rust:rustielin-branch-prefix-build_dbd773c4d0c6c4bac21bc210dadd87eb0b11863c 
INFO[0242] Pushed us-docker.pkg.dev/aptos-registry/docker/indexer-client-examples/rust@sha256:6776a413b25dd4ec6a632a34719376ff36366e[192](https://github.com/aptos-labs/aptos-indexer-processors/actions/runs/11168000083/job/31045425474?pr=538#step:5:193)f2999c4704d2b3200431481
```

And it's in GAR 

![image](https://github.com/user-attachments/assets/97683059-46a5-498a-acdf-4d1a8c69fa46)
