### PR TITLE
remove cargo test from lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,6 +44,3 @@ jobs:
       - name: Ensure the --no-default-features build passes too
         run: cargo build --no-default-features
         working-directory: rust
-      - name: Ensure tests pass
-        run: cargo test
-        working-directory: rust


### PR DESCRIPTION
### Description
We already have a separate github action that runs cargo test. 