### PR TITLE
Update SDK dep

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 [[package]]
 name = "aptos-indexer-processor-sdk"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=faf0469441fc27fd62bff4eed0dfab89e0bd5ddd#faf0469441fc27fd62bff4eed0dfab89e0bd5ddd"
 dependencies = [
  "ahash",
  "anyhow",
@@ -174,7 +174,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-processor-sdk-server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=faf0469441fc27fd62bff4eed0dfab89e0bd5ddd#faf0469441fc27fd62bff4eed0dfab89e0bd5ddd"
 dependencies = [
  "anyhow",
  "aptos-indexer-processor-sdk",
@@ -207,10 +207,10 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-transaction-stream"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=faf0469441fc27fd62bff4eed0dfab89e0bd5ddd#faf0469441fc27fd62bff4eed0dfab89e0bd5ddd"
 dependencies = [
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=faf0469441fc27fd62bff4eed0dfab89e0bd5ddd)",
  "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
  "chrono",
  "futures-util",
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=faf0469441fc27fd62bff4eed0dfab89e0bd5ddd#faf0469441fc27fd62bff4eed0dfab89e0bd5ddd"
 dependencies = [
  "chrono",
 ]
@@ -2219,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "instrumented-channel"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=faf0469441fc27fd62bff4eed0dfab89e0bd5ddd#faf0469441fc27fd62bff4eed0dfab89e0bd5ddd"
 dependencies = [
  "delegate",
  "derive_builder",
@@ -4095,7 +4095,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "sample"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=faf0469441fc27fd62bff4eed0dfab89e0bd5ddd#faf0469441fc27fd62bff4eed0dfab89e0bd5ddd"
 dependencies = [
  "tracing",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,8 +30,8 @@ testing-transactions = { path = "testing-transactions" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.86"
-aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "95d76e07dd66a20a0e50a9e6c559885bff7ab52b" }
-aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "95d76e07dd66a20a0e50a9e6c559885bff7ab52b" }
+aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "faf0469441fc27fd62bff4eed0dfab89e0bd5ddd" }
+aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "faf0469441fc27fd62bff4eed0dfab89e0bd5ddd" }
 aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }
 aptos-indexer-test-transactions = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "7246f0536d599789d7dd5e9fb776554abbe11eac" }

--- a/rust/sdk-processor/src/processors/events_processor.rs
+++ b/rust/sdk-processor/src/processors/events_processor.rs
@@ -4,9 +4,7 @@ use crate::{
         processor_config::ProcessorConfig,
     },
     steps::{
-        common::latest_processed_version_tracker::{
-            LatestVersionProcessedTracker, UPDATE_PROCESSOR_STATUS_SECS,
-        },
+        common::latest_processed_version_tracker::LatestVersionProcessedTracker,
         events_processor::{EventsExtractor, EventsStorer},
     },
     utils::{
@@ -19,10 +17,9 @@ use anyhow::Result;
 use aptos_indexer_processor_sdk::{
     aptos_indexer_transaction_stream::{TransactionStream, TransactionStreamConfig},
     builder::ProcessorBuilder,
-    common_steps::{OrderByVersionStep, TransactionStreamStep},
+    common_steps::TransactionStreamStep,
     traits::IntoRunnableStep,
 };
-use std::time::Duration;
 use tracing::{debug, info};
 
 pub struct EventsProcessor {

--- a/rust/sdk-processor/src/processors/events_processor.rs
+++ b/rust/sdk-processor/src/processors/events_processor.rs
@@ -97,10 +97,6 @@ impl EventsProcessor {
         .await?;
         let events_extractor = EventsExtractor {};
         let events_storer = EventsStorer::new(self.db_pool.clone(), processor_config);
-        let order_step = OrderByVersionStep::new(
-            starting_version,
-            Duration::from_secs(UPDATE_PROCESSOR_STATUS_SECS),
-        );
         let version_tracker =
             LatestVersionProcessedTracker::new(self.db_pool.clone(), processor_name.to_string());
 
@@ -110,7 +106,6 @@ impl EventsProcessor {
         )
         .connect_to(events_extractor.into_runnable_step(), channel_size)
         .connect_to(events_storer.into_runnable_step(), channel_size)
-        .connect_to(order_step.into_runnable_step(), channel_size)
         .connect_to(version_tracker.into_runnable_step(), channel_size)
         .end_and_return_output_receiver(channel_size);
 

--- a/rust/sdk-processor/src/processors/fungible_asset_processor.rs
+++ b/rust/sdk-processor/src/processors/fungible_asset_processor.rs
@@ -4,9 +4,7 @@ use crate::{
         processor_config::ProcessorConfig,
     },
     steps::{
-        common::latest_processed_version_tracker::{
-            LatestVersionProcessedTracker, UPDATE_PROCESSOR_STATUS_SECS,
-        },
+        common::latest_processed_version_tracker::LatestVersionProcessedTracker,
         fungible_asset_processor::{
             fungible_asset_extractor::FungibleAssetExtractor,
             fungible_asset_storer::FungibleAssetStorer,
@@ -22,11 +20,10 @@ use anyhow::Result;
 use aptos_indexer_processor_sdk::{
     aptos_indexer_transaction_stream::{TransactionStream, TransactionStreamConfig},
     builder::ProcessorBuilder,
-    common_steps::{OrderByVersionStep, TransactionStreamStep},
+    common_steps::TransactionStreamStep,
     traits::IntoRunnableStep,
 };
 use processor::worker::TableFlags;
-use std::time::Duration;
 use tracing::{debug, info};
 
 pub struct FungibleAssetProcessor {

--- a/rust/sdk-processor/src/processors/fungible_asset_processor.rs
+++ b/rust/sdk-processor/src/processors/fungible_asset_processor.rs
@@ -101,10 +101,6 @@ impl FungibleAssetProcessor {
             processor_config,
             deprecated_table_flags,
         );
-        let order_step = OrderByVersionStep::new(
-            starting_version,
-            Duration::from_secs(UPDATE_PROCESSOR_STATUS_SECS),
-        );
         let version_tracker =
             LatestVersionProcessedTracker::new(self.db_pool.clone(), processor_name.to_string());
 
@@ -114,7 +110,6 @@ impl FungibleAssetProcessor {
         )
         .connect_to(fa_extractor.into_runnable_step(), channel_size)
         .connect_to(fa_storer.into_runnable_step(), channel_size)
-        .connect_to(order_step.into_runnable_step(), channel_size)
         .connect_to(version_tracker.into_runnable_step(), channel_size)
         .end_and_return_output_receiver(channel_size);
 


### PR DESCRIPTION
## Summary
Update SDK dep to get latency metrics and remove the OrderByVersion step in the SDK processors