### PR TITLE
Migrate FA processor to SDK

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 [[package]]
 name = "aptos-indexer-processor-sdk"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=9ecd252ccff53023664562001dd04c2886488c0d#9ecd252ccff53023664562001dd04c2886488c0d"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
 dependencies = [
  "anyhow",
  "aptos-indexer-transaction-stream",
@@ -173,7 +173,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-processor-sdk-server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=9ecd252ccff53023664562001dd04c2886488c0d#9ecd252ccff53023664562001dd04c2886488c0d"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
 dependencies = [
  "anyhow",
  "aptos-indexer-processor-sdk",
@@ -206,10 +206,10 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-transaction-stream"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=9ecd252ccff53023664562001dd04c2886488c0d#9ecd252ccff53023664562001dd04c2886488c0d"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
 dependencies = [
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=9ecd252ccff53023664562001dd04c2886488c0d)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315)",
  "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
  "chrono",
  "futures-util",
@@ -234,7 +234,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=9ecd252ccff53023664562001dd04c2886488c0d#9ecd252ccff53023664562001dd04c2886488c0d"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
 dependencies = [
  "chrono",
 ]
@@ -2218,7 +2218,7 @@ dependencies = [
 [[package]]
 name = "instrumented-channel"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=9ecd252ccff53023664562001dd04c2886488c0d#9ecd252ccff53023664562001dd04c2886488c0d"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
 dependencies = [
  "delegate",
  "derive_builder",
@@ -4094,7 +4094,10 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "sample"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=9ecd252ccff53023664562001dd04c2886488c0d#9ecd252ccff53023664562001dd04c2886488c0d"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "schannel"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -141,8 +141,9 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 [[package]]
 name = "aptos-indexer-processor-sdk"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
+ "ahash",
  "anyhow",
  "aptos-indexer-transaction-stream",
  "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
@@ -173,7 +174,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-processor-sdk-server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "anyhow",
  "aptos-indexer-processor-sdk",
@@ -206,10 +207,10 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-transaction-stream"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b)",
  "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
  "chrono",
  "futures-util",
@@ -234,7 +235,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "chrono",
 ]
@@ -2218,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "instrumented-channel"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "delegate",
  "derive_builder",
@@ -4094,7 +4095,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "sample"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "tracing",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,8 +30,8 @@ testing-transactions = { path = "testing-transactions" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.86"
-aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "ca658a0881c4bff4e1dee14c59a7c63608a5b315" }
-aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "ca658a0881c4bff4e1dee14c59a7c63608a5b315" }
+aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "95d76e07dd66a20a0e50a9e6c559885bff7ab52b" }
+aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "95d76e07dd66a20a0e50a9e6c559885bff7ab52b" }
 aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }
 aptos-indexer-test-transactions = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "7246f0536d599789d7dd5e9fb776554abbe11eac" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,8 +30,8 @@ testing-transactions = { path = "testing-transactions" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.86"
-aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "9ecd252ccff53023664562001dd04c2886488c0d" }
-aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "9ecd252ccff53023664562001dd04c2886488c0d" }
+aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "4923bbb8bf82298bc85dc3d16971fef2f22fc0b0" }
+aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "4923bbb8bf82298bc85dc3d16971fef2f22fc0b0" }
 aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }
 aptos-indexer-test-transactions = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "7246f0536d599789d7dd5e9fb776554abbe11eac" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,8 +30,8 @@ testing-transactions = { path = "testing-transactions" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.86"
-aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "4923bbb8bf82298bc85dc3d16971fef2f22fc0b0" }
-aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "4923bbb8bf82298bc85dc3d16971fef2f22fc0b0" }
+aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "ca658a0881c4bff4e1dee14c59a7c63608a5b315" }
+aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "ca658a0881c4bff4e1dee14c59a7c63608a5b315" }
 aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }
 aptos-indexer-test-transactions = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "7246f0536d599789d7dd5e9fb776554abbe11eac" }

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -169,7 +169,7 @@ async fn insert_to_db(
     Ok(())
 }
 
