### PR TITLE
[indexer-test-coverage] add test coverage ci

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,71 @@
+name: "Test_Coverage"
+on:
+  # Trigger if any of the conditions
+  #   1. Daily at 12am UTC from the main branch, or
+  #   2. PR with a specific label (see below)
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+
+# cancel redundant builds
+concurrency:
+  # cancel redundant builds on PRs (only on PR, not on branches)
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.ref) || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  rust-unit-coverage:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+      - uses: ./.github/actions/dep_install_and_lint
+        with:
+          working-directory: rust
+      - run: rustup component add llvm-tools-preview
+      - uses: taiki-e/install-action@4fedbddde88aab767a45a011661f832d68202716 # pin@v2.33.28
+        with:
+          tool: nextest,cargo-llvm-cov
+      - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
+      - run: cargo llvm-cov nextest --lcov --output-path lcov_unit.info -vv --ignore-run-fail --workspace
+        env:
+          INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
+          RUST_MIN_STACK: 33554432 # 32 MB of stack
+          MVP_TEST_ON_CI: true
+          SOLC_EXE: /home/runner/bin/solc
+          Z3_EXE: /home/runner/bin/z3
+          CVC5_EXE: /home/runner/bin/cvc5
+          DOTNET_ROOT: /home/runner/.dotnet
+          BOOGIE_EXE: /home/runner/.dotnet/tools/boogie
+        working-directory: rust
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lcov_unit
+          path: lcov_unit.info
+
+  upload-to-codecov:
+    runs-on: ubuntu-latest
+    continue-on-error: true # Don't fail if the codecov upload fails
+    #    env:
+    #      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    needs: [ rust-unit-coverage ]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: lcov_unit
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
+        with:
+          files: lcov_unit.info,lcov_smoke.info
+          fail_ci_if_error: true

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -29,9 +29,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
-      - uses: ./.github/actions/dep_install_and_lint
-        with:
-          working-directory: rust
+
+      - name: rust setup
+        run: |
+          sudo apt update && sudo apt install libdw-dev
+          cargo update
+        working-directory: rust
+
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@4fedbddde88aab767a45a011661f832d68202716 # pin@v2.33.28
         with:
@@ -48,24 +52,28 @@ jobs:
           DOTNET_ROOT: /home/runner/.dotnet
           BOOGIE_EXE: /home/runner/.dotnet/tools/boogie
         working-directory: rust
+      - run: ls -R
+        working-directory: rust
       - uses: actions/upload-artifact@v4
         with:
           name: lcov_unit
-          path: lcov_unit.info
+          path: rust/lcov_unit.info
 
   upload-to-codecov:
     runs-on: ubuntu-latest
     continue-on-error: true # Don't fail if the codecov upload fails
-    #    env:
-    #      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     needs: [ rust-unit-coverage ]
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: lcov_unit
-
+      - run: ls -R
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
         with:
-          files: lcov_unit.info,lcov_smoke.info
-          fail_ci_if_error: true
+          files: lcov_unit.info
+#          fail_ci_if_error: true
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![codecov](https://codecov.io/gh/aptos-labs/aptos-indexer-processors/graph/badge.svg?token=yOKOnndthm)](https://codecov.io/gh/aptos-labs/aptos-indexer-processors)
+
+
 # Aptos Indexer Client Guide
 
 This guide will get you started with creating an Aptos indexer with custom parsing. We have several endpoints that provided a streaming RPC of transaction data.


### PR DESCRIPTION
### Description
Introducing a CI workflow to track and report test coverage using cargo llvm-cov and integrates with Codecov for visualization. The workflow runs daily or on PRs, generates an lcov report, and uploads it to Codecov. It also updates the README.md to include a Codecov badge for coverage metrics. This aims to improve code quality by providing continuous visibility into test coverage and highlighting untested areas.


### Test Plan
https://app.codecov.io/github/aptos-labs/aptos-indexer-processors/tree/11-06-_indexer-test-coverage_add_test_coverage_ci

we can find our coverage here.


### Next Step
- will need to investigate if we can specify the directory we would like to track as a indexer coverage 
