### PR TITLE
remove null address from delegator count

### DIFF
--- a/rust/processor/src/db/postgres/migrations/2024-10-23-232703_num_active_delegator_per_pool/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-10-23-232703_num_active_delegator_per_pool/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS num_active_delegator_per_pool;

--- a/rust/processor/src/db/postgres/migrations/2024-10-23-232703_num_active_delegator_per_pool/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-10-23-232703_num_active_delegator_per_pool/up.sql
@@ -1,0 +1,9 @@
+-- need this for delegation staking
+CREATE OR REPLACE VIEW num_active_delegator_per_pool AS
+SELECT pool_address,
+  COUNT(DISTINCT delegator_address) AS num_active_delegator
+FROM current_delegator_balances
+WHERE shares > 0
+  AND delegator_address  != '0x0000000000000000000000000000000000000000000000000000000000000000'
+  AND pool_type = 'active_shares'
+GROUP BY 1;


### PR DESCRIPTION
When a delegator first receives a delegation in the UI it will show as having 3 active delegators.

ex. https://explorer.aptoslabs.com/txn/1828020008/changes?network=mainnet

The 3 table items with balance are

1. reward address
2. NULL address
3. delegator

I've changed the tooltip to reflect that reward address will be included https://github.com/aptos-labs/explorer/pull/836

This logic change removes the NULL address from being counted

Context on NULL address https://github.com/aptos-labs/aptos-core/blob/114d361d6cc7119f88eec11ae562c5ec6797275a/aptos-move/framework/aptos-framework/sources/delegation_pool.move#L1568