### PR TITLE
Reset LastSuccessfulVersion to 0 if Restarting on Stauts=Complete

### DIFF
--- a/rust/sdk-processor/src/steps/common/processor_status_saver.rs
+++ b/rust/sdk-processor/src/steps/common/processor_status_saver.rs
@@ -140,7 +140,7 @@ impl ProcessorStatusSaver for ProcessorStatusSaverEnum {
                             backfill_processor_status::backfill_end_version
                                 .eq(excluded(backfill_processor_status::backfill_end_version)),
                         )),
-                    None,
+                        Some(" WHERE backfill_processor_status.last_success_version <= EXCLUDED.last_success_version "),
                 )
                 .await?;
                 Ok(())

--- a/rust/sdk-processor/src/utils/starting_version.rs
+++ b/rust/sdk-processor/src/utils/starting_version.rs
@@ -2,12 +2,11 @@ use super::database::ArcDbPool;
 use crate::{
     config::indexer_processor_config::IndexerProcessorConfig,
     db::common::models::{
-        backfill_processor_status::{BackfillProcessorStatusQuery, BackfillStatus},
+        backfill_processor_status::{
+            BackfillProcessorStatus, BackfillProcessorStatusQuery, BackfillStatus,
+        },
         processor_status::ProcessorStatusQuery,
     },
-};
-use crate::{
-    db::common::models::backfill_processor_status::BackfillProcessorStatus,
     utils::database::execute_with_better_error,
 };
 use anyhow::{Context, Result};
@@ -67,7 +66,7 @@ async fn get_starting_version_from_db(
                 // If status is Complete, this is the start of a new backfill job.
                 BackfillStatus::Complete => {
                     let backfill_alias = status.backfill_alias.clone();
-                    let backfill_end_version_mapped = status.backfill_end_version.map(|v| v as i64);
+                    let backfill_end_version_mapped = status.backfill_end_version;
                     let status = BackfillProcessorStatus {
                         backfill_alias,
                         backfill_status: BackfillStatus::InProgress,


### PR DESCRIPTION
## Purpose
If the backfillStatus is Complete on a particular row, while the processor will correctly start to backfill from 0 again, the table will not reflect the current status due to the monotonic increasing invariant set on the table writes. A workaround was to simply remove that invariant. 

This PR adds back that invariant to avoid possible edge cases and instead resets the latestSuccessVersion to 0 in the `starting_version` logic upon encountering the `Complete` state.

## Testing
Manually tested expected behavior:
![image](https://github.com/user-attachments/assets/361aa2c2-180d-457d-8680-95ac9d8289c8)

![image](https://github.com/user-attachments/assets/5bda1769-cee3-4a0e-97e1-d86dc983a8a5)

![image](https://github.com/user-attachments/assets/80a52100-60b4-4baa-91e4-a40b9b8d4d23)

