### PR TITLE
[parquet-sdk-migration] add a logic to determine the starting version for parquet processor

### DIFF
--- a/rust/sdk-processor/src/parquet_processors/mod.rs
+++ b/rust/sdk-processor/src/parquet_processors/mod.rs
@@ -1,1 +1,87 @@
+use processor::db::common::models::default_models::{
+    parquet_move_modules::MoveModule, parquet_move_resources::MoveResource,
+    parquet_move_tables::TableItem, parquet_transactions::Transaction as ParquetTransaction,
+    parquet_write_set_changes::WriteSetChangeModel,
+};
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumIter};
+
 pub mod parquet_default_processor;
+
+/// Enum representing the different types of Parquet files that can be processed.
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Display, EnumIter)]
+#[cfg_attr(
+    test,
+    derive(strum::EnumDiscriminants),
+    strum_discriminants(
+        derive(
+            strum::EnumVariantNames,
+            Deserialize,
+            Serialize,
+            strum::IntoStaticStr,
+            strum::Display,
+            clap::ValueEnum
+        ),
+        name(ParquetTypeName),
+        strum(serialize_all = "snake_case")
+    )
+)]
+pub enum ParquetTypeEnum {
+    MoveResource,
+    WriteSetChange,
+    Transaction,
+    TableItem,
+    MoveModule,
+}
+
+#[derive(Clone, Debug, strum::EnumDiscriminants)]
+#[strum(serialize_all = "snake_case")]
+#[strum_discriminants(
+    derive(
+        Deserialize,
+        Serialize,
+        strum::EnumVariantNames,
+        strum::IntoStaticStr,
+        strum::Display,
+        clap::ValueEnum
+    ),
+    name(ParquetTypeStructName),
+    clap(rename_all = "snake_case"),
+    serde(rename_all = "snake_case"),
+    strum(serialize_all = "snake_case")
+)]
+pub enum ParquetTypeStructs {
+    MoveResource(Vec<MoveResource>),
+    WriteSetChange(Vec<WriteSetChangeModel>),
+    Transaction(Vec<ParquetTransaction>),
+    TableItem(Vec<TableItem>),
+    MoveModule(Vec<MoveModule>),
+}
+
+impl ParquetTypeStructs {
+    pub fn default_for_type(parquet_type: &ParquetTypeEnum) -> Self {
+        match parquet_type {
+            ParquetTypeEnum::MoveResource => ParquetTypeStructs::MoveResource(Vec::new()),
+            ParquetTypeEnum::WriteSetChange => ParquetTypeStructs::WriteSetChange(Vec::new()),
+            ParquetTypeEnum::Transaction => ParquetTypeStructs::Transaction(Vec::new()),
+            ParquetTypeEnum::TableItem => ParquetTypeStructs::TableItem(Vec::new()),
+            ParquetTypeEnum::MoveModule => ParquetTypeStructs::MoveModule(Vec::new()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use strum::VariantNames;
+
+    /// This test exists to make sure that when a new processor is added, it is added
+    /// to both Processor and ProcessorConfig.
+    ///
+    /// To make sure this passes, make sure the variants are in the same order
+    /// (lexicographical) and the names match.
+    #[test]
+    fn test_parquet_type_names_complete() {
+        assert_eq!(ParquetTypeStructName::VARIANTS, ParquetTypeName::VARIANTS);
+    }
+}

--- a/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
+++ b/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
@@ -62,7 +62,6 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             },
         }
 
-        // TODO: Starting version from config. 0 if not set.
         // Determine the processing mode (backfill or regular)
         let is_backfill = self.config.backfill_config.is_some();
 

--- a/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
+++ b/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
@@ -62,6 +62,7 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             },
         }
 
+        // TODO: Starting version from config. 0 if not set.
         // Determine the processing mode (backfill or regular)
         let is_backfill = self.config.backfill_config.is_some();
 

--- a/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
+++ b/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
@@ -74,10 +74,8 @@ impl ProcessorTrait for ParquetDefaultProcessor {
                 .config
                 .processor_config
                 .get_table_names()
-                .context(format!(
-                    "Failed to get table names for the processor {}",
-                    self.config.processor_config.name()
-                ))?;
+                .context("Failed to get table names for the processor")?;
+
             get_min_last_success_version_parquet(&self.config, self.db_pool.clone(), table_names)
                 .await?;
         };


### PR DESCRIPTION
[parquet-sdk-migration] add a logic to determine the starting version for parquet processor

add docstring [Cand update the name of functions

fanout builder failing with send trait