### PR TITLE
[move-script] rename example_addr to test_addr

### DIFF
--- a/test_move_script/sources/modules/managed_fungible_asset.move
+++ b/test_move_script/sources/modules/managed_fungible_asset.move
@@ -361,7 +361,7 @@ module test_addr::managed_fungible_asset {
         object_from_constructor_ref<Metadata>(constructor_ref)
     }
 
-    #[test(creator = @example_addr)]
+    #[test(creator = @test_addr)]
     fun test_basic_flow(
         creator: &signer,
     ) acquires ManagingRefs {
@@ -406,7 +406,7 @@ module test_addr::managed_fungible_asset {
         assert!(primary_fungible_store::balance(aaron_address, metadata) == 0, 11);
     }
 
-    #[test(creator = @example_addr, aaron = @0xface)]
+    #[test(creator = @test_addr, aaron = @0xface)]
     #[expected_failure(abort_code = 0x50001, location = Self)]
     fun test_permission_denied(
         creator: &signer,


### PR DESCRIPTION
This PR makes a small change in managed_fungible_asset, renaming example_addr to test_addr to help the tests run smoothly.