### PR TITLE
Rewrite Stake Processor with SDK

### DIFF
--- a/rust/processor/src/processors/stake_processor.rs
+++ b/rust/processor/src/processors/stake_processor.rs
@@ -19,7 +19,7 @@ use crate::{
     gap_detectors::ProcessingResult,
     schema,
     utils::{
-        database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool},
+        database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool, DbPoolConnection},
         util::{parse_timestamp, standardize_address},
     },
     IndexerGrpcProcessorConfig,
@@ -190,7 +190,7 @@ async fn insert_to_db(
     Ok(())
 }
 
-fn insert_current_stake_pool_voter_query(
+pub fn insert_current_stake_pool_voter_query(
     items_to_insert: Vec<CurrentStakingPoolVoter>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -215,7 +215,7 @@ fn insert_current_stake_pool_voter_query(
     )
 }
 
-fn insert_proposal_votes_query(
+pub fn insert_proposal_votes_query(
     items_to_insert: Vec<ProposalVote>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -232,7 +232,7 @@ fn insert_proposal_votes_query(
     )
 }
 
-fn insert_delegator_activities_query(
+pub fn insert_delegator_activities_query(
     items_to_insert: Vec<DelegatedStakingActivity>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -249,7 +249,7 @@ fn insert_delegator_activities_query(
     )
 }
 
-fn insert_delegator_balances_query(
+pub fn insert_delegator_balances_query(
     items_to_insert: Vec<DelegatorBalance>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -266,7 +266,7 @@ fn insert_delegator_balances_query(
     )
 }
 
-fn insert_current_delegator_balances_query(
+pub fn insert_current_delegator_balances_query(
     items_to_insert: Vec<CurrentDelegatorBalance>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -290,7 +290,7 @@ fn insert_current_delegator_balances_query(
     )
 }
 
-fn insert_delegator_pools_query(
+pub fn insert_delegator_pools_query(
     items_to_insert: Vec<DelegatorPool>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -312,7 +312,7 @@ fn insert_delegator_pools_query(
     )
 }
 
-fn insert_delegator_pool_balances_query(
+pub fn insert_delegator_pool_balances_query(
     items_to_insert: Vec<DelegatorPoolBalance>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -329,7 +329,7 @@ fn insert_delegator_pool_balances_query(
     )
 }
 
-fn insert_current_delegator_pool_balances_query(
+pub fn insert_current_delegator_pool_balances_query(
     items_to_insert: Vec<CurrentDelegatorPoolBalance>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -356,7 +356,7 @@ fn insert_current_delegator_pool_balances_query(
     )
 }
 
-fn insert_current_delegated_voter_query(
+pub fn insert_current_delegated_voter_query(
     item_to_insert: Vec<CurrentDelegatedVoter>,
 ) -> (
     impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
@@ -382,6 +382,191 @@ fn insert_current_delegated_voter_query(
     )
 }
 
+pub async fn parse_stake_data(
+    transactions: &Vec<Transaction>,
+    mut conn: DbPoolConnection<'_>,
+    query_retries: u32,
+    query_retry_delay_ms: u64,
+) -> Result<
+    (
+        Vec<CurrentStakingPoolVoter>,
+        Vec<ProposalVote>,
+        Vec<DelegatedStakingActivity>,
+        Vec<DelegatorBalance>,
+        Vec<CurrentDelegatorBalance>,
+        Vec<DelegatorPool>,
+        Vec<DelegatorPoolBalance>,
+        Vec<CurrentDelegatorPoolBalance>,
+        Vec<CurrentDelegatedVoter>,
+    ),
+    anyhow::Error,
+> {
+    let mut all_current_stake_pool_voters: StakingPoolVoterMap = AHashMap::new();
+    let mut all_proposal_votes = vec![];
+    let mut all_delegator_activities = vec![];
+    let mut all_delegator_balances = vec![];
+    let mut all_current_delegator_balances: CurrentDelegatorBalanceMap = AHashMap::new();
+    let mut all_delegator_pools: DelegatorPoolMap = AHashMap::new();
+    let mut all_delegator_pool_balances = vec![];
+    let mut all_current_delegator_pool_balances = AHashMap::new();
+
+    let mut active_pool_to_staking_pool = AHashMap::new();
+    // structs needed to get delegated voters
+    let mut all_current_delegated_voter = AHashMap::new();
+    let mut all_vote_delegation_handle_to_pool_address = AHashMap::new();
+
+    for txn in transactions {
+        // Add votes data
+        let current_stake_pool_voter = CurrentStakingPoolVoter::from_transaction(txn).unwrap();
+        all_current_stake_pool_voters.extend(current_stake_pool_voter);
+        let mut proposal_votes = ProposalVote::from_transaction(txn).unwrap();
+        all_proposal_votes.append(&mut proposal_votes);
+
+        // Add delegator activities
+        let mut delegator_activities = DelegatedStakingActivity::from_transaction(txn).unwrap();
+        all_delegator_activities.append(&mut delegator_activities);
+
+        // Add delegator pools
+        let (delegator_pools, mut delegator_pool_balances, current_delegator_pool_balances) =
+            DelegatorPool::from_transaction(txn).unwrap();
+        all_delegator_pools.extend(delegator_pools);
+        all_delegator_pool_balances.append(&mut delegator_pool_balances);
+        all_current_delegator_pool_balances.extend(current_delegator_pool_balances);
+
+        // Moving the transaction code here is the new paradigm to avoid redoing a lot of the duplicate work
+        // Currently only delegator voting follows this paradigm
+        // TODO: refactor all the other staking code to follow this paradigm
+        let txn_version = txn.version as i64;
+        let txn_timestamp = parse_timestamp(txn.timestamp.as_ref().unwrap(), txn_version);
+        let transaction_info = txn.info.as_ref().expect("Transaction info doesn't exist!");
+        // adding some metadata for subsequent parsing
+        for wsc in &transaction_info.changes {
+            if let Change::WriteResource(write_resource) = wsc.change.as_ref().unwrap() {
+                if let Some(DelegationVoteGovernanceRecordsResource::GovernanceRecords(inner)) =
+                    DelegationVoteGovernanceRecordsResource::from_write_resource(
+                        write_resource,
+                        txn_version,
+                    )?
+                {
+                    let delegation_pool_address =
+                        standardize_address(&write_resource.address.to_string());
+                    let vote_delegation_handle = inner.vote_delegation.buckets.inner.get_handle();
+
+                    all_vote_delegation_handle_to_pool_address
+                        .insert(vote_delegation_handle, delegation_pool_address.clone());
+                }
+                if let Some(map) = CurrentDelegatorBalance::get_active_pool_to_staking_pool_mapping(
+                    write_resource,
+                    txn_version,
+                )
+                .unwrap()
+                {
+                    active_pool_to_staking_pool.extend(map);
+                }
+            }
+        }
+
+        // Add delegator balances
+        let (mut delegator_balances, current_delegator_balances) =
+            CurrentDelegatorBalance::from_transaction(
+                txn,
+                &active_pool_to_staking_pool,
+                &mut conn,
+                query_retries,
+                query_retry_delay_ms,
+            )
+            .await
+            .unwrap();
+        all_delegator_balances.append(&mut delegator_balances);
+        all_current_delegator_balances.extend(current_delegator_balances);
+
+        // this write table item indexing is to get delegator address, table handle, and voter & pending voter
+        for wsc in &transaction_info.changes {
+            if let Change::WriteTableItem(write_table_item) = wsc.change.as_ref().unwrap() {
+                let voter_map = CurrentDelegatedVoter::from_write_table_item(
+                    write_table_item,
+                    txn_version,
+                    txn_timestamp,
+                    &all_vote_delegation_handle_to_pool_address,
+                    &mut conn,
+                    query_retries,
+                    query_retry_delay_ms,
+                )
+                .await
+                .unwrap();
+
+                all_current_delegated_voter.extend(voter_map);
+            }
+        }
+
+        // we need one last loop to prefill delegators that got in before the delegated voting contract was deployed
+        for wsc in &transaction_info.changes {
+            if let Change::WriteTableItem(write_table_item) = wsc.change.as_ref().unwrap() {
+                if let Some(voter) = CurrentDelegatedVoter::get_delegators_pre_contract_deployment(
+                    write_table_item,
+                    txn_version,
+                    txn_timestamp,
+                    &active_pool_to_staking_pool,
+                    &all_current_delegated_voter,
+                    &mut conn,
+                    query_retries,
+                    query_retry_delay_ms,
+                )
+                .await
+                .unwrap()
+                {
+                    all_current_delegated_voter.insert(voter.pk(), voter);
+                }
+            }
+        }
+    }
+
+    // Getting list of values and sorting by pk in order to avoid postgres deadlock since we're doing multi threaded db writes
+    let mut all_current_stake_pool_voters = all_current_stake_pool_voters
+        .into_values()
+        .collect::<Vec<CurrentStakingPoolVoter>>();
+    let mut all_current_delegator_balances = all_current_delegator_balances
+        .into_values()
+        .collect::<Vec<CurrentDelegatorBalance>>();
+    let mut all_delegator_pools = all_delegator_pools
+        .into_values()
+        .collect::<Vec<DelegatorPool>>();
+    let mut all_current_delegator_pool_balances = all_current_delegator_pool_balances
+        .into_values()
+        .collect::<Vec<CurrentDelegatorPoolBalance>>();
+    let mut all_current_delegated_voter = all_current_delegated_voter
+        .into_values()
+        .collect::<Vec<CurrentDelegatedVoter>>();
+
+    // Sort by PK
+    all_current_stake_pool_voters
+        .sort_by(|a, b| a.staking_pool_address.cmp(&b.staking_pool_address));
+    all_current_delegator_balances.sort_by(|a, b| {
+        (&a.delegator_address, &a.pool_address, &a.pool_type).cmp(&(
+            &b.delegator_address,
+            &b.pool_address,
+            &b.pool_type,
+        ))
+    });
+
+    all_delegator_pools.sort_by(|a, b| a.staking_pool_address.cmp(&b.staking_pool_address));
+    all_current_delegator_pool_balances
+        .sort_by(|a, b| a.staking_pool_address.cmp(&b.staking_pool_address));
+    all_current_delegated_voter.sort();
+
+    Ok((
+        all_current_stake_pool_voters,
+        all_proposal_votes,
+        all_delegator_activities,
+        all_delegator_balances,
+        all_current_delegator_balances,
+        all_delegator_pools,
+        all_delegator_pool_balances,
+        all_current_delegator_pool_balances,
+        all_current_delegated_voter,
+    ))
+}
+
 #[async_trait]
 impl ProcessorTrait for StakeProcessor {
     fn name(&self) -> &'static str {
@@ -398,164 +583,33 @@ impl ProcessorTrait for StakeProcessor {
         let processing_start = std::time::Instant::now();
         let last_transaction_timestamp = transactions.last().unwrap().timestamp.clone();
 
-        let mut conn = self.get_conn().await;
+        let conn = self.get_conn().await;
         let query_retries = self.config.query_retries;
         let query_retry_delay_ms = self.config.query_retry_delay_ms;
 
-        let mut all_current_stake_pool_voters: StakingPoolVoterMap = AHashMap::new();
-        let mut all_proposal_votes = vec![];
-        let mut all_delegator_activities = vec![];
-        let mut all_delegator_balances = vec![];
-        let mut all_current_delegator_balances: CurrentDelegatorBalanceMap = AHashMap::new();
-        let mut all_delegator_pools: DelegatorPoolMap = AHashMap::new();
-        let mut all_delegator_pool_balances = vec![];
-        let mut all_current_delegator_pool_balances = AHashMap::new();
-
-        let mut active_pool_to_staking_pool = AHashMap::new();
-        // structs needed to get delegated voters
-        let mut all_current_delegated_voter = AHashMap::new();
-        let mut all_vote_delegation_handle_to_pool_address = AHashMap::new();
-
-        for txn in &transactions {
-            // Add votes data
-            let current_stake_pool_voter = CurrentStakingPoolVoter::from_transaction(txn).unwrap();
-            all_current_stake_pool_voters.extend(current_stake_pool_voter);
-            let mut proposal_votes = ProposalVote::from_transaction(txn).unwrap();
-            all_proposal_votes.append(&mut proposal_votes);
-
-            // Add delegator activities
-            let mut delegator_activities = DelegatedStakingActivity::from_transaction(txn).unwrap();
-            all_delegator_activities.append(&mut delegator_activities);
-
-            // Add delegator pools
-            let (delegator_pools, mut delegator_pool_balances, current_delegator_pool_balances) =
-                DelegatorPool::from_transaction(txn).unwrap();
-            all_delegator_pools.extend(delegator_pools);
-            all_delegator_pool_balances.append(&mut delegator_pool_balances);
-            all_current_delegator_pool_balances.extend(current_delegator_pool_balances);
-
-            // Moving the transaction code here is the new paradigm to avoid redoing a lot of the duplicate work
-            // Currently only delegator voting follows this paradigm
-            // TODO: refactor all the other staking code to follow this paradigm
-            let txn_version = txn.version as i64;
-            let txn_timestamp = parse_timestamp(txn.timestamp.as_ref().unwrap(), txn_version);
-            let transaction_info = txn.info.as_ref().expect("Transaction info doesn't exist!");
-            // adding some metadata for subsequent parsing
-            for wsc in &transaction_info.changes {
-                if let Change::WriteResource(write_resource) = wsc.change.as_ref().unwrap() {
-                    if let Some(DelegationVoteGovernanceRecordsResource::GovernanceRecords(inner)) =
-                        DelegationVoteGovernanceRecordsResource::from_write_resource(
-                            write_resource,
-                            txn_version,
-                        )?
-                    {
-                        let delegation_pool_address =
-                            standardize_address(&write_resource.address.to_string());
-                        let vote_delegation_handle =
-                            inner.vote_delegation.buckets.inner.get_handle();
-
-                        all_vote_delegation_handle_to_pool_address
-                            .insert(vote_delegation_handle, delegation_pool_address.clone());
-                    }
-                    if let Some(map) =
-                        CurrentDelegatorBalance::get_active_pool_to_staking_pool_mapping(
-                            write_resource,
-                            txn_version,
-                        )
-                        .unwrap()
-                    {
-                        active_pool_to_staking_pool.extend(map);
-                    }
-                }
-            }
-
-            // Add delegator balances
-            let (mut delegator_balances, current_delegator_balances) =
-                CurrentDelegatorBalance::from_transaction(
-                    txn,
-                    &active_pool_to_staking_pool,
-                    &mut conn,
-                    query_retries,
-                    query_retry_delay_ms,
-                )
-                .await
-                .unwrap();
-            all_delegator_balances.append(&mut delegator_balances);
-            all_current_delegator_balances.extend(current_delegator_balances);
-
-            // this write table item indexing is to get delegator address, table handle, and voter & pending voter
-            for wsc in &transaction_info.changes {
-                if let Change::WriteTableItem(write_table_item) = wsc.change.as_ref().unwrap() {
-                    let voter_map = CurrentDelegatedVoter::from_write_table_item(
-                        write_table_item,
-                        txn_version,
-                        txn_timestamp,
-                        &all_vote_delegation_handle_to_pool_address,
-                        &mut conn,
-                        query_retries,
-                        query_retry_delay_ms,
-                    )
-                    .await
-                    .unwrap();
-
-                    all_current_delegated_voter.extend(voter_map);
-                }
-            }
-
-            // we need one last loop to prefill delegators that got in before the delegated voting contract was deployed
-            for wsc in &transaction_info.changes {
-                if let Change::WriteTableItem(write_table_item) = wsc.change.as_ref().unwrap() {
-                    if let Some(voter) =
-                        CurrentDelegatedVoter::get_delegators_pre_contract_deployment(
-                            write_table_item,
-                            txn_version,
-                            txn_timestamp,
-                            &active_pool_to_staking_pool,
-                            &all_current_delegated_voter,
-                            &mut conn,
-                            query_retries,
-                            query_retry_delay_ms,
-                        )
-                        .await
-                        .unwrap()
-                    {
-                        all_current_delegated_voter.insert(voter.pk(), voter);
-                    }
-                }
-            }
-        }
-
-        // Getting list of values and sorting by pk in order to avoid postgres deadlock since we're doing multi threaded db writes
-        let mut all_current_stake_pool_voters = all_current_stake_pool_voters
-            .into_values()
-            .collect::<Vec<CurrentStakingPoolVoter>>();
-        let mut all_current_delegator_balances = all_current_delegator_balances
-            .into_values()
-            .collect::<Vec<CurrentDelegatorBalance>>();
-        let mut all_delegator_pools = all_delegator_pools
-            .into_values()
-            .collect::<Vec<DelegatorPool>>();
-        let mut all_current_delegator_pool_balances = all_current_delegator_pool_balances
-            .into_values()
-            .collect::<Vec<CurrentDelegatorPoolBalance>>();
-        let mut all_current_delegated_voter = all_current_delegated_voter
-            .into_values()
-            .collect::<Vec<CurrentDelegatedVoter>>();
-
-        // Sort by PK
-        all_current_stake_pool_voters
-            .sort_by(|a, b| a.staking_pool_address.cmp(&b.staking_pool_address));
-        all_current_delegator_balances.sort_by(|a, b| {
-            (&a.delegator_address, &a.pool_address, &a.pool_type).cmp(&(
-                &b.delegator_address,
-                &b.pool_address,
-                &b.pool_type,
-            ))
-        });
-        all_delegator_pools.sort_by(|a, b| a.staking_pool_address.cmp(&b.staking_pool_address));
-        all_current_delegator_pool_balances
-            .sort_by(|a, b| a.staking_pool_address.cmp(&b.staking_pool_address));
-        all_current_delegated_voter.sort();
+        let (
+            all_current_stake_pool_voters,
+            all_proposal_votes,
+            all_delegator_activities,
+            all_delegator_balances,
+            all_current_delegator_balances,
+            all_delegator_pools,
+            all_delegator_pool_balances,
+            all_current_delegator_pool_balances,
+            all_current_delegated_voter,
+        ) = match parse_stake_data(&transactions, conn, query_retries, query_retry_delay_ms).await {
+            Ok(data) => data,
+            Err(e) => {
+                error!(
+                    start_version = start_version,
+                    end_version = end_version,
+                    processor_name = self.name(),
+                    error = ?e,
+                    "[Parser] Error parsing stake data",
+                );
+                bail!(e)
+            },
+        };
 
         let processing_duration_in_secs = processing_start.elapsed().as_secs_f64();
         let db_insertion_start = std::time::Instant::now();

--- a/rust/sdk-processor/src/config/indexer_processor_config.rs
+++ b/rust/sdk-processor/src/config/indexer_processor_config.rs
@@ -4,6 +4,7 @@
 use super::{db_config::DbConfig, processor_config::ProcessorConfig};
 use crate::processors::{
     events_processor::EventsProcessor, fungible_asset_processor::FungibleAssetProcessor,
+    stake_processor::StakeProcessor,
 };
 use anyhow::Result;
 use aptos_indexer_processor_sdk::{
@@ -12,6 +13,9 @@ use aptos_indexer_processor_sdk::{
 };
 use aptos_indexer_processor_sdk_server_framework::RunnableConfig;
 use serde::{Deserialize, Serialize};
+
+pub const QUERY_DEFAULT_RETRIES: u32 = 5;
+pub const QUERY_DEFAULT_RETRY_DELAY_MS: u64 = 500;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -33,6 +37,10 @@ impl RunnableConfig for IndexerProcessorConfig {
             ProcessorConfig::FungibleAssetProcessor(_) => {
                 let fungible_asset_processor = FungibleAssetProcessor::new(self.clone()).await?;
                 fungible_asset_processor.run_processor().await
+            },
+            ProcessorConfig::StakeProcessor(_) => {
+                let stake_processor = StakeProcessor::new(self.clone()).await?;
+                stake_processor.run_processor().await
             },
         }
     }

--- a/rust/sdk-processor/src/config/processor_config.rs
+++ b/rust/sdk-processor/src/config/processor_config.rs
@@ -1,8 +1,7 @@
+use crate::processors::stake_processor::StakeProcessorConfig;
 use ahash::AHashMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-
-use crate::processors::stake_processor::StakeProcessorConfig;
 
 /// This enum captures the configs for all the different processors that are defined.
 ///

--- a/rust/sdk-processor/src/config/processor_config.rs
+++ b/rust/sdk-processor/src/config/processor_config.rs
@@ -2,6 +2,8 @@ use ahash::AHashMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
+use crate::processors::stake_processor::StakeProcessorConfig;
+
 /// This enum captures the configs for all the different processors that are defined.
 ///
 /// The configs for each processor should only contain configuration specific to that
@@ -37,6 +39,7 @@ use std::collections::HashSet;
 pub enum ProcessorConfig {
     EventsProcessor(DefaultProcessorConfig),
     FungibleAssetProcessor(DefaultProcessorConfig),
+    StakeProcessor(StakeProcessorConfig),
 }
 
 impl ProcessorConfig {
@@ -64,5 +67,15 @@ pub struct DefaultProcessorConfig {
 impl DefaultProcessorConfig {
     pub const fn default_channel_size() -> usize {
         10
+    }
+}
+
+impl Default for DefaultProcessorConfig {
+    fn default() -> Self {
+        Self {
+            per_table_chunk_sizes: AHashMap::new(),
+            channel_size: Self::default_channel_size(),
+            deprecated_tables: HashSet::new(),
+        }
     }
 }

--- a/rust/sdk-processor/src/processors/mod.rs
+++ b/rust/sdk-processor/src/processors/mod.rs
@@ -1,2 +1,3 @@
 pub mod events_processor;
 pub mod fungible_asset_processor;
+pub mod stake_processor;

--- a/rust/sdk-processor/src/processors/stake_processor.rs
+++ b/rust/sdk-processor/src/processors/stake_processor.rs
@@ -1,0 +1,160 @@
+use crate::{
+    config::{
+        db_config::DbConfig,
+        indexer_processor_config::{
+            IndexerProcessorConfig, QUERY_DEFAULT_RETRIES, QUERY_DEFAULT_RETRY_DELAY_MS,
+        },
+        processor_config::{DefaultProcessorConfig, ProcessorConfig},
+    },
+    steps::{
+        common::get_processor_status_saver,
+        stake_processor::{StakeExtractor, StakeStorer},
+    },
+    utils::{
+        chain_id::check_or_update_chain_id,
+        database::{new_db_pool, run_migrations, ArcDbPool},
+        starting_version::get_starting_version,
+    },
+};
+use anyhow::Result;
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::{TransactionStream, TransactionStreamConfig},
+    builder::ProcessorBuilder,
+    common_steps::{
+        TransactionStreamStep, VersionTrackerStep, DEFAULT_UPDATE_PROCESSOR_STATUS_SECS,
+    },
+    traits::{processor_trait::ProcessorTrait, IntoRunnableStep},
+};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct StakeProcessorConfig {
+    #[serde(flatten)]
+    pub default_config: DefaultProcessorConfig,
+    #[serde(default = "StakeProcessorConfig::default_query_retries")]
+    pub query_retries: u32,
+    #[serde(default = "StakeProcessorConfig::default_query_retry_delay_ms")]
+    pub query_retry_delay_ms: u64,
+}
+
+impl StakeProcessorConfig {
+    pub const fn default_query_retries() -> u32 {
+        QUERY_DEFAULT_RETRIES
+    }
+
+    pub const fn default_query_retry_delay_ms() -> u64 {
+        QUERY_DEFAULT_RETRY_DELAY_MS
+    }
+}
+
+pub struct StakeProcessor {
+    pub config: IndexerProcessorConfig,
+    pub db_pool: ArcDbPool,
+}
+
+impl StakeProcessor {
+    pub async fn new(config: IndexerProcessorConfig) -> Result<Self> {
+        match config.db_config {
+            DbConfig::PostgresConfig(ref postgres_config) => {
+                let conn_pool = new_db_pool(
+                    &postgres_config.connection_string,
+                    Some(postgres_config.db_pool_size),
+                )
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to create connection pool for PostgresConfig: {:?}",
+                        e
+                    )
+                })?;
+
+                Ok(Self {
+                    config,
+                    db_pool: conn_pool,
+                })
+            },
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProcessorTrait for StakeProcessor {
+    fn name(&self) -> &'static str {
+        self.config.processor_config.name()
+    }
+
+    async fn run_processor(&self) -> Result<()> {
+        //  Run migrations
+        match self.config.db_config {
+            DbConfig::PostgresConfig(ref postgres_config) => {
+                run_migrations(
+                    postgres_config.connection_string.clone(),
+                    self.db_pool.clone(),
+                )
+                .await;
+            },
+        }
+
+        // Merge the starting version from config and the latest processed version from the DB
+        let starting_version = get_starting_version(&self.config, self.db_pool.clone()).await?;
+
+        // Check and update the ledger chain id to ensure we're indexing the correct chain
+        let grpc_chain_id = TransactionStream::new(self.config.transaction_stream_config.clone())
+            .await?
+            .get_chain_id()
+            .await?;
+        check_or_update_chain_id(grpc_chain_id as i64, self.db_pool.clone()).await?;
+
+        let processor_config = match &self.config.processor_config {
+            ProcessorConfig::StakeProcessor(processor_config) => processor_config,
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Processor config is wrong type for StakeProcessor"
+                ))
+            },
+        };
+        let channel_size = processor_config.default_config.channel_size;
+
+        // Define processor steps
+        let transaction_stream = TransactionStreamStep::new(TransactionStreamConfig {
+            starting_version: Some(starting_version),
+            ..self.config.transaction_stream_config.clone()
+        })
+        .await?;
+        let extractor = StakeExtractor::new(
+            self.db_pool.clone(),
+            processor_config.query_retries,
+            processor_config.query_retry_delay_ms,
+        );
+        let storer = StakeStorer::new(self.db_pool.clone(), processor_config.clone());
+        let version_tracker = VersionTrackerStep::new(
+            get_processor_status_saver(self.db_pool.clone(), self.config.clone()),
+            DEFAULT_UPDATE_PROCESSOR_STATUS_SECS,
+        );
+        // Connect processor steps together
+        let (_, buffer_receiver) = ProcessorBuilder::new_with_inputless_first_step(
+            transaction_stream.into_runnable_step(),
+        )
+        .connect_to(extractor.into_runnable_step(), channel_size)
+        .connect_to(storer.into_runnable_step(), channel_size)
+        .connect_to(version_tracker.into_runnable_step(), channel_size)
+        .end_and_return_output_receiver(channel_size);
+
+        loop {
+            match buffer_receiver.recv().await {
+                Ok(txn_context) => {
+                    debug!(
+                        "Finished processing versions [{:?}, {:?}]",
+                        txn_context.metadata.start_version, txn_context.metadata.end_version,
+                    );
+                },
+                Err(e) => {
+                    info!("No more transactions in channel: {:?}", e);
+                    break Ok(());
+                },
+            }
+        }
+    }
+}

--- a/rust/sdk-processor/src/steps/mod.rs
+++ b/rust/sdk-processor/src/steps/mod.rs
@@ -1,3 +1,4 @@
 pub mod common;
 pub mod events_processor;
 pub mod fungible_asset_processor;
+pub mod stake_processor;

--- a/rust/sdk-processor/src/steps/stake_processor/mod.rs
+++ b/rust/sdk-processor/src/steps/stake_processor/mod.rs
@@ -1,0 +1,5 @@
+pub mod stake_extractor;
+pub mod stake_storer;
+
+pub use stake_extractor::StakeExtractor;
+pub use stake_storer::StakeStorer;

--- a/rust/sdk-processor/src/steps/stake_processor/stake_extractor.rs
+++ b/rust/sdk-processor/src/steps/stake_processor/stake_extractor.rs
@@ -1,0 +1,147 @@
+use crate::utils::database::ArcDbPool;
+use aptos_indexer_processor_sdk::{
+    aptos_protos::transaction::v1::Transaction,
+    traits::{async_step::AsyncRunType, AsyncStep, NamedStep, Processable},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+use processor::{
+    db::common::models::stake_models::{
+        current_delegated_voter::CurrentDelegatedVoter,
+        delegator_activities::DelegatedStakingActivity,
+        delegator_balances::{CurrentDelegatorBalance, DelegatorBalance},
+        delegator_pools::{CurrentDelegatorPoolBalance, DelegatorPool, DelegatorPoolBalance},
+        proposal_votes::ProposalVote,
+        staking_pool_voter::CurrentStakingPoolVoter,
+    },
+    processors::stake_processor::parse_stake_data,
+};
+use tracing::error;
+
+pub struct StakeExtractor
+where
+    Self: Sized + Send + 'static,
+{
+    conn_pool: ArcDbPool,
+    query_retries: u32,
+    query_retry_delay_ms: u64,
+}
+
+impl StakeExtractor {
+    pub fn new(conn_pool: ArcDbPool, query_retries: u32, query_retry_delay_ms: u64) -> Self {
+        Self {
+            conn_pool,
+            query_retries,
+            query_retry_delay_ms,
+        }
+    }
+}
+
+#[async_trait]
+impl Processable for StakeExtractor {
+    type Input = Vec<Transaction>;
+    type Output = (
+        Vec<CurrentStakingPoolVoter>,
+        Vec<ProposalVote>,
+        Vec<DelegatedStakingActivity>,
+        Vec<DelegatorBalance>,
+        Vec<CurrentDelegatorBalance>,
+        Vec<DelegatorPool>,
+        Vec<DelegatorPoolBalance>,
+        Vec<CurrentDelegatorPoolBalance>,
+        Vec<CurrentDelegatedVoter>,
+    );
+    type RunType = AsyncRunType;
+
+    /// Processes a batch of transactions and extracts relevant staking data.
+    ///
+    /// This function processes a batch of transactions, extracting various types of staking-related
+    /// data such as current staking pool voters, proposal votes, delegated staking activities,
+    /// delegator balances, and more. The extracted data is then returned in a `TransactionContext`
+    /// for further processing or storage.
+    async fn process(
+        &mut self,
+        transactions: TransactionContext<Vec<Transaction>>,
+    ) -> Result<
+        Option<
+            TransactionContext<(
+                Vec<CurrentStakingPoolVoter>,
+                Vec<ProposalVote>,
+                Vec<DelegatedStakingActivity>,
+                Vec<DelegatorBalance>,
+                Vec<CurrentDelegatorBalance>,
+                Vec<DelegatorPool>,
+                Vec<DelegatorPoolBalance>,
+                Vec<CurrentDelegatorPoolBalance>,
+                Vec<CurrentDelegatedVoter>,
+            )>,
+        >,
+        ProcessorError,
+    > {
+        let conn = self
+            .conn_pool
+            .get()
+            .await
+            .map_err(|e| ProcessorError::DBStoreError {
+                message: format!("Failed to get connection from pool: {:?}", e),
+                query: None,
+            })?;
+
+        let (
+            all_current_stake_pool_voters,
+            all_proposal_votes,
+            all_delegator_activities,
+            all_delegator_balances,
+            all_current_delegator_balances,
+            all_delegator_pools,
+            all_delegator_pool_balances,
+            all_current_delegator_pool_balances,
+            all_current_delegated_voter,
+        ) = match parse_stake_data(
+            &transactions.data,
+            conn,
+            self.query_retries,
+            self.query_retry_delay_ms,
+        )
+        .await
+        {
+            Ok(data) => data,
+            Err(e) => {
+                error!(
+                    start_version = transactions.metadata.start_version,
+                    end_version = transactions.metadata.end_version,
+                    processor_name = self.name(),
+                    error = ?e,
+                    "[Parser] Error parsing stake data",
+                );
+                return Err(ProcessorError::ProcessError {
+                    message: format!("Error parsing stake data: {:?}", e),
+                });
+            },
+        };
+
+        Ok(Some(TransactionContext {
+            data: (
+                all_current_stake_pool_voters,
+                all_proposal_votes,
+                all_delegator_activities,
+                all_delegator_balances,
+                all_current_delegator_balances,
+                all_delegator_pools,
+                all_delegator_pool_balances,
+                all_current_delegator_pool_balances,
+                all_current_delegated_voter,
+            ),
+            metadata: transactions.metadata,
+        }))
+    }
+}
+
+impl AsyncStep for StakeExtractor {}
+
+impl NamedStep for StakeExtractor {
+    fn name(&self) -> String {
+        "StakeExtractor".to_string()
+    }
+}

--- a/rust/sdk-processor/src/steps/stake_processor/stake_storer.rs
+++ b/rust/sdk-processor/src/steps/stake_processor/stake_storer.rs
@@ -185,6 +185,6 @@ impl AsyncStep for StakeStorer {}
 
 impl NamedStep for StakeStorer {
     fn name(&self) -> String {
-        "FungibleAssetStorer".to_string()
+        "StakeStorer".to_string()
     }
 }

--- a/rust/sdk-processor/src/steps/stake_processor/stake_storer.rs
+++ b/rust/sdk-processor/src/steps/stake_processor/stake_storer.rs
@@ -1,0 +1,188 @@
+use crate::processors::stake_processor::StakeProcessorConfig;
+use crate::utils::database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool};
+use ahash::AHashMap;
+use anyhow::Result;
+use aptos_indexer_processor_sdk::{
+    traits::{async_step::AsyncRunType, AsyncStep, NamedStep, Processable},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+use processor::{
+    db::common::models::stake_models::{
+        current_delegated_voter::CurrentDelegatedVoter,
+        delegator_activities::DelegatedStakingActivity,
+        delegator_balances::{CurrentDelegatorBalance, DelegatorBalance},
+        delegator_pools::{CurrentDelegatorPoolBalance, DelegatorPool, DelegatorPoolBalance},
+        proposal_votes::ProposalVote,
+        staking_pool_voter::CurrentStakingPoolVoter,
+    },
+    processors::stake_processor::{
+        insert_current_delegated_voter_query, insert_current_delegator_balances_query,
+        insert_current_delegator_pool_balances_query, insert_current_stake_pool_voter_query,
+        insert_delegator_activities_query, insert_delegator_balances_query,
+        insert_delegator_pool_balances_query, insert_delegator_pools_query,
+        insert_proposal_votes_query,
+    },
+};
+
+pub struct StakeStorer
+where
+    Self: Sized + Send + 'static,
+{
+    conn_pool: ArcDbPool,
+    processor_config: StakeProcessorConfig,
+}
+
+impl StakeStorer {
+    pub fn new(conn_pool: ArcDbPool, processor_config: StakeProcessorConfig) -> Self {
+        Self {
+            conn_pool,
+            processor_config,
+        }
+    }
+}
+
+#[async_trait]
+impl Processable for StakeStorer {
+    type Input = (
+        Vec<CurrentStakingPoolVoter>,
+        Vec<ProposalVote>,
+        Vec<DelegatedStakingActivity>,
+        Vec<DelegatorBalance>,
+        Vec<CurrentDelegatorBalance>,
+        Vec<DelegatorPool>,
+        Vec<DelegatorPoolBalance>,
+        Vec<CurrentDelegatorPoolBalance>,
+        Vec<CurrentDelegatedVoter>,
+    );
+    type Output = ();
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        input: TransactionContext<(
+            Vec<CurrentStakingPoolVoter>,
+            Vec<ProposalVote>,
+            Vec<DelegatedStakingActivity>,
+            Vec<DelegatorBalance>,
+            Vec<CurrentDelegatorBalance>,
+            Vec<DelegatorPool>,
+            Vec<DelegatorPoolBalance>,
+            Vec<CurrentDelegatorPoolBalance>,
+            Vec<CurrentDelegatedVoter>,
+        )>,
+    ) -> Result<Option<TransactionContext<Self::Output>>, ProcessorError> {
+        let per_table_chunk_sizes: AHashMap<String, usize> = self
+            .processor_config
+            .default_config
+            .per_table_chunk_sizes
+            .clone();
+
+        let (
+            current_stake_pool_voters,
+            proposal_votes,
+            delegator_activities,
+            delegator_balances,
+            current_delegator_balances,
+            delegator_pools,
+            delegator_pool_balances,
+            current_delegator_pool_balances,
+            current_delegated_voter,
+        ) = input.data;
+
+        let cspv = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_current_stake_pool_voter_query,
+            &current_stake_pool_voters,
+            get_config_table_chunk_size::<CurrentStakingPoolVoter>(
+                "current_staking_pool_voter",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let pv = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_proposal_votes_query,
+            &proposal_votes,
+            get_config_table_chunk_size::<ProposalVote>("proposal_votes", &per_table_chunk_sizes),
+        );
+        let da = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_delegator_activities_query,
+            &delegator_activities,
+            get_config_table_chunk_size::<DelegatedStakingActivity>(
+                "delegated_staking_activities",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let db = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_delegator_balances_query,
+            &delegator_balances,
+            get_config_table_chunk_size::<DelegatorBalance>(
+                "delegator_balances",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let cdb = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_current_delegator_balances_query,
+            &current_delegator_balances,
+            get_config_table_chunk_size::<CurrentDelegatorBalance>(
+                "current_delegator_balances",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let dp = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_delegator_pools_query,
+            &delegator_pools,
+            get_config_table_chunk_size::<DelegatorPool>(
+                "delegated_staking_pools",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let dpb = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_delegator_pool_balances_query,
+            &delegator_pool_balances,
+            get_config_table_chunk_size::<DelegatorPoolBalance>(
+                "delegated_staking_pool_balances",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let cdpb = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_current_delegator_pool_balances_query,
+            &current_delegator_pool_balances,
+            get_config_table_chunk_size::<CurrentDelegatorPoolBalance>(
+                "current_delegated_staking_pool_balances",
+                &per_table_chunk_sizes,
+            ),
+        );
+        let cdv = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_current_delegated_voter_query,
+            &current_delegated_voter,
+            get_config_table_chunk_size::<CurrentDelegatedVoter>(
+                "current_delegated_voter",
+                &per_table_chunk_sizes,
+            ),
+        );
+
+        futures::try_join!(cspv, pv, da, db, cdb, dp, dpb, cdpb, cdv)?;
+
+        Ok(Some(TransactionContext {
+            data: (),
+            metadata: input.metadata,
+        }))
+    }
+}
+
+impl AsyncStep for StakeStorer {}
+
+impl NamedStep for StakeStorer {
+    fn name(&self) -> String {
+        "FungibleAssetStorer".to_string()
+    }
+}

--- a/rust/sdk-processor/src/steps/stake_processor/stake_storer.rs
+++ b/rust/sdk-processor/src/steps/stake_processor/stake_storer.rs
@@ -1,5 +1,7 @@
-use crate::processors::stake_processor::StakeProcessorConfig;
-use crate::utils::database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool};
+use crate::{
+    processors::stake_processor::StakeProcessorConfig,
+    utils::database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool},
+};
 use ahash::AHashMap;
 use anyhow::Result;
 use aptos_indexer_processor_sdk::{


### PR DESCRIPTION
## Purpose
- Refactor existing stake processor to locate all parsing logic in `parse_stake_data`.
- Rewrite stake processor using the sdk
- add new, non-default ProcessorConfig called StakeProcessorConfig that contains additional fields to the default one. Namely, query_retries, query_retry_delay_ms.

## Testing
![image](https://github.com/user-attachments/assets/23bc7f3e-fe4a-4e8b-871b-0863339b0c94)
