### PR TITLE
Speed up tests by avoiding long lookups 

### DIFF
--- a/rust/integration-tests/src/sdk_tests/objects_processor_tests.rs
+++ b/rust/integration-tests/src/sdk_tests/objects_processor_tests.rs
@@ -29,8 +29,9 @@ pub fn setup_objects_processor_config(
 
     let objects_processor_config = ObjectsProcessorConfig {
         default_config: default_processor_config,
-        query_retries: ObjectsProcessorConfig::default_query_retries(),
-        query_retry_delay_ms: ObjectsProcessorConfig::default_query_retry_delay_ms(),
+        // Avoid doing long lookups in tests
+        query_retries: 1,
+        query_retry_delay_ms: 100,
     };
 
     let processor_config = ProcessorConfig::ObjectsProcessor(objects_processor_config);

--- a/rust/integration-tests/src/sdk_tests/stake_processor_tests.rs
+++ b/rust/integration-tests/src/sdk_tests/stake_processor_tests.rs
@@ -27,8 +27,9 @@ pub async fn setup_stake_processor_config(
             channel_size: 100,
             deprecated_tables: HashSet::new(),
         },
-        query_retries: 10,
-        query_retry_delay_ms: 1000,
+        // Avoid doing long lookups in tests
+        query_retries: 1,
+        query_retry_delay_ms: 100,
     };
 
     let processor_config = ProcessorConfig::StakeProcessor(default_processor_config);

--- a/rust/integration-tests/src/sdk_tests/token_v2_processor_tests.rs
+++ b/rust/integration-tests/src/sdk_tests/token_v2_processor_tests.rs
@@ -28,8 +28,9 @@ pub fn setup_token_v2_processor_config(
     };
     let token_v2_processor_config = TokenV2ProcessorConfig {
         default_config: default_processor_config,
-        query_retries: TokenV2ProcessorConfig::default_query_retries(),
-        query_retry_delay_ms: TokenV2ProcessorConfig::default_query_retry_delay_ms(),
+        // Avoid doing long lookups in tests
+        query_retries: 1,
+        query_retry_delay_ms: 100,
     };
 
     let processor_config = ProcessorConfig::TokenV2Processor(token_v2_processor_config);


### PR DESCRIPTION
## Description 

Single transaction test should not need to lookup any data in the DB since it won't exist anyway. Lower the lookup retries and wait time to speed up the test. 

## Testing 
Before
```
test sdk_tests::stake_processor_tests::tests::mainnet_stake_gov_record_txn has been running for over 60 seconds
test sdk_tests::stake_processor_tests::tests::mainnet_stake_pool_delegation_txn has been running for over 60 seconds
```
After
`cargo test` runs fine