### PR TITLE
update integration test workflow

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -8,7 +8,7 @@ description: |
 runs:
   using: composite
   steps:
-    - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld --no-install-recommends --assume-yes
+    - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld libdw-dev --no-install-recommends --assume-yes
       shell: bash
 
     - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -59,12 +59,8 @@ jobs:
         run: cargo update
         working-directory: rust
 
-      - name: Install Dependencies and Run Linter
-        uses: ./.github/actions/dep_install_and_lint
-        with:
-          working-directory: rust
-
       # Run Integration Tests
       - name: Run Integration Tests
-        run: cargo test --manifest-path integration-tests/Cargo.toml -- --nocapture
+        # we want to generate output so that all_tests doesn't fail when new transaction is added
+        run: cargo test --manifest-path integration-tests/Cargo.toml -- --nocapture generate-output 
         working-directory: rust

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -59,11 +59,13 @@ jobs:
         run: |
           sudo apt update && sudo apt install libdw-dev
           cargo update
-        working-directory:
-          rust
+        working-directory: rust
 
       # Run Integration Tests
       - name: Run Integration Tests
         # we want to generate output so that all_tests doesn't fail when new transaction is added
-        run: cargo test --manifest-path integration-tests/Cargo.toml -- --nocapture generate-output 
-        working-directory: rust
+        run: |
+          # TODO: until we have more comprehensive cli parsers, we will need to run tests separately.
+          cargo test all_tests -- --nocapture generate-output
+          cargo test sdk_tests -- --nocapture generate-output
+        working-directory: rust/integration-tests

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -55,9 +55,12 @@ jobs:
         run: cat rust/Cargo.toml  # Correct path to the Cargo.toml file
 
       # Ensure Cargo.lock is updated with the latest dependencies
-      - name: Update Dependencies
-        run: cargo update
-        working-directory: rust
+      - name: rust setup
+        run: |
+          sudo apt update && sudo apt install libdw-dev
+          cargo update
+        working-directory:
+          rust
 
       # Run Integration Tests
       - name: Run Integration Tests

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 [[package]]
 name = "aptos-indexer-processor-sdk"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=41dd3e52235032d447f736664d28b9ec4fd0a299#41dd3e52235032d447f736664d28b9ec4fd0a299"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=c8f12a75c3648fba889c3da657ff713cd5e676dc#c8f12a75c3648fba889c3da657ff713cd5e676dc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -174,7 +174,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-processor-sdk-server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=41dd3e52235032d447f736664d28b9ec4fd0a299#41dd3e52235032d447f736664d28b9ec4fd0a299"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=c8f12a75c3648fba889c3da657ff713cd5e676dc#c8f12a75c3648fba889c3da657ff713cd5e676dc"
 dependencies = [
  "anyhow",
  "aptos-indexer-processor-sdk",
@@ -207,7 +207,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-testing-framework"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=41dd3e52235032d447f736664d28b9ec4fd0a299#41dd3e52235032d447f736664d28b9ec4fd0a299"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=c8f12a75c3648fba889c3da657ff713cd5e676dc#c8f12a75c3648fba889c3da657ff713cd5e676dc"
 dependencies = [
  "anyhow",
  "aptos-indexer-processor-sdk",
@@ -218,6 +218,7 @@ dependencies = [
  "diesel_migrations",
  "futures",
  "futures-util",
+ "lazy_static",
  "native-tls",
  "once_cell",
  "postgres-native-tls",
@@ -234,10 +235,10 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-transaction-stream"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=41dd3e52235032d447f736664d28b9ec4fd0a299#41dd3e52235032d447f736664d28b9ec4fd0a299"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=c8f12a75c3648fba889c3da657ff713cd5e676dc#c8f12a75c3648fba889c3da657ff713cd5e676dc"
 dependencies = [
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=41dd3e52235032d447f736664d28b9ec4fd0a299)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=c8f12a75c3648fba889c3da657ff713cd5e676dc)",
  "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
  "chrono",
  "futures-util",
@@ -262,7 +263,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=41dd3e52235032d447f736664d28b9ec4fd0a299#41dd3e52235032d447f736664d28b9ec4fd0a299"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=c8f12a75c3648fba889c3da657ff713cd5e676dc#c8f12a75c3648fba889c3da657ff713cd5e676dc"
 dependencies = [
  "chrono",
 ]
@@ -2246,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "instrumented-channel"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=41dd3e52235032d447f736664d28b9ec4fd0a299#41dd3e52235032d447f736664d28b9ec4fd0a299"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=c8f12a75c3648fba889c3da657ff713cd5e676dc#c8f12a75c3648fba889c3da657ff713cd5e676dc"
 dependencies = [
  "delegate",
  "derive_builder",
@@ -4129,7 +4130,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "sample"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=41dd3e52235032d447f736664d28b9ec4fd0a299#41dd3e52235032d447f736664d28b9ec4fd0a299"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=c8f12a75c3648fba889c3da657ff713cd5e676dc#c8f12a75c3648fba889c3da657ff713cd5e676dc"
 dependencies = [
  "tracing",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,12 +30,12 @@ testing-transactions = { path = "testing-transactions" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.86"
-aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "41dd3e52235032d447f736664d28b9ec4fd0a299" }
-aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "41dd3e52235032d447f736664d28b9ec4fd0a299" }
+aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "c8f12a75c3648fba889c3da657ff713cd5e676dc" }
+aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "c8f12a75c3648fba889c3da657ff713cd5e676dc" }
 aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }
 aptos-indexer-test-transactions = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "9ffc0a383e416e5b4f9845f043be2fde8a9a5656" }
-aptos-indexer-testing-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "41dd3e52235032d447f736664d28b9ec4fd0a299" }
+aptos-indexer-testing-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "c8f12a75c3648fba889c3da657ff713cd5e676dc" }
 async-trait = "0.1.53"
 backtrace = "0.3.58"
 base64 = "0.13.0"


### PR DESCRIPTION
### Descrption:
use generate-output flag to generate when when new txn inputs are deteced so that integration test triggering workflow in aptos-core doesn't fail. 

added a follow-up task in the. test coverage milestones: https://www.notion.so/aptoslabs/Indexer-Test-Coverage-11a8b846eb7280868323d79a37313478?pvs=4#12e8b846eb728018b3faccd83e09d80f
### Test Plan
triggered the test against the branch and passed. 
https://github.com/aptos-labs/aptos-indexer-processors/actions/runs/11583791402