-fn insert_fungible_asset_activities_query(
+pub fn insert_fungible_asset_activities_query(
     items_to_insert: Vec<FungibleAssetActivity>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -186,7 +186,7 @@ fn insert_fungible_asset_activities_query(
     )
 }
 
-fn insert_fungible_asset_metadata_query(
+pub fn insert_fungible_asset_metadata_query(
     items_to_insert: Vec<FungibleAssetMetadataModel>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -222,7 +222,7 @@ fn insert_fungible_asset_metadata_query(
     )
 }
 
-fn insert_fungible_asset_balances_query(
+pub fn insert_fungible_asset_balances_query(
     items_to_insert: Vec<FungibleAssetBalance>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -239,7 +239,7 @@ fn insert_fungible_asset_balances_query(
     )
 }
 
-fn insert_current_fungible_asset_balances_query(
+pub fn insert_current_fungible_asset_balances_query(
     items_to_insert: Vec<CurrentFungibleAssetBalance>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -269,7 +269,7 @@ fn insert_current_fungible_asset_balances_query(
     )
 }
 
-fn insert_current_unified_fungible_asset_balances_v1_query(
+pub fn insert_current_unified_fungible_asset_balances_v1_query(
     items_to_insert: Vec<CurrentUnifiedFungibleAssetBalance>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -298,7 +298,7 @@ fn insert_current_unified_fungible_asset_balances_v1_query(
     )
 }
 
-fn insert_current_unified_fungible_asset_balances_v2_query(
+pub fn insert_current_unified_fungible_asset_balances_v2_query(
     items_to_insert: Vec<CurrentUnifiedFungibleAssetBalance>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -328,7 +328,7 @@ fn insert_current_unified_fungible_asset_balances_v2_query(
     )
 }
 
-fn insert_coin_supply_query(
+pub fn insert_coin_supply_query(
     items_to_insert: Vec<CoinSupply>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,

--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -451,7 +451,7 @@ impl ProcessorTrait for FungibleAssetProcessor {
 }
 
 /// V2 coin is called fungible assets and this flow includes all data from V1 in coin_processor
-async fn parse_v2_coin(
+pub async fn parse_v2_coin(
     transactions: &[Transaction],
 ) -> (
     Vec<FungibleAssetActivity>,

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -114,6 +114,18 @@ bitflags! {
     }
 }
 
+impl TableFlags {
+    pub fn from_set(set: &HashSet<String>) -> Self {
+        let mut flags = TableFlags::empty();
+        for table in set {
+            if let Some(flag) = TableFlags::from_name(table) {
+                flags |= flag;
+            }
+        }
+        flags
+    }
+}
+
 pub struct Worker {
     pub db_pool: ArcDbPool,
     pub processor_config: ProcessorConfig,

--- a/rust/sdk-processor/src/config/indexer_processor_config.rs
+++ b/rust/sdk-processor/src/config/indexer_processor_config.rs
@@ -5,11 +5,11 @@ use super::{db_config::DbConfig, processor_config::ProcessorConfig};
 use crate::processors::{
     events_processor::EventsProcessor, fungible_asset_processor::FungibleAssetProcessor,
 };
-use ahash::HashSet;
 use anyhow::Result;
 use aptos_indexer_processor_sdk::aptos_indexer_transaction_stream::TransactionStreamConfig;
 use aptos_indexer_processor_sdk_server_framework::RunnableConfig;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/rust/sdk-processor/src/config/indexer_processor_config.rs
+++ b/rust/sdk-processor/src/config/indexer_processor_config.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{db_config::DbConfig, processor_config::ProcessorConfig};
-use crate::processors::events_processor::EventsProcessor;
+use crate::processors::{
+    events_processor::EventsProcessor, fungible_asset_processor::FungibleAssetProcessor,
+};
+use ahash::HashSet;
 use anyhow::Result;
 use aptos_indexer_processor_sdk::aptos_indexer_transaction_stream::TransactionStreamConfig;
 use aptos_indexer_processor_sdk_server_framework::RunnableConfig;
@@ -14,6 +17,10 @@ pub struct IndexerProcessorConfig {
     pub processor_config: ProcessorConfig,
     pub transaction_stream_config: TransactionStreamConfig,
     pub db_config: DbConfig,
+
+    // String vector for deprecated tables to skip db writes
+    #[serde(default)]
+    pub deprecated_tables: HashSet<String>,
 }
 
 #[async_trait::async_trait]
@@ -23,6 +30,10 @@ impl RunnableConfig for IndexerProcessorConfig {
             ProcessorConfig::EventsProcessor(_) => {
                 let events_processor = EventsProcessor::new(self.clone()).await?;
                 events_processor.run_processor().await
+            },
+            ProcessorConfig::FungibleAssetProcessor(_) => {
+                let fungible_asset_processor = FungibleAssetProcessor::new(self.clone()).await?;
+                fungible_asset_processor.run_processor().await
             },
         }
     }

--- a/rust/sdk-processor/src/config/indexer_processor_config.rs
+++ b/rust/sdk-processor/src/config/indexer_processor_config.rs
@@ -9,7 +9,6 @@ use anyhow::Result;
 use aptos_indexer_processor_sdk::aptos_indexer_transaction_stream::TransactionStreamConfig;
 use aptos_indexer_processor_sdk_server_framework::RunnableConfig;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -17,10 +16,6 @@ pub struct IndexerProcessorConfig {
     pub processor_config: ProcessorConfig,
     pub transaction_stream_config: TransactionStreamConfig,
     pub db_config: DbConfig,
-
-    // String vector for deprecated tables to skip db writes
-    #[serde(default)]
-    pub deprecated_tables: HashSet<String>,
 }
 
 #[async_trait::async_trait]

--- a/rust/sdk-processor/src/config/processor_config.rs
+++ b/rust/sdk-processor/src/config/processor_config.rs
@@ -1,4 +1,6 @@
-use crate::processors::events_processor::EventsProcessorConfig;
+use crate::processors::{
+    events_processor::EventsProcessorConfig, fungible_asset_processor::FungibleAssetProcessorConfig,
+};
 use serde::{Deserialize, Serialize};
 
 /// This enum captures the configs for all the different processors that are defined.
@@ -35,6 +37,7 @@ use serde::{Deserialize, Serialize};
 )]
 pub enum ProcessorConfig {
     EventsProcessor(EventsProcessorConfig),
+    FungibleAssetProcessor(FungibleAssetProcessorConfig),
 }
 
 impl ProcessorConfig {

--- a/rust/sdk-processor/src/config/processor_config.rs
+++ b/rust/sdk-processor/src/config/processor_config.rs
@@ -1,7 +1,6 @@
-use crate::processors::{
-    events_processor::EventsProcessorConfig, fungible_asset_processor::FungibleAssetProcessorConfig,
-};
+use ahash::AHashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 /// This enum captures the configs for all the different processors that are defined.
 ///
@@ -36,8 +35,8 @@ use serde::{Deserialize, Serialize};
     strum(serialize_all = "snake_case")
 )]
 pub enum ProcessorConfig {
-    EventsProcessor(EventsProcessorConfig),
-    FungibleAssetProcessor(FungibleAssetProcessorConfig),
+    EventsProcessor(DefaultProcessorConfig),
+    FungibleAssetProcessor(DefaultProcessorConfig),
 }
 
 impl ProcessorConfig {
@@ -47,33 +46,23 @@ impl ProcessorConfig {
         self.into()
     }
 }
-#[derive(Debug)]
-// To ensure that the variants of ProcessorConfig and Processor line up, in the testing
-// build path we derive EnumDiscriminants on this enum as well and make sure the two
-// sets of variants match up in `test_processor_names_complete`.
-#[cfg_attr(
-    test,
-    derive(strum::EnumDiscriminants),
-    strum_discriminants(
-        derive(strum::EnumVariantNames),
-        name(ProcessorDiscriminants),
-        strum(serialize_all = "snake_case")
-    )
-)]
-pub enum Processor {
-    EventsProcessor,
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DefaultProcessorConfig {
+    // Number of rows to insert, per chunk, for each DB table. Default per table is ~32,768 (2**16/2)
+    #[serde(default = "AHashMap::new")]
+    pub per_table_chunk_sizes: AHashMap<String, usize>,
+    // Size of channel between steps
+    #[serde(default = "DefaultProcessorConfig::default_channel_size")]
+    pub channel_size: usize,
+    // String vector for deprecated tables to skip db writes
+    #[serde(default)]
+    pub deprecated_tables: HashSet<String>,
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    use strum::VariantNames;
-
-    /// This test exists to make sure that when a new processor is added, it is added
-    /// to both Processor and ProcessorConfig. To make sure this passes, make sure the
-    /// variants are in the same order (lexicographical) and the names match.
-    #[test]
-    fn test_processor_names_complete() {
-        assert_eq!(ProcessorName::VARIANTS, ProcessorDiscriminants::VARIANTS);
+impl DefaultProcessorConfig {
+    pub const fn default_channel_size() -> usize {
+        10
     }
 }

--- a/rust/sdk-processor/src/processors/events_processor.rs
+++ b/rust/sdk-processor/src/processors/events_processor.rs
@@ -132,12 +132,9 @@ impl EventsProcessor {
         loop {
             match buffer_receiver.recv().await {
                 Ok(txn_context) => {
-                    if txn_context.data.is_empty() {
-                        continue;
-                    }
                     debug!(
                         "Finished processing events from versions [{:?}, {:?}]",
-                        txn_context.start_version, txn_context.end_version,
+                        txn_context.metadata.start_version, txn_context.metadata.end_version,
                     );
                 },
                 Err(e) => {

--- a/rust/sdk-processor/src/processors/mod.rs
+++ b/rust/sdk-processor/src/processors/mod.rs
@@ -1,1 +1,2 @@
 pub mod events_processor;
+pub mod fungible_asset_processor;

--- a/rust/sdk-processor/src/steps/events_processor/events_extractor.rs
+++ b/rust/sdk-processor/src/steps/events_processor/events_extractor.rs
@@ -17,14 +17,14 @@ where
 
 #[async_trait]
 impl Processable for EventsExtractor {
-    type Input = Transaction;
-    type Output = EventModel;
+    type Input = Vec<Transaction>;
+    type Output = Vec<EventModel>;
     type RunType = AsyncRunType;
 
     async fn process(
         &mut self,
-        item: TransactionContext<Transaction>,
-    ) -> Result<Option<TransactionContext<EventModel>>, ProcessorError> {
+        item: TransactionContext<Vec<Transaction>>,
+    ) -> Result<Option<TransactionContext<Vec<EventModel>>>, ProcessorError> {
         // info!(
         //     start_version = item.start_version,
         //     end_version = item.end_version,
@@ -68,11 +68,7 @@ impl Processable for EventsExtractor {
             .collect::<Vec<EventModel>>();
         Ok(Some(TransactionContext {
             data: events,
-            start_version: item.start_version,
-            end_version: item.end_version,
-            start_transaction_timestamp: item.start_transaction_timestamp,
-            end_transaction_timestamp: item.end_transaction_timestamp,
-            total_size_in_bytes: item.total_size_in_bytes,
+            metadata: item.metadata,
         }))
     }
 }

--- a/rust/sdk-processor/src/steps/events_processor/events_storer.rs
+++ b/rust/sdk-processor/src/steps/events_processor/events_storer.rs
@@ -1,6 +1,6 @@
 use crate::{
+    config::processor_config::DefaultProcessorConfig,
     db::common::models::events_models::events::EventModel,
-    processors::events_processor::EventsProcessorConfig,
     utils::database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool},
 };
 use ahash::AHashMap;
@@ -24,11 +24,11 @@ where
     Self: Sized + Send + 'static,
 {
     conn_pool: ArcDbPool,
-    processor_config: EventsProcessorConfig,
+    processor_config: DefaultProcessorConfig,
 }
 
 impl EventsStorer {
-    pub fn new(conn_pool: ArcDbPool, processor_config: EventsProcessorConfig) -> Self {
+    pub fn new(conn_pool: ArcDbPool, processor_config: DefaultProcessorConfig) -> Self {
         Self {
             conn_pool,
             processor_config,

--- a/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_extractor.rs
+++ b/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_extractor.rs
@@ -26,7 +26,7 @@ where
 
 #[async_trait]
 impl Processable for FungibleAssetExtractor {
-    type Input = Transaction;
+    type Input = Vec<Transaction>;
     type Output = (
         Vec<FungibleAssetActivity>,
         Vec<FungibleAssetMetadataModel>,
@@ -39,7 +39,7 @@ impl Processable for FungibleAssetExtractor {
 
     async fn process(
         &mut self,
-        transactions: TransactionContext<Transaction>,
+        transactions: TransactionContext<Vec<Transaction>>,
     ) -> Result<
         Option<
             TransactionContext<(
@@ -63,19 +63,15 @@ impl Processable for FungibleAssetExtractor {
         ) = parse_v2_coin(&transactions.data).await;
 
         Ok(Some(TransactionContext {
-            data: vec![(
+            data: (
                 fungible_asset_activities,
                 fungible_asset_metadata,
                 fungible_asset_balances,
                 current_fungible_asset_balances,
                 current_unified_fungible_asset_balances,
                 coin_supply,
-            )],
-            start_version: transactions.start_version,
-            end_version: transactions.end_version,
-            start_transaction_timestamp: transactions.start_transaction_timestamp,
-            end_transaction_timestamp: transactions.end_transaction_timestamp,
-            total_size_in_bytes: transactions.total_size_in_bytes,
+            ),
+            metadata: transactions.metadata,
         }))
     }
 }

--- a/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_extractor.rs
+++ b/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_extractor.rs
@@ -1,0 +1,89 @@
+use aptos_indexer_processor_sdk::{
+    aptos_protos::transaction::v1::Transaction,
+    traits::{async_step::AsyncRunType, AsyncStep, NamedStep, Processable},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+use processor::{
+    db::common::models::{
+        coin_models::coin_supply::CoinSupply,
+        fungible_asset_models::{
+            v2_fungible_asset_activities::FungibleAssetActivity,
+            v2_fungible_asset_balances::{
+                CurrentFungibleAssetBalance, CurrentUnifiedFungibleAssetBalance,
+                FungibleAssetBalance,
+            },
+            v2_fungible_metadata::FungibleAssetMetadataModel,
+        },
+    },
+    processors::fungible_asset_processor::parse_v2_coin,
+};
+
+pub struct FungibleAssetExtractor
+where
+    Self: Sized + Send + 'static, {}
+
+#[async_trait]
+impl Processable for FungibleAssetExtractor {
+    type Input = Transaction;
+    type Output = (
+        Vec<FungibleAssetActivity>,
+        Vec<FungibleAssetMetadataModel>,
+        Vec<FungibleAssetBalance>,
+        Vec<CurrentFungibleAssetBalance>,
+        Vec<CurrentUnifiedFungibleAssetBalance>,
+        Vec<CoinSupply>,
+    );
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        transactions: TransactionContext<Transaction>,
+    ) -> Result<
+        Option<
+            TransactionContext<(
+                Vec<FungibleAssetActivity>,
+                Vec<FungibleAssetMetadataModel>,
+                Vec<FungibleAssetBalance>,
+                Vec<CurrentFungibleAssetBalance>,
+                Vec<CurrentUnifiedFungibleAssetBalance>,
+                Vec<CoinSupply>,
+            )>,
+        >,
+        ProcessorError,
+    > {
+        let (
+            fungible_asset_activities,
+            fungible_asset_metadata,
+            fungible_asset_balances,
+            current_fungible_asset_balances,
+            current_unified_fungible_asset_balances,
+            coin_supply,
+        ) = parse_v2_coin(&transactions.data).await;
+
+        Ok(Some(TransactionContext {
+            data: vec![(
+                fungible_asset_activities,
+                fungible_asset_metadata,
+                fungible_asset_balances,
+                current_fungible_asset_balances,
+                current_unified_fungible_asset_balances,
+                coin_supply,
+            )],
+            start_version: transactions.start_version,
+            end_version: transactions.end_version,
+            start_transaction_timestamp: transactions.start_transaction_timestamp,
+            end_transaction_timestamp: transactions.end_transaction_timestamp,
+            total_size_in_bytes: transactions.total_size_in_bytes,
+        }))
+    }
+}
+
+impl AsyncStep for FungibleAssetExtractor {}
+
+impl NamedStep for FungibleAssetExtractor {
+    fn name(&self) -> String {
+        "FungibleAssetExtractor".to_string()
+    }
+}

--- a/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_storer.rs
+++ b/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_storer.rs
@@ -1,10 +1,5 @@
 use crate::{
-    config::indexer_processor_config::IndexerProcessorConfig,
-    db::common::models::events_models::events::EventModel,
-    processors::{
-        events_processor::EventsProcessorConfig,
-        fungible_asset_processor::FungibleAssetProcessorConfig,
-    },
+    processors::fungible_asset_processor::FungibleAssetProcessorConfig,
     utils::database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool},
 };
 use ahash::AHashMap;
@@ -15,11 +10,6 @@ use aptos_indexer_processor_sdk::{
     utils::errors::ProcessorError,
 };
 use async_trait::async_trait;
-use diesel::{
-    pg::{upsert::excluded, Pg},
-    query_builder::QueryFragment,
-    ExpressionMethods,
-};
 use processor::{
     db::common::models::{
         coin_models::coin_supply::CoinSupply,
@@ -39,10 +29,8 @@ use processor::{
         insert_fungible_asset_activities_query, insert_fungible_asset_balances_query,
         insert_fungible_asset_metadata_query,
     },
-    schema,
     worker::TableFlags,
 };
-use serde::de;
 
 pub struct FungibleAssetStorer
 where

--- a/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_storer.rs
+++ b/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_storer.rs
@@ -1,0 +1,108 @@
+use crate::{
+    db::common::models::events_models::events::EventModel,
+    processors::events_processor::EventsProcessorConfig,
+    utils::database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool},
+};
+use ahash::AHashMap;
+use anyhow::Result;
+use aptos_indexer_processor_sdk::{
+    traits::{async_step::AsyncRunType, AsyncStep, NamedStep, Processable},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+use diesel::{
+    pg::{upsert::excluded, Pg},
+    query_builder::QueryFragment,
+    ExpressionMethods,
+};
+use processor::{
+    db::common::models::{
+        coin_models::coin_supply::CoinSupply,
+        fungible_asset_models::{
+            v2_fungible_asset_activities::FungibleAssetActivity,
+            v2_fungible_asset_balances::{
+                CurrentFungibleAssetBalance, CurrentUnifiedFungibleAssetBalance,
+                FungibleAssetBalance,
+            },
+            v2_fungible_metadata::FungibleAssetMetadataModel,
+        },
+    },
+    schema,
+};
+use tracing::debug;
+
+pub struct FungibleAssetStorer
+where
+    Self: Sized + Send + 'static,
+{
+    conn_pool: ArcDbPool,
+    processor_config: EventsProcessorConfig,
+}
+
+impl FungibleAssetStorer {
+    pub fn new(conn_pool: ArcDbPool, processor_config: EventsProcessorConfig) -> Self {
+        Self {
+            conn_pool,
+            processor_config,
+        }
+    }
+}
+
+#[async_trait]
+impl Processable for FungibleAssetStorer {
+    type Input = (
+        Vec<FungibleAssetActivity>,
+        Vec<FungibleAssetMetadataModel>,
+        Vec<FungibleAssetBalance>,
+        Vec<CurrentFungibleAssetBalance>,
+        Vec<CurrentUnifiedFungibleAssetBalance>,
+        Vec<CoinSupply>,
+    );
+    type Output = (
+        Vec<FungibleAssetActivity>,
+        Vec<FungibleAssetMetadataModel>,
+        Vec<FungibleAssetBalance>,
+        Vec<CurrentFungibleAssetBalance>,
+        Vec<CurrentUnifiedFungibleAssetBalance>,
+        Vec<CoinSupply>,
+    );
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        events: TransactionContext<(
+            Vec<FungibleAssetActivity>,
+            Vec<FungibleAssetMetadataModel>,
+            Vec<FungibleAssetBalance>,
+            Vec<CurrentFungibleAssetBalance>,
+            Vec<CurrentUnifiedFungibleAssetBalance>,
+            Vec<CoinSupply>,
+        )>,
+    ) -> Result<Option<TransactionContext<EventModel>>, ProcessorError> {
+
+        // match execute_res {
+        //     Ok(_) => {
+        //         debug!(
+        //             "Events version [{}, {}] stored successfully",
+        //             events.start_version, events.end_version
+        //         );
+        //         Ok(Some(events))
+        //     },
+        //     Err(e) => Err(ProcessorError::DBStoreError {
+        //         message: format!(
+        //             "Failed to store events versions {} to {}: {:?}",
+        //             events.start_version, events.end_version, e,
+        //         ),
+        //     }),
+        // }
+    }
+}
+
+impl AsyncStep for FungibleAssetStorer {}
+
+impl NamedStep for FungibleAssetStorer {
+    fn name(&self) -> String {
+        "FungibleAssetStorer".to_string()
+    }
+}

--- a/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_storer.rs
+++ b/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_storer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    processors::fungible_asset_processor::FungibleAssetProcessorConfig,
+    config::processor_config::DefaultProcessorConfig,
     utils::database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool},
 };
 use ahash::AHashMap;
@@ -37,19 +37,19 @@ where
     Self: Sized + Send + 'static,
 {
     conn_pool: ArcDbPool,
-    fa_config: FungibleAssetProcessorConfig,
+    processor_config: DefaultProcessorConfig,
     deprecated_tables: TableFlags,
 }
 
 impl FungibleAssetStorer {
     pub fn new(
         conn_pool: ArcDbPool,
-        fa_config: FungibleAssetProcessorConfig,
+        processor_config: DefaultProcessorConfig,
         deprecated_tables: TableFlags,
     ) -> Self {
         Self {
             conn_pool,
-            fa_config,
+            processor_config,
             deprecated_tables,
         }
     }
@@ -89,7 +89,7 @@ impl Processable for FungibleAssetStorer {
         ) = input.data;
 
         let per_table_chunk_sizes: AHashMap<String, usize> =
-            self.fa_config.per_table_chunk_sizes.clone();
+            self.processor_config.per_table_chunk_sizes.clone();
         // if flag turned on we need to not include any value in the table
         let (unified_coin_balances, unified_fa_balances): (Vec<_>, Vec<_>) = if self
             .deprecated_tables

--- a/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_storer.rs
+++ b/rust/sdk-processor/src/steps/fungible_asset_processor/fungible_asset_storer.rs
@@ -1,6 +1,10 @@
 use crate::{
+    config::indexer_processor_config::IndexerProcessorConfig,
     db::common::models::events_models::events::EventModel,
-    processors::events_processor::EventsProcessorConfig,
+    processors::{
+        events_processor::EventsProcessorConfig,
+        fungible_asset_processor::FungibleAssetProcessorConfig,
+    },
     utils::database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool},
 };
 use ahash::AHashMap;
@@ -28,23 +32,37 @@ use processor::{
             v2_fungible_metadata::FungibleAssetMetadataModel,
         },
     },
+    processors::fungible_asset_processor::{
+        insert_coin_supply_query, insert_current_fungible_asset_balances_query,
+        insert_current_unified_fungible_asset_balances_v1_query,
+        insert_current_unified_fungible_asset_balances_v2_query,
+        insert_fungible_asset_activities_query, insert_fungible_asset_balances_query,
+        insert_fungible_asset_metadata_query,
+    },
     schema,
+    worker::TableFlags,
 };
-use tracing::debug;
+use serde::de;
 
 pub struct FungibleAssetStorer
 where
     Self: Sized + Send + 'static,
 {
     conn_pool: ArcDbPool,
-    processor_config: EventsProcessorConfig,
+    fa_config: FungibleAssetProcessorConfig,
+    deprecated_tables: TableFlags,
 }
 
 impl FungibleAssetStorer {
-    pub fn new(conn_pool: ArcDbPool, processor_config: EventsProcessorConfig) -> Self {
+    pub fn new(
+        conn_pool: ArcDbPool,
+        fa_config: FungibleAssetProcessorConfig,
+        deprecated_tables: TableFlags,
+    ) -> Self {
         Self {
             conn_pool,
-            processor_config,
+            fa_config,
+            deprecated_tables,
         }
     }
 }
@@ -59,19 +77,12 @@ impl Processable for FungibleAssetStorer {
         Vec<CurrentUnifiedFungibleAssetBalance>,
         Vec<CoinSupply>,
     );
-    type Output = (
-        Vec<FungibleAssetActivity>,
-        Vec<FungibleAssetMetadataModel>,
-        Vec<FungibleAssetBalance>,
-        Vec<CurrentFungibleAssetBalance>,
-        Vec<CurrentUnifiedFungibleAssetBalance>,
-        Vec<CoinSupply>,
-    );
+    type Output = ();
     type RunType = AsyncRunType;
 
     async fn process(
         &mut self,
-        events: TransactionContext<(
+        input: TransactionContext<(
             Vec<FungibleAssetActivity>,
             Vec<FungibleAssetMetadataModel>,
             Vec<FungibleAssetBalance>,
@@ -79,23 +90,135 @@ impl Processable for FungibleAssetStorer {
             Vec<CurrentUnifiedFungibleAssetBalance>,
             Vec<CoinSupply>,
         )>,
-    ) -> Result<Option<TransactionContext<EventModel>>, ProcessorError> {
+    ) -> Result<Option<TransactionContext<Self::Output>>, ProcessorError> {
+        let (
+            fungible_asset_activities,
+            fungible_asset_metadata,
+            mut fungible_asset_balances,
+            mut current_fungible_asset_balances,
+            current_unified_fungible_asset_balances,
+            mut coin_supply,
+        ) = input.data;
 
-        // match execute_res {
-        //     Ok(_) => {
-        //         debug!(
-        //             "Events version [{}, {}] stored successfully",
-        //             events.start_version, events.end_version
-        //         );
-        //         Ok(Some(events))
-        //     },
-        //     Err(e) => Err(ProcessorError::DBStoreError {
-        //         message: format!(
-        //             "Failed to store events versions {} to {}: {:?}",
-        //             events.start_version, events.end_version, e,
-        //         ),
-        //     }),
-        // }
+        let per_table_chunk_sizes: AHashMap<String, usize> =
+            self.fa_config.per_table_chunk_sizes.clone();
+        // if flag turned on we need to not include any value in the table
+        let (unified_coin_balances, unified_fa_balances): (Vec<_>, Vec<_>) = if self
+            .deprecated_tables
+            .contains(TableFlags::CURRENT_UNIFIED_FUNGIBLE_ASSET_BALANCES)
+        {
+            (vec![], vec![])
+        } else {
+            // Basically we need to split the current unified balances into v1 and v2
+            // by looking at whether asset_type_v2 is null (must be v1 if it's null)
+            // Note, we can't check asset_type_v1 is none because we're now filling asset_type_v1
+            // for certain assets
+            current_unified_fungible_asset_balances
+                .into_iter()
+                .partition(|x| x.asset_type_v2.is_none())
+        };
+
+        if self
+            .deprecated_tables
+            .contains(TableFlags::FUNGIBLE_ASSET_BALANCES)
+        {
+            fungible_asset_balances.clear();
+        }
+
+        if self
+            .deprecated_tables
+            .contains(TableFlags::CURRENT_FUNGIBLE_ASSET_BALANCES)
+        {
+            current_fungible_asset_balances.clear();
+        }
+
+        if self.deprecated_tables.contains(TableFlags::COIN_SUPPLY) {
+            coin_supply.clear();
+        }
+
+        let faa = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_fungible_asset_activities_query,
+            &fungible_asset_activities,
+            get_config_table_chunk_size::<FungibleAssetActivity>(
+                "fungible_asset_activities",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let fam = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_fungible_asset_metadata_query,
+            &fungible_asset_metadata,
+            get_config_table_chunk_size::<FungibleAssetMetadataModel>(
+                "fungible_asset_metadata",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let fab = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_fungible_asset_balances_query,
+            &fungible_asset_balances,
+            get_config_table_chunk_size::<FungibleAssetBalance>(
+                "fungible_asset_balances",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let cfab = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_current_fungible_asset_balances_query,
+            &current_fungible_asset_balances,
+            get_config_table_chunk_size::<CurrentFungibleAssetBalance>(
+                "current_fungible_asset_balances",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let cufab_v1 = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_current_unified_fungible_asset_balances_v1_query,
+            &unified_coin_balances,
+            get_config_table_chunk_size::<CurrentUnifiedFungibleAssetBalance>(
+                "current_unified_fungible_asset_balances",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let cufab_v2 = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_current_unified_fungible_asset_balances_v2_query,
+            &unified_fa_balances,
+            get_config_table_chunk_size::<CurrentUnifiedFungibleAssetBalance>(
+                "current_unified_fungible_asset_balances",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let cs = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_coin_supply_query,
+            &coin_supply,
+            get_config_table_chunk_size::<CoinSupply>("coin_supply", &per_table_chunk_sizes),
+        );
+        let (faa_res, fam_res, fab_res, cfab_res, cufab1_res, cufab2_res, cs_res) =
+            tokio::join!(faa, fam, fab, cfab, cufab_v1, cufab_v2, cs);
+        for res in [
+            faa_res, fam_res, fab_res, cfab_res, cufab1_res, cufab2_res, cs_res,
+        ] {
+            match res {
+                Ok(_) => {},
+                Err(e) => {
+                    return Err(ProcessorError::DBStoreError {
+                        message: format!(
+                            "Failed to store versions {} to {}: {:?}",
+                            input.metadata.start_version, input.metadata.end_version, e,
+                        ),
+                        query: None,
+                    })
+                },
+            }
+        }
+
+        Ok(Some(TransactionContext {
+            data: (),
+            metadata: input.metadata,
+        }))
     }
 }
 

--- a/rust/sdk-processor/src/steps/fungible_asset_processor/mod.rs
+++ b/rust/sdk-processor/src/steps/fungible_asset_processor/mod.rs
@@ -1,0 +1,3 @@
+pub mod fungible_asset_deduper;
+pub mod fungible_asset_extractor;
+pub mod fungible_asset_storer;

--- a/rust/sdk-processor/src/steps/fungible_asset_processor/mod.rs
+++ b/rust/sdk-processor/src/steps/fungible_asset_processor/mod.rs
@@ -1,3 +1,2 @@
-pub mod fungible_asset_deduper;
 pub mod fungible_asset_extractor;
 pub mod fungible_asset_storer;

--- a/rust/sdk-processor/src/steps/mod.rs
+++ b/rust/sdk-processor/src/steps/mod.rs
@@ -1,2 +1,3 @@
 pub mod common;
 pub mod events_processor;
+pub mod fungible_asset_processor;


### PR DESCRIPTION
## Description

- Upgrade SDK dependency to latest version
- Migrate FungibleAssetProcessor to
  - Add FungibleAssetExtractor and FungibleAssetStorer steps
  - Update config to support FungibleAssetProcessor
  - Add support for deprecated tables flags

## Testing
Run fa processor 

![Screenshot 2024-10-07 at 6.46.53 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vIwavW9noSx0eb70aDLz/be1f9fa5-7c3c-47ba-a421-81976124c202.png)

