### PR TITLE
migrate all tables from default processor to parquet default processor

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4190,6 +4190,7 @@ dependencies = [
  "google-cloud-storage",
  "jemallocator",
  "lazy_static",
+ "log",
  "native-tls",
  "num_cpus",
  "parquet",

--- a/rust/processor/src/bq_analytics/generic_parquet_processor.rs
+++ b/rust/processor/src/bq_analytics/generic_parquet_processor.rs
@@ -29,6 +29,7 @@ pub trait NamedTable {
     const TABLE_NAME: &'static str;
 }
 
+/// TODO: Deprecate once fully migrated to SDK
 pub trait HasVersion {
     fn version(&self) -> i64;
 }
@@ -37,6 +38,7 @@ pub trait HasParquetSchema {
     fn schema() -> Arc<parquet::schema::types::Type>;
 }
 
+/// TODO: Deprecate once fully migrated to SDK
 pub trait GetTimeStamp {
     fn get_timestamp(&self) -> chrono::NaiveDateTime;
 }

--- a/rust/processor/src/db/common/models/default_models/mod.rs
+++ b/rust/processor/src/db/common/models/default_models/mod.rs
@@ -1,1 +1,2 @@
+pub mod raw_current_table_items;
 pub mod raw_table_items;

--- a/rust/processor/src/db/common/models/default_models/mod.rs
+++ b/rust/processor/src/db/common/models/default_models/mod.rs
@@ -1,3 +1,4 @@
 pub mod raw_block_metadata_transactions;
 pub mod raw_current_table_items;
 pub mod raw_table_items;
+pub mod raw_table_metadata;

--- a/rust/processor/src/db/common/models/default_models/mod.rs
+++ b/rust/processor/src/db/common/models/default_models/mod.rs
@@ -1,2 +1,3 @@
+pub mod raw_block_metadata_transactions;
 pub mod raw_current_table_items;
 pub mod raw_table_items;

--- a/rust/processor/src/db/common/models/default_models/raw_block_metadata_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/raw_block_metadata_transactions.rs
@@ -1,0 +1,57 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::utils::util::{parse_timestamp, standardize_address};
+use aptos_protos::{transaction::v1::BlockMetadataTransaction, util::timestamp::Timestamp};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RawBlockMetadataTransaction {
+    pub version: i64,
+    pub block_height: i64,
+    pub id: String,
+    pub round: i64,
+    pub epoch: i64,
+    pub previous_block_votes_bitvec: String, // serde_json::Value,
+    pub proposer: String,
+    pub failed_proposer_indices: String, //serde_json::Value,
+    pub timestamp: chrono::NaiveDateTime,
+}
+
+impl RawBlockMetadataTransaction {
+    pub fn from_bmt_transaction(
+        txn: &BlockMetadataTransaction,
+        version: i64,
+        block_height: i64,
+        epoch: i64,
+        timestamp: &Timestamp,
+    ) -> Self {
+        Self {
+            version,
+            block_height,
+            id: txn.id.to_string(),
+            epoch,
+            round: txn.round as i64,
+            proposer: standardize_address(txn.proposer.as_str()),
+            failed_proposer_indices: serde_json::to_value(&txn.failed_proposer_indices)
+                .unwrap()
+                .to_string(),
+            previous_block_votes_bitvec: serde_json::to_value(&txn.previous_block_votes_bitvec)
+                .unwrap()
+                .to_string(),
+            // time is in microseconds
+            timestamp: parse_timestamp(timestamp, version),
+        }
+    }
+}
+
+// Prevent conflicts with other things named `Transaction`
+pub type RawBlockMetadataTransactionModel = RawBlockMetadataTransaction;
+
+pub trait BlockMetadataTransactionConvertible {
+    fn from_raw(raw_item: &RawBlockMetadataTransaction) -> Self;
+}

--- a/rust/processor/src/db/common/models/default_models/raw_block_metadata_transactions.rs
+++ b/rust/processor/src/db/common/models/default_models/raw_block_metadata_transactions.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use crate::utils::util::{parse_timestamp, standardize_address};
+use crate::utils::util::{compute_nanos_since_epoch, parse_timestamp, standardize_address};
 use aptos_protos::{transaction::v1::BlockMetadataTransaction, util::timestamp::Timestamp};
 use serde::{Deserialize, Serialize};
 
@@ -16,10 +16,11 @@ pub struct RawBlockMetadataTransaction {
     pub id: String,
     pub round: i64,
     pub epoch: i64,
-    pub previous_block_votes_bitvec: String, // serde_json::Value,
+    pub previous_block_votes_bitvec: String,
     pub proposer: String,
-    pub failed_proposer_indices: String, //serde_json::Value,
+    pub failed_proposer_indices: String,
     pub timestamp: chrono::NaiveDateTime,
+    pub ns_since_unix_epoch: u64,
 }
 
 impl RawBlockMetadataTransaction {
@@ -30,6 +31,7 @@ impl RawBlockMetadataTransaction {
         epoch: i64,
         timestamp: &Timestamp,
     ) -> Self {
+        let block_timestamp = parse_timestamp(timestamp, version);
         Self {
             version,
             block_height,
@@ -44,7 +46,8 @@ impl RawBlockMetadataTransaction {
                 .unwrap()
                 .to_string(),
             // time is in microseconds
-            timestamp: parse_timestamp(timestamp, version),
+            timestamp: block_timestamp,
+            ns_since_unix_epoch: compute_nanos_since_epoch(block_timestamp),
         }
     }
 }

--- a/rust/processor/src/db/common/models/default_models/raw_current_table_items.rs
+++ b/rust/processor/src/db/common/models/default_models/raw_current_table_items.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RawCurrentTableItem {
+    pub table_handle: String,
+    pub key_hash: String,
+    pub key: String,
+    pub decoded_key: String,
+    pub decoded_value: Option<String>,
+    // pub decoded_key: serde_json::Value,
+    // pub decoded_value: Option<serde_json::Value>,
+    pub last_transaction_version: i64,
+    pub is_deleted: bool,
+    pub block_timestamp: chrono::NaiveDateTime,
+}
+
+pub trait CurrentTableItemConvertible {
+    fn from_raw(raw_item: &RawCurrentTableItem) -> Self;
+}

--- a/rust/processor/src/db/common/models/default_models/raw_current_table_items.rs
+++ b/rust/processor/src/db/common/models/default_models/raw_current_table_items.rs
@@ -7,8 +7,6 @@ pub struct RawCurrentTableItem {
     pub key: String,
     pub decoded_key: String,
     pub decoded_value: Option<String>,
-    // pub decoded_key: serde_json::Value,
-    // pub decoded_value: Option<serde_json::Value>,
     pub last_transaction_version: i64,
     pub is_deleted: bool,
     pub block_timestamp: chrono::NaiveDateTime,

--- a/rust/processor/src/db/common/models/default_models/raw_table_items.rs
+++ b/rust/processor/src/db/common/models/default_models/raw_table_items.rs
@@ -1,5 +1,8 @@
 use crate::{
-    db::postgres::models::default_models::move_tables::{CurrentTableItem, TableItem},
+    db::{
+        common::models::default_models::raw_current_table_items::RawCurrentTableItem,
+        postgres::models::default_models::move_tables::TableItem,
+    },
     utils::util::{hash_str, standardize_address},
 };
 use aptos_protos::transaction::v1::{DeleteTableItem, WriteTableItem};
@@ -24,7 +27,7 @@ impl RawTableItem {
         txn_version: i64,
         transaction_block_height: i64,
         block_timestamp: chrono::NaiveDateTime,
-    ) -> (Self, CurrentTableItem) {
+    ) -> (Self, RawCurrentTableItem) {
         (
             Self {
                 txn_version,
@@ -37,20 +40,15 @@ impl RawTableItem {
                 is_deleted: false,
                 block_timestamp,
             },
-            CurrentTableItem {
+            RawCurrentTableItem {
                 table_handle: standardize_address(&write_table_item.handle.to_string()),
                 key_hash: hash_str(&write_table_item.key.to_string()),
                 key: write_table_item.key.to_string(),
-                decoded_key: serde_json::from_str(
-                    write_table_item.data.as_ref().unwrap().key.as_str(),
-                )
-                .unwrap(),
-                decoded_value: serde_json::from_str(
-                    write_table_item.data.as_ref().unwrap().value.as_str(),
-                )
-                .unwrap(),
+                decoded_key: write_table_item.data.as_ref().unwrap().key.clone(),
+                decoded_value: Some(write_table_item.data.as_ref().unwrap().value.clone()),
                 last_transaction_version: txn_version,
                 is_deleted: false,
+                block_timestamp,
             },
         )
     }
@@ -61,7 +59,7 @@ impl RawTableItem {
         txn_version: i64,
         transaction_block_height: i64,
         block_timestamp: chrono::NaiveDateTime,
-    ) -> (Self, CurrentTableItem) {
+    ) -> (Self, RawCurrentTableItem) {
         (
             Self {
                 txn_version,
@@ -74,17 +72,15 @@ impl RawTableItem {
                 is_deleted: true,
                 block_timestamp,
             },
-            CurrentTableItem {
+            RawCurrentTableItem {
                 table_handle: standardize_address(&delete_table_item.handle.to_string()),
                 key_hash: hash_str(&delete_table_item.key.to_string()),
                 key: delete_table_item.key.to_string(),
-                decoded_key: serde_json::from_str(
-                    delete_table_item.data.as_ref().unwrap().key.as_str(),
-                )
-                .unwrap(),
+                decoded_key: delete_table_item.data.as_ref().unwrap().key.clone(),
                 decoded_value: None,
                 last_transaction_version: txn_version,
                 is_deleted: true,
+                block_timestamp,
             },
         )
     }

--- a/rust/processor/src/db/common/models/default_models/raw_table_metadata.rs
+++ b/rust/processor/src/db/common/models/default_models/raw_table_metadata.rs
@@ -1,0 +1,23 @@
+use aptos_protos::transaction::v1::WriteTableItem;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RawTableMetadata {
+    pub handle: String,
+    pub key_type: String,
+    pub value_type: String,
+}
+
+impl RawTableMetadata {
+    pub fn from_write_table_item(table_item: &WriteTableItem) -> Self {
+        Self {
+            handle: table_item.handle.to_string(),
+            key_type: table_item.data.as_ref().unwrap().key_type.clone(),
+            value_type: table_item.data.as_ref().unwrap().value_type.clone(),
+        }
+    }
+}
+
+pub trait TableMetadataConvertible {
+    fn from_raw(raw_item: &RawTableMetadata) -> Self;
+}

--- a/rust/processor/src/db/parquet/models/default_models/mod.rs
+++ b/rust/processor/src/db/parquet/models/default_models/mod.rs
@@ -3,5 +3,6 @@ pub mod parquet_block_metadata_transactions;
 pub mod parquet_move_modules;
 pub mod parquet_move_resources;
 pub mod parquet_move_tables;
+pub mod parquet_table_metadata;
 pub mod parquet_transactions;
 pub mod parquet_write_set_changes;

--- a/rust/processor/src/db/parquet/models/default_models/mod.rs
+++ b/rust/processor/src/db/parquet/models/default_models/mod.rs
@@ -1,4 +1,5 @@
 // parquet models
+pub mod parquet_block_metadata_transactions;
 pub mod parquet_move_modules;
 pub mod parquet_move_resources;
 pub mod parquet_move_tables;

--- a/rust/processor/src/db/parquet/models/default_models/parquet_block_metadata_transactions.rs
+++ b/rust/processor/src/db/parquet/models/default_models/parquet_block_metadata_transactions.rs
@@ -1,0 +1,151 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
+    db::common::models::default_models::raw_block_metadata_transactions::{
+        BlockMetadataTransactionConvertible, RawBlockMetadataTransaction,
+    },
+};
+use allocative_derive::Allocative;
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, Serialize, ParquetRecordWriter,
+)]
+pub struct BlockMetadataTransaction {
+    pub txn_version: i64,
+    pub block_height: i64,
+    pub id: String,
+    pub round: i64,
+    pub epoch: i64,
+    pub previous_block_votes_bitvec: String, // serde_json::Value,
+    pub proposer: String,
+    pub failed_proposer_indices: String, //serde_json::Value,
+    #[allocative(skip)]
+    pub block_timestamp: chrono::NaiveDateTime,
+}
+
+impl NamedTable for BlockMetadataTransaction {
+    const TABLE_NAME: &'static str = "block_metadata_transactions";
+}
+
+impl HasVersion for BlockMetadataTransaction {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl GetTimeStamp for BlockMetadataTransaction {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
+    }
+}
+
+impl BlockMetadataTransactionConvertible for BlockMetadataTransaction {
+    fn from_raw(raw_item: &RawBlockMetadataTransaction) -> Self {
+        BlockMetadataTransaction {
+            txn_version: raw_item.version,
+            block_height: raw_item.block_height,
+            id: raw_item.id.clone(),
+            round: raw_item.round,
+            epoch: raw_item.epoch,
+            previous_block_votes_bitvec: raw_item.previous_block_votes_bitvec.clone(),
+            proposer: raw_item.proposer.clone(),
+            failed_proposer_indices: raw_item.failed_proposer_indices.clone(),
+            block_timestamp: raw_item.timestamp,
+        }
+    }
+}
+
+#[allow(deprecated)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parquet::record::RecordWriter;
+    use chrono::NaiveDateTime;
+    use parquet::file::writer::SerializedFileWriter;
+    use serde_json::json;
+    #[test]
+    fn test_raw_block_metadata_transaction() {
+        let samples = vec![BlockMetadataTransaction {
+            txn_version: 1,
+            block_height: 1,
+            id: "id".to_string(),
+            round: 1,
+            epoch: 1,
+            previous_block_votes_bitvec: json!([1, 2, 3]).to_string(),
+            proposer: "proposer".to_string(),
+            failed_proposer_indices: json!([1, 2, 3]).to_string(),
+            block_timestamp: NaiveDateTime::from_timestamp(1, 0),
+        }];
+
+        let schema = samples.as_slice().schema().unwrap();
+
+        let mut writer = SerializedFileWriter::new(Vec::new(), schema, Default::default()).unwrap();
+
+        let mut row_group = writer.next_row_group().unwrap();
+        samples
+            .as_slice()
+            .write_to_row_group(&mut row_group)
+            .unwrap();
+        row_group.close().unwrap();
+        writer.close().unwrap();
+    }
+
+    #[test]
+    fn test_from_raw() {
+        let raw = RawBlockMetadataTransaction {
+            version: 1,
+            block_height: 1,
+            id: "id".to_string(),
+            round: 1,
+            epoch: 1,
+            previous_block_votes_bitvec: json!([1, 2, 3]).to_string(),
+            proposer: "proposer".to_string(),
+            failed_proposer_indices: json!([1, 2, 3]).to_string(),
+            timestamp: NaiveDateTime::from_timestamp(1, 0),
+        };
+
+        let block_metadata_transaction = BlockMetadataTransaction::from_raw(&raw);
+
+        assert_eq!(block_metadata_transaction.txn_version, 1);
+        assert_eq!(block_metadata_transaction.block_height, 1);
+        assert_eq!(block_metadata_transaction.id, "id");
+        assert_eq!(block_metadata_transaction.round, 1);
+        assert_eq!(block_metadata_transaction.epoch, 1);
+        assert_eq!(
+            block_metadata_transaction.previous_block_votes_bitvec,
+            "[1,2,3]"
+        );
+        assert_eq!(block_metadata_transaction.proposer, "proposer");
+        assert_eq!(
+            block_metadata_transaction.failed_proposer_indices,
+            "[1,2,3]"
+        );
+        assert_eq!(
+            block_metadata_transaction.block_timestamp,
+            NaiveDateTime::from_timestamp(1, 0)
+        );
+
+        let samples = vec![block_metadata_transaction];
+
+        let schema = samples.as_slice().schema().unwrap();
+
+        let mut writer = SerializedFileWriter::new(Vec::new(), schema, Default::default()).unwrap();
+
+        let mut row_group = writer.next_row_group().unwrap();
+        samples
+            .as_slice()
+            .write_to_row_group(&mut row_group)
+            .unwrap();
+        row_group.close().unwrap();
+        writer.close().unwrap();
+    }
+}

--- a/rust/processor/src/db/parquet/models/default_models/parquet_block_metadata_transactions.rs
+++ b/rust/processor/src/db/parquet/models/default_models/parquet_block_metadata_transactions.rs
@@ -25,9 +25,9 @@ pub struct BlockMetadataTransaction {
     pub id: String,
     pub round: i64,
     pub epoch: i64,
-    pub previous_block_votes_bitvec: String, // serde_json::Value,
+    pub previous_block_votes_bitvec: String,
     pub proposer: String,
-    pub failed_proposer_indices: String, //serde_json::Value,
+    pub failed_proposer_indices: String,
     #[allocative(skip)]
     pub block_timestamp: chrono::NaiveDateTime,
 }

--- a/rust/processor/src/db/parquet/models/default_models/parquet_move_tables.rs
+++ b/rust/processor/src/db/parquet/models/default_models/parquet_move_tables.rs
@@ -64,6 +64,10 @@ pub struct CurrentTableItem {
     pub block_timestamp: chrono::NaiveDateTime,
 }
 
+impl NamedTable for CurrentTableItem {
+    const TABLE_NAME: &'static str = "current_table_items";
+}
+
 impl HasVersion for CurrentTableItem {
     fn version(&self) -> i64 {
         self.last_transaction_version

--- a/rust/processor/src/db/parquet/models/default_models/parquet_move_tables.rs
+++ b/rust/processor/src/db/parquet/models/default_models/parquet_move_tables.rs
@@ -5,7 +5,10 @@
 
 use crate::{
     bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
-    db::common::models::default_models::raw_table_items::{RawTableItem, TableItemConvertible},
+    db::common::models::default_models::{
+        raw_current_table_items::{CurrentTableItemConvertible, RawCurrentTableItem},
+        raw_table_items::{RawTableItem, TableItemConvertible},
+    },
     utils::util::{hash_str, standardize_address},
 };
 use allocative_derive::Allocative;
@@ -46,15 +49,31 @@ impl GetTimeStamp for TableItem {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, FieldCount, Serialize)]
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, Serialize, ParquetRecordWriter,
+)]
 pub struct CurrentTableItem {
     pub table_handle: String,
     pub key_hash: String,
     pub key: String,
-    pub decoded_key: serde_json::Value,
-    pub decoded_value: Option<serde_json::Value>,
+    pub decoded_key: String,
+    pub decoded_value: Option<String>,
     pub last_transaction_version: i64,
     pub is_deleted: bool,
+    #[allocative(skip)]
+    pub block_timestamp: chrono::NaiveDateTime,
+}
+
+impl HasVersion for CurrentTableItem {
+    fn version(&self) -> i64 {
+        self.last_transaction_version
+    }
+}
+
+impl GetTimeStamp for CurrentTableItem {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
+    }
 }
 
 #[derive(
@@ -107,16 +126,11 @@ impl TableItem {
                 table_handle: standardize_address(&write_table_item.handle.to_string()),
                 key_hash: hash_str(&write_table_item.key.to_string()),
                 key: write_table_item.key.to_string(),
-                decoded_key: serde_json::from_str(
-                    write_table_item.data.as_ref().unwrap().key.as_str(),
-                )
-                .unwrap(),
-                decoded_value: serde_json::from_str(
-                    write_table_item.data.as_ref().unwrap().value.as_str(),
-                )
-                .unwrap(),
+                decoded_key: write_table_item.data.as_ref().unwrap().key.clone(),
+                decoded_value: Some(write_table_item.data.as_ref().unwrap().value.clone()),
                 last_transaction_version: txn_version,
                 is_deleted: false,
+                block_timestamp,
             },
         )
     }
@@ -144,13 +158,11 @@ impl TableItem {
                 table_handle: standardize_address(&delete_table_item.handle.to_string()),
                 key_hash: hash_str(&delete_table_item.key.to_string()),
                 key: delete_table_item.key.to_string(),
-                decoded_key: serde_json::from_str(
-                    delete_table_item.data.as_ref().unwrap().key.as_str(),
-                )
-                .unwrap(),
+                decoded_key: delete_table_item.data.as_ref().unwrap().key.clone(),
                 decoded_value: None,
                 last_transaction_version: txn_version,
                 is_deleted: true,
+                block_timestamp,
             },
         )
     }
@@ -176,6 +188,21 @@ impl TableItemConvertible for TableItem {
             table_handle: raw_item.table_handle.clone(),
             decoded_key: raw_item.decoded_key.clone(),
             decoded_value: raw_item.decoded_value.clone(),
+            is_deleted: raw_item.is_deleted,
+            block_timestamp: raw_item.block_timestamp,
+        }
+    }
+}
+
+impl CurrentTableItemConvertible for CurrentTableItem {
+    fn from_raw(raw_item: &RawCurrentTableItem) -> Self {
+        CurrentTableItem {
+            table_handle: raw_item.table_handle.clone(),
+            key_hash: raw_item.key_hash.clone(),
+            key: raw_item.key.clone(),
+            decoded_key: raw_item.decoded_key.clone(),
+            decoded_value: raw_item.decoded_value.clone(),
+            last_transaction_version: raw_item.last_transaction_version,
             is_deleted: raw_item.is_deleted,
             block_timestamp: raw_item.block_timestamp,
         }

--- a/rust/processor/src/db/parquet/models/default_models/parquet_move_tables.rs
+++ b/rust/processor/src/db/parquet/models/default_models/parquet_move_tables.rs
@@ -90,7 +90,7 @@ pub struct TableMetadata {
 }
 
 impl NamedTable for TableMetadata {
-    const TABLE_NAME: &'static str = "table_metadatas";
+    const TABLE_NAME: &'static str = "table_metadata";
 }
 
 impl HasVersion for TableMetadata {

--- a/rust/processor/src/db/parquet/models/default_models/parquet_table_metadata.rs
+++ b/rust/processor/src/db/parquet/models/default_models/parquet_table_metadata.rs
@@ -1,0 +1,46 @@
+use crate::{
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
+    db::common::models::default_models::raw_table_metadata::{
+        RawTableMetadata, TableMetadataConvertible,
+    },
+};
+use allocative_derive::Allocative;
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, Serialize, ParquetRecordWriter,
+)]
+pub struct TableMetadata {
+    pub handle: String,
+    pub key_type: String,
+    pub value_type: String,
+}
+
+impl NamedTable for TableMetadata {
+    const TABLE_NAME: &'static str = "table_metadata";
+}
+
+impl HasVersion for TableMetadata {
+    fn version(&self) -> i64 {
+        -1
+    }
+}
+
+impl GetTimeStamp for TableMetadata {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        #[allow(deprecated)]
+        chrono::NaiveDateTime::from_timestamp(0, 0)
+    }
+}
+
+impl TableMetadataConvertible for TableMetadata {
+    fn from_raw(raw_item: &RawTableMetadata) -> Self {
+        Self {
+            handle: raw_item.handle.clone(),
+            key_type: raw_item.key_type.clone(),
+            value_type: raw_item.value_type.clone(),
+        }
+    }
+}

--- a/rust/processor/src/db/postgres/migrations/2024-11-26-215016_processor_status/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-11-26-215016_processor_status/down.sql
@@ -1,0 +1,11 @@
+-- This file should undo anything in `up.sql`
+-- Revert changes to the processor column
+ALTER TABLE processor_status DROP CONSTRAINT IF EXISTS processor_status_pkey;
+
+-- Reset the processor column to its original type
+ALTER TABLE processor_status
+ALTER COLUMN processor TYPE TEXT, -- Replace TEXT with the original type
+ALTER COLUMN processor DROP NOT NULL;
+
+-- Remove primary key constraint
+ALTER TABLE processor_status DROP CONSTRAINT IF EXISTS processor_status_pkey;

--- a/rust/processor/src/db/postgres/migrations/2024-11-26-215016_processor_status/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2024-11-26-215016_processor_status/up.sql
@@ -1,0 +1,12 @@
+-- Your SQL goes here
+-- Drop existing constraints if needed
+ALTER TABLE processor_status DROP CONSTRAINT IF EXISTS processor_status_pkey;
+
+-- Modify the processor column
+ALTER TABLE processor_status
+ALTER COLUMN processor TYPE VARCHAR(100),
+ALTER COLUMN processor SET NOT NULL;
+
+-- Add unique constraint and primary key
+ALTER TABLE processor_status ADD CONSTRAINT processor_status_pkey UNIQUE (processor);
+ALTER TABLE processor_status ADD PRIMARY KEY (processor);

--- a/rust/processor/src/db/postgres/models/default_models/move_tables.rs
+++ b/rust/processor/src/db/postgres/models/default_models/move_tables.rs
@@ -7,10 +7,10 @@ use crate::{
     db::common::models::default_models::{
         raw_current_table_items::{CurrentTableItemConvertible, RawCurrentTableItem},
         raw_table_items::{RawTableItem, TableItemConvertible},
+        raw_table_metadata::{RawTableMetadata, TableMetadataConvertible},
     },
     schema::{current_table_items, table_items, table_metadatas},
 };
-use aptos_protos::transaction::v1::WriteTableItem;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
@@ -68,12 +68,12 @@ impl TableItemConvertible for TableItem {
     }
 }
 
-impl TableMetadata {
-    pub fn from_write_table_item(table_item: &WriteTableItem) -> Self {
-        Self {
-            handle: table_item.handle.to_string(),
-            key_type: table_item.data.as_ref().unwrap().key_type.clone(),
-            value_type: table_item.data.as_ref().unwrap().value_type.clone(),
+impl TableMetadataConvertible for TableMetadata {
+    fn from_raw(raw_item: &RawTableMetadata) -> Self {
+        TableMetadata {
+            handle: raw_item.handle.clone(),
+            key_type: raw_item.key_type.clone(),
+            value_type: raw_item.value_type.clone(),
         }
     }
 }

--- a/rust/processor/src/db/postgres/models/default_models/move_tables.rs
+++ b/rust/processor/src/db/postgres/models/default_models/move_tables.rs
@@ -4,7 +4,10 @@
 #![allow(clippy::extra_unused_lifetimes)]
 
 use crate::{
-    db::common::models::default_models::raw_table_items::{RawTableItem, TableItemConvertible},
+    db::common::models::default_models::{
+        raw_current_table_items::{CurrentTableItemConvertible, RawCurrentTableItem},
+        raw_table_items::{RawTableItem, TableItemConvertible},
+    },
     schema::{current_table_items, table_items, table_metadatas},
 };
 use aptos_protos::transaction::v1::WriteTableItem;
@@ -71,6 +74,23 @@ impl TableMetadata {
             handle: table_item.handle.to_string(),
             key_type: table_item.data.as_ref().unwrap().key_type.clone(),
             value_type: table_item.data.as_ref().unwrap().value_type.clone(),
+        }
+    }
+}
+
+impl CurrentTableItemConvertible for CurrentTableItem {
+    fn from_raw(raw_item: &RawCurrentTableItem) -> Self {
+        CurrentTableItem {
+            table_handle: raw_item.table_handle.clone(),
+            key_hash: raw_item.key_hash.clone(),
+            key: raw_item.key.clone(),
+            decoded_key: serde_json::from_str(raw_item.decoded_key.as_str()).unwrap(),
+            decoded_value: raw_item
+                .decoded_value
+                .clone()
+                .map(|v| serde_json::from_str(v.as_str()).unwrap()),
+            last_transaction_version: raw_item.last_transaction_version,
+            is_deleted: raw_item.is_deleted,
         }
     }
 }

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -943,7 +943,7 @@ diesel::table! {
 
 diesel::table! {
     processor_status (processor) {
-        #[max_length = 50]
+        #[max_length = 100]
         processor -> Varchar,
         last_success_version -> Int8,
         last_updated -> Timestamp,

--- a/rust/processor/src/processors/default_processor.rs
+++ b/rust/processor/src/processors/default_processor.rs
@@ -367,8 +367,9 @@ pub fn process_transactions(
             .expect("Transaction info doesn't exist!");
 
         #[allow(deprecated)]
-        let block_timestamp = chrono::NaiveDateTime::from_timestamp_opt(timestamp.seconds, 0)
-            .expect("Txn Timestamp is invalid!");
+        let block_timestamp =
+            chrono::NaiveDateTime::from_timestamp_opt(timestamp.seconds, timestamp.nanos as u32)
+                .expect("Txn Timestamp is invalid!");
         let txn_data = match transaction.txn_data.as_ref() {
             Some(txn_data) => txn_data,
             None => {

--- a/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
+++ b/rust/processor/src/processors/parquet_processors/parquet_default_processor.rs
@@ -227,11 +227,10 @@ pub fn process_transactions_parquet(
     AHashMap<i64, i64>,
 ) {
     let mut transaction_version_to_struct_count: AHashMap<i64, i64> = AHashMap::new();
-    let (txns, _block_metadata_txns, write_set_changes, wsc_details) =
-        TransactionModel::from_transactions(
-            &transactions,
-            &mut transaction_version_to_struct_count,
-        );
+    let (txns, write_set_changes, wsc_details) = TransactionModel::from_transactions(
+        &transactions,
+        &mut transaction_version_to_struct_count,
+    );
 
     let mut move_modules = vec![];
     let mut move_resources = vec![];

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -301,6 +301,17 @@ pub fn parse_timestamp(ts: &Timestamp, version: i64) -> chrono::NaiveDateTime {
         .unwrap_or_else(|| panic!("Could not parse timestamp {:?} for version {}", ts, version))
 }
 
+pub fn compute_nanos_since_epoch(datetime: NaiveDateTime) -> u64 {
+    // The Unix epoch is 1970-01-01T00:00:00Z
+    #[allow(deprecated)]
+    let unix_epoch = NaiveDateTime::from_timestamp(0, 0);
+    let duration_since_epoch = datetime.signed_duration_since(unix_epoch);
+
+    // Convert the duration to nanoseconds and return
+    duration_since_epoch.num_seconds() as u64 * 1_000_000_000
+        + duration_since_epoch.subsec_nanos() as u64
+}
+
 pub fn parse_timestamp_secs(ts: u64, version: i64) -> chrono::NaiveDateTime {
     #[allow(deprecated)]
     chrono::NaiveDateTime::from_timestamp_opt(

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -112,7 +112,9 @@ bitflags! {
         // User transaction
         const SIGNATURES = 1 << 23;
 
+        // More tables
         const CURRENT_TABLE_ITEMS = 1 << 24;
+        const BLOCK_METADATA_TRANSACTIONS = 1 << 25;
     }
 }
 

--- a/rust/processor/src/worker.rs
+++ b/rust/processor/src/worker.rs
@@ -111,6 +111,8 @@ bitflags! {
 
         // User transaction
         const SIGNATURES = 1 << 23;
+
+        const CURRENT_TABLE_ITEMS = 1 << 24;
     }
 }
 

--- a/rust/sdk-processor/Cargo.toml
+++ b/rust/sdk-processor/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { workspace = true }
 tokio-postgres = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+log = "0.4.22"
 
 [features]
 libpq = ["diesel/postgres"]

--- a/rust/sdk-processor/Cargo.toml
+++ b/rust/sdk-processor/Cargo.toml
@@ -25,6 +25,7 @@ futures-util = { workspace = true }
 google-cloud-storage = { workspace = true }
 jemallocator = { workspace = true }
 lazy_static = { workspace = true }
+log = "0.4.22"
 
 # Postgres SSL support
 native-tls = { workspace = true }
@@ -41,7 +42,6 @@ tokio = { workspace = true }
 tokio-postgres = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-log = "0.4.22"
 
 [features]
 libpq = ["diesel/postgres"]

--- a/rust/sdk-processor/src/parquet_processors/mod.rs
+++ b/rust/sdk-processor/src/parquet_processors/mod.rs
@@ -17,6 +17,7 @@ use processor::{
         parquet_move_modules::MoveModule,
         parquet_move_resources::MoveResource,
         parquet_move_tables::{CurrentTableItem, TableItem},
+        parquet_table_metadata::TableMetadata,
         parquet_transactions::Transaction as ParquetTransaction,
         parquet_write_set_changes::WriteSetChangeModel,
     },
@@ -62,7 +63,7 @@ pub enum ParquetTypeEnum {
     MoveModule,
     CurrentTableItem,
     BlockMetadataTransaction,
-    // TableMetadata,
+    TableMetadata,
 }
 
 /// Trait for handling various Parquet types.
@@ -118,6 +119,7 @@ impl_parquet_trait!(
     BlockMetadataTransaction,
     ParquetTypeEnum::BlockMetadataTransaction
 );
+impl_parquet_trait!(TableMetadata, ParquetTypeEnum::TableMetadata);
 
 #[derive(Debug, Clone)]
 #[enum_dispatch(ParquetTypeTrait)]
@@ -129,6 +131,7 @@ pub enum ParquetTypeStructs {
     MoveModule(Vec<MoveModule>),
     CurrentTableItem(Vec<CurrentTableItem>),
     BlockMetadataTransaction(Vec<BlockMetadataTransaction>),
+    TableMetadata(Vec<TableMetadata>),
 }
 
 impl ParquetTypeStructs {
@@ -143,6 +146,7 @@ impl ParquetTypeStructs {
             ParquetTypeEnum::BlockMetadataTransaction => {
                 ParquetTypeStructs::BlockMetadataTransaction(Vec::new())
             },
+            ParquetTypeEnum::TableMetadata => ParquetTypeStructs::TableMetadata(Vec::new()),
         }
     }
 
@@ -194,6 +198,12 @@ impl ParquetTypeStructs {
             (
                 ParquetTypeStructs::BlockMetadataTransaction(self_data),
                 ParquetTypeStructs::BlockMetadataTransaction(other_data),
+            ) => {
+                handle_append!(self_data, other_data)
+            },
+            (
+                ParquetTypeStructs::TableMetadata(self_data),
+                ParquetTypeStructs::TableMetadata(other_data),
             ) => {
                 handle_append!(self_data, other_data)
             },

--- a/rust/sdk-processor/src/parquet_processors/mod.rs
+++ b/rust/sdk-processor/src/parquet_processors/mod.rs
@@ -56,13 +56,13 @@ const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
     )
 )]
 pub enum ParquetTypeEnum {
-    MoveResource,
-    WriteSetChange,
-    Transaction,
-    TableItem,
-    MoveModule,
-    CurrentTableItem,
-    BlockMetadataTransaction,
+    MoveResources,
+    WriteSetChanges,
+    Transactions,
+    TableItems,
+    MoveModules,
+    CurrentTableItems,
+    BlockMetadataTransactions,
     TableMetadata,
 }
 
@@ -109,15 +109,15 @@ macro_rules! impl_parquet_trait {
 }
 
 // Apply macro to supported types
-impl_parquet_trait!(MoveResource, ParquetTypeEnum::MoveResource);
-impl_parquet_trait!(WriteSetChangeModel, ParquetTypeEnum::WriteSetChange);
-impl_parquet_trait!(ParquetTransaction, ParquetTypeEnum::Transaction);
-impl_parquet_trait!(TableItem, ParquetTypeEnum::TableItem);
-impl_parquet_trait!(MoveModule, ParquetTypeEnum::MoveModule);
-impl_parquet_trait!(CurrentTableItem, ParquetTypeEnum::CurrentTableItem);
+impl_parquet_trait!(MoveResource, ParquetTypeEnum::MoveResources);
+impl_parquet_trait!(WriteSetChangeModel, ParquetTypeEnum::WriteSetChanges);
+impl_parquet_trait!(ParquetTransaction, ParquetTypeEnum::Transactions);
+impl_parquet_trait!(TableItem, ParquetTypeEnum::TableItems);
+impl_parquet_trait!(MoveModule, ParquetTypeEnum::MoveModules);
+impl_parquet_trait!(CurrentTableItem, ParquetTypeEnum::CurrentTableItems);
 impl_parquet_trait!(
     BlockMetadataTransaction,
-    ParquetTypeEnum::BlockMetadataTransaction
+    ParquetTypeEnum::BlockMetadataTransactions
 );
 impl_parquet_trait!(TableMetadata, ParquetTypeEnum::TableMetadata);
 
@@ -137,13 +137,13 @@ pub enum ParquetTypeStructs {
 impl ParquetTypeStructs {
     pub fn default_for_type(parquet_type: &ParquetTypeEnum) -> Self {
         match parquet_type {
-            ParquetTypeEnum::MoveResource => ParquetTypeStructs::MoveResource(Vec::new()),
-            ParquetTypeEnum::WriteSetChange => ParquetTypeStructs::WriteSetChange(Vec::new()),
-            ParquetTypeEnum::Transaction => ParquetTypeStructs::Transaction(Vec::new()),
-            ParquetTypeEnum::TableItem => ParquetTypeStructs::TableItem(Vec::new()),
-            ParquetTypeEnum::MoveModule => ParquetTypeStructs::MoveModule(Vec::new()),
-            ParquetTypeEnum::CurrentTableItem => ParquetTypeStructs::CurrentTableItem(Vec::new()),
-            ParquetTypeEnum::BlockMetadataTransaction => {
+            ParquetTypeEnum::MoveResources => ParquetTypeStructs::MoveResource(Vec::new()),
+            ParquetTypeEnum::WriteSetChanges => ParquetTypeStructs::WriteSetChange(Vec::new()),
+            ParquetTypeEnum::Transactions => ParquetTypeStructs::Transaction(Vec::new()),
+            ParquetTypeEnum::TableItems => ParquetTypeStructs::TableItem(Vec::new()),
+            ParquetTypeEnum::MoveModules => ParquetTypeStructs::MoveModule(Vec::new()),
+            ParquetTypeEnum::CurrentTableItems => ParquetTypeStructs::CurrentTableItem(Vec::new()),
+            ParquetTypeEnum::BlockMetadataTransactions => {
                 ParquetTypeStructs::BlockMetadataTransaction(Vec::new())
             },
             ParquetTypeEnum::TableMetadata => ParquetTypeStructs::TableMetadata(Vec::new()),
@@ -305,12 +305,12 @@ mod tests {
     #[test]
     fn test_parquet_type_enum_matches_trait() {
         let types = vec![
-            ParquetTypeEnum::MoveResource,
-            ParquetTypeEnum::WriteSetChange,
-            ParquetTypeEnum::Transaction,
-            ParquetTypeEnum::TableItem,
-            ParquetTypeEnum::MoveModule,
-            ParquetTypeEnum::CurrentTableItem,
+            ParquetTypeEnum::MoveResources,
+            ParquetTypeEnum::WriteSetChanges,
+            ParquetTypeEnum::Transactions,
+            ParquetTypeEnum::TableItems,
+            ParquetTypeEnum::MoveModules,
+            ParquetTypeEnum::CurrentTableItems,
         ];
 
         for t in types {

--- a/rust/sdk-processor/src/parquet_processors/mod.rs
+++ b/rust/sdk-processor/src/parquet_processors/mod.rs
@@ -13,6 +13,7 @@ use google_cloud_storage::client::{Client as GCSClient, ClientConfig as GcsClien
 use parquet::schema::types::Type;
 use processor::{
     db::parquet::models::default_models::{
+        parquet_block_metadata_transactions::BlockMetadataTransaction,
         parquet_move_modules::MoveModule,
         parquet_move_resources::MoveResource,
         parquet_move_tables::{CurrentTableItem, TableItem},
@@ -60,6 +61,8 @@ pub enum ParquetTypeEnum {
     TableItem,
     MoveModule,
     CurrentTableItem,
+    BlockMetadataTransaction,
+    // TableMetadata,
 }
 
 /// Trait for handling various Parquet types.
@@ -111,6 +114,10 @@ impl_parquet_trait!(ParquetTransaction, ParquetTypeEnum::Transaction);
 impl_parquet_trait!(TableItem, ParquetTypeEnum::TableItem);
 impl_parquet_trait!(MoveModule, ParquetTypeEnum::MoveModule);
 impl_parquet_trait!(CurrentTableItem, ParquetTypeEnum::CurrentTableItem);
+impl_parquet_trait!(
+    BlockMetadataTransaction,
+    ParquetTypeEnum::BlockMetadataTransaction
+);
 
 #[derive(Debug, Clone)]
 #[enum_dispatch(ParquetTypeTrait)]
@@ -121,6 +128,7 @@ pub enum ParquetTypeStructs {
     TableItem(Vec<TableItem>),
     MoveModule(Vec<MoveModule>),
     CurrentTableItem(Vec<CurrentTableItem>),
+    BlockMetadataTransaction(Vec<BlockMetadataTransaction>),
 }
 
 impl ParquetTypeStructs {
@@ -132,6 +140,9 @@ impl ParquetTypeStructs {
             ParquetTypeEnum::TableItem => ParquetTypeStructs::TableItem(Vec::new()),
             ParquetTypeEnum::MoveModule => ParquetTypeStructs::MoveModule(Vec::new()),
             ParquetTypeEnum::CurrentTableItem => ParquetTypeStructs::CurrentTableItem(Vec::new()),
+            ParquetTypeEnum::BlockMetadataTransaction => {
+                ParquetTypeStructs::BlockMetadataTransaction(Vec::new())
+            },
         }
     }
 
@@ -177,6 +188,12 @@ impl ParquetTypeStructs {
             (
                 ParquetTypeStructs::CurrentTableItem(self_data),
                 ParquetTypeStructs::CurrentTableItem(other_data),
+            ) => {
+                handle_append!(self_data, other_data)
+            },
+            (
+                ParquetTypeStructs::BlockMetadataTransaction(self_data),
+                ParquetTypeStructs::BlockMetadataTransaction(other_data),
             ) => {
                 handle_append!(self_data, other_data)
             },

--- a/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
+++ b/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
@@ -111,6 +111,7 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             processor_status_table_names,
         )
         .await?;
+        println!("Starting version: {:?}", starting_version);
 
         // Define processor transaction stream config
         let transaction_stream = TransactionStreamStep::new(TransactionStreamConfig {
@@ -128,20 +129,20 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             initialize_gcs_client(parquet_db_config.google_application_credentials.clone()).await;
 
         let parquet_type_to_schemas: HashMap<ParquetTypeEnum, Arc<Type>> = [
-            (ParquetTypeEnum::MoveResource, MoveResource::schema()),
+            (ParquetTypeEnum::MoveResources, MoveResource::schema()),
             (
-                ParquetTypeEnum::WriteSetChange,
+                ParquetTypeEnum::WriteSetChanges,
                 WriteSetChangeModel::schema(),
             ),
-            (ParquetTypeEnum::Transaction, ParquetTransaction::schema()),
-            (ParquetTypeEnum::TableItem, TableItem::schema()),
-            (ParquetTypeEnum::MoveModule, MoveModule::schema()),
+            (ParquetTypeEnum::Transactions, ParquetTransaction::schema()),
+            (ParquetTypeEnum::TableItems, TableItem::schema()),
+            (ParquetTypeEnum::MoveModules, MoveModule::schema()),
             (
-                ParquetTypeEnum::CurrentTableItem,
+                ParquetTypeEnum::CurrentTableItems,
                 CurrentTableItem::schema(),
             ),
             (
-                ParquetTypeEnum::BlockMetadataTransaction,
+                ParquetTypeEnum::BlockMetadataTransactions,
                 BlockMetadataTransaction::schema(),
             ),
             (ParquetTypeEnum::TableMetadata, TableMetadata::schema()),

--- a/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
+++ b/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
@@ -31,8 +31,10 @@ use parquet::schema::types::Type;
 use processor::{
     bq_analytics::generic_parquet_processor::HasParquetSchema,
     db::parquet::models::default_models::{
-        parquet_move_modules::MoveModule, parquet_move_resources::MoveResource,
-        parquet_move_tables::TableItem, parquet_transactions::Transaction as ParquetTransaction,
+        parquet_move_modules::MoveModule,
+        parquet_move_resources::MoveResource,
+        parquet_move_tables::{CurrentTableItem, TableItem},
+        parquet_transactions::Transaction as ParquetTransaction,
         parquet_write_set_changes::WriteSetChangeModel,
     },
 };
@@ -132,6 +134,10 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             (ParquetTypeEnum::Transaction, ParquetTransaction::schema()),
             (ParquetTypeEnum::TableItem, TableItem::schema()),
             (ParquetTypeEnum::MoveModule, MoveModule::schema()),
+            (
+                ParquetTypeEnum::CurrentTableItem,
+                CurrentTableItem::schema(),
+            ),
         ]
         .into_iter()
         .collect();

--- a/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
+++ b/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
@@ -31,6 +31,7 @@ use parquet::schema::types::Type;
 use processor::{
     bq_analytics::generic_parquet_processor::HasParquetSchema,
     db::parquet::models::default_models::{
+        parquet_block_metadata_transactions::BlockMetadataTransaction,
         parquet_move_modules::MoveModule,
         parquet_move_resources::MoveResource,
         parquet_move_tables::{CurrentTableItem, TableItem},
@@ -137,6 +138,10 @@ impl ProcessorTrait for ParquetDefaultProcessor {
             (
                 ParquetTypeEnum::CurrentTableItem,
                 CurrentTableItem::schema(),
+            ),
+            (
+                ParquetTypeEnum::BlockMetadataTransaction,
+                BlockMetadataTransaction::schema(),
             ),
         ]
         .into_iter()

--- a/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
+++ b/rust/sdk-processor/src/parquet_processors/parquet_default_processor.rs
@@ -35,6 +35,7 @@ use processor::{
         parquet_move_modules::MoveModule,
         parquet_move_resources::MoveResource,
         parquet_move_tables::{CurrentTableItem, TableItem},
+        parquet_table_metadata::TableMetadata,
         parquet_transactions::Transaction as ParquetTransaction,
         parquet_write_set_changes::WriteSetChangeModel,
     },
@@ -143,6 +144,7 @@ impl ProcessorTrait for ParquetDefaultProcessor {
                 ParquetTypeEnum::BlockMetadataTransaction,
                 BlockMetadataTransaction::schema(),
             ),
+            (ParquetTypeEnum::TableMetadata, TableMetadata::schema()),
         ]
         .into_iter()
         .collect();

--- a/rust/sdk-processor/src/steps/common/parquet_buffer_step.rs
+++ b/rust/sdk-processor/src/steps/common/parquet_buffer_step.rs
@@ -318,8 +318,8 @@ mod tests {
             ParquetBufferStep::new(Duration::from_secs(10), buffer_uploader, 100);
 
         let data = HashMap::from([(
-            ParquetTypeEnum::MoveResource,
-            ParquetTypeStructs::default_for_type(&ParquetTypeEnum::MoveResource),
+            ParquetTypeEnum::MoveResources,
+            ParquetTypeStructs::default_for_type(&ParquetTypeEnum::MoveResources),
         )]);
         let metadata = TransactionMetadata::default();
 
@@ -348,8 +348,8 @@ mod tests {
 
         // Test data below `buffer_max_size`
         let data = HashMap::from([(
-            ParquetTypeEnum::MoveResource,
-            ParquetTypeStructs::default_for_type(&ParquetTypeEnum::MoveResource),
+            ParquetTypeEnum::MoveResources,
+            ParquetTypeStructs::default_for_type(&ParquetTypeEnum::MoveResources),
         )]);
         let metadata = TransactionMetadata::default();
 
@@ -364,8 +364,8 @@ mod tests {
 
         // Test buffer + data > `buffer_max_size`
         let data = HashMap::from([(
-            ParquetTypeEnum::MoveResource,
-            ParquetTypeStructs::default_for_type(&ParquetTypeEnum::MoveResource),
+            ParquetTypeEnum::MoveResources,
+            ParquetTypeStructs::default_for_type(&ParquetTypeEnum::MoveResources),
         )]);
         let metadata = TransactionMetadata::default();
 
@@ -390,7 +390,7 @@ mod tests {
         let gcs_client = Arc::new(GCSClient::new(gcs_config));
 
         let parquet_type_to_schemas: HashMap<ParquetTypeEnum, Arc<Type>> =
-            [(ParquetTypeEnum::MoveResource, MoveResource::schema())]
+            [(ParquetTypeEnum::MoveResources, MoveResource::schema())]
                 .into_iter()
                 .collect();
 

--- a/rust/sdk-processor/src/steps/common/processor_status_saver.rs
+++ b/rust/sdk-processor/src/steps/common/processor_status_saver.rs
@@ -5,7 +5,10 @@ use crate::{
         processor_status::ProcessorStatus,
     },
     steps::common::parquet_version_tracker_step::ParquetProcessorStatusSaver,
-    utils::database::{execute_with_better_error, ArcDbPool},
+    utils::{
+        database::{execute_with_better_error, ArcDbPool},
+        parquet_processor_table_mapping::format_table_name,
+    },
 };
 use anyhow::Result;
 use aptos_indexer_processor_sdk::{
@@ -112,8 +115,8 @@ impl ProcessorStatusSaverEnum {
                 conn_pool,
                 processor_name,
             } => {
-                let processor_name = if table_name.is_some() {
-                    format!("{}_{}", processor_name, table_name.unwrap())
+                let processor_name = if let Some(table_name) = table_name {
+                    format_table_name(processor_name, &table_name)
                 } else {
                     processor_name.clone()
                 };

--- a/rust/sdk-processor/src/steps/default_processor/default_extractor.rs
+++ b/rust/sdk-processor/src/steps/default_processor/default_extractor.rs
@@ -7,7 +7,10 @@ use aptos_indexer_processor_sdk::{
 use async_trait::async_trait;
 use processor::{
     db::{
-        common::models::default_models::raw_table_items::TableItemConvertible,
+        common::models::default_models::{
+            raw_current_table_items::CurrentTableItemConvertible,
+            raw_table_items::TableItemConvertible,
+        },
         postgres::models::default_models::{
             block_metadata_transactions::BlockMetadataTransactionModel,
             move_tables::{CurrentTableItem, TableItem, TableMetadata},
@@ -49,17 +52,21 @@ impl Processable for DefaultExtractor {
         >,
         ProcessorError,
     > {
-        let (block_metadata_transactions, raw_table_items, current_table_items, table_metadata) =
+        let (block_metadata_transactions, raw_table_items, raw_current_table_items, table_metadata) =
             process_transactions(transactions.data.clone());
 
         let postgres_table_items: Vec<TableItem> =
             raw_table_items.iter().map(TableItem::from_raw).collect();
+        let postgres_current_table_items: Vec<CurrentTableItem> = raw_current_table_items
+            .iter()
+            .map(CurrentTableItem::from_raw)
+            .collect();
 
         Ok(Some(TransactionContext {
             data: (
                 block_metadata_transactions,
                 postgres_table_items,
-                current_table_items,
+                postgres_current_table_items,
                 table_metadata,
             ),
             metadata: transactions.metadata,

--- a/rust/sdk-processor/src/steps/default_processor/default_extractor.rs
+++ b/rust/sdk-processor/src/steps/default_processor/default_extractor.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use processor::{
     db::{
         common::models::default_models::{
+            raw_block_metadata_transactions::BlockMetadataTransactionConvertible,
             raw_current_table_items::CurrentTableItemConvertible,
             raw_table_items::TableItemConvertible,
         },
@@ -52,8 +53,12 @@ impl Processable for DefaultExtractor {
         >,
         ProcessorError,
     > {
-        let (block_metadata_transactions, raw_table_items, raw_current_table_items, table_metadata) =
-            process_transactions(transactions.data.clone());
+        let (
+            raw_block_metadata_transactions,
+            raw_table_items,
+            raw_current_table_items,
+            table_metadata,
+        ) = process_transactions(transactions.data.clone());
 
         let postgres_table_items: Vec<TableItem> =
             raw_table_items.iter().map(TableItem::from_raw).collect();
@@ -61,10 +66,15 @@ impl Processable for DefaultExtractor {
             .iter()
             .map(CurrentTableItem::from_raw)
             .collect();
+        let postgres_block_metadata_transactions: Vec<BlockMetadataTransactionModel> =
+            raw_block_metadata_transactions
+                .iter()
+                .map(BlockMetadataTransactionModel::from_raw)
+                .collect();
 
         Ok(Some(TransactionContext {
             data: (
-                block_metadata_transactions,
+                postgres_block_metadata_transactions,
                 postgres_table_items,
                 postgres_current_table_items,
                 table_metadata,

--- a/rust/sdk-processor/src/steps/default_processor/default_extractor.rs
+++ b/rust/sdk-processor/src/steps/default_processor/default_extractor.rs
@@ -10,7 +10,7 @@ use processor::{
         common::models::default_models::{
             raw_block_metadata_transactions::BlockMetadataTransactionConvertible,
             raw_current_table_items::CurrentTableItemConvertible,
-            raw_table_items::TableItemConvertible,
+            raw_table_items::TableItemConvertible, raw_table_metadata::TableMetadataConvertible,
         },
         postgres::models::default_models::{
             block_metadata_transactions::BlockMetadataTransactionModel,
@@ -57,7 +57,7 @@ impl Processable for DefaultExtractor {
             raw_block_metadata_transactions,
             raw_table_items,
             raw_current_table_items,
-            table_metadata,
+            raw_table_metadata,
         ) = process_transactions(transactions.data.clone());
 
         let postgres_table_items: Vec<TableItem> =
@@ -71,13 +71,17 @@ impl Processable for DefaultExtractor {
                 .iter()
                 .map(BlockMetadataTransactionModel::from_raw)
                 .collect();
+        let postgres_table_metadata = raw_table_metadata
+            .iter()
+            .map(TableMetadata::from_raw)
+            .collect();
 
         Ok(Some(TransactionContext {
             data: (
                 postgres_block_metadata_transactions,
                 postgres_table_items,
                 postgres_current_table_items,
-                table_metadata,
+                postgres_table_metadata,
             ),
             metadata: transactions.metadata,
         }))

--- a/rust/sdk-processor/src/steps/parquet_default_processor/parquet_default_extractor.rs
+++ b/rust/sdk-processor/src/steps/parquet_default_processor/parquet_default_extractor.rs
@@ -14,11 +14,12 @@ use processor::{
         common::models::default_models::{
             raw_block_metadata_transactions::BlockMetadataTransactionConvertible,
             raw_current_table_items::CurrentTableItemConvertible,
-            raw_table_items::TableItemConvertible,
+            raw_table_items::TableItemConvertible, raw_table_metadata::TableMetadataConvertible,
         },
         parquet::models::default_models::{
             parquet_block_metadata_transactions::BlockMetadataTransaction,
             parquet_move_tables::{CurrentTableItem, TableItem},
+            parquet_table_metadata::TableMetadata,
         },
     },
     processors::{
@@ -54,7 +55,7 @@ impl Processable for ParquetDefaultExtractor {
             raw_block_metadata_transactions,
             raw_table_items,
             raw_current_table_items,
-            _table_metadata,
+            raw_table_metadata,
         ) = process_transactions(transactions.data.clone());
 
         let parquet_table_items: Vec<TableItem> =
@@ -68,6 +69,10 @@ impl Processable for ParquetDefaultExtractor {
                 .iter()
                 .map(BlockMetadataTransaction::from_raw)
                 .collect();
+        let parquet_table_metadata: Vec<TableMetadata> = raw_table_metadata
+            .iter()
+            .map(TableMetadata::from_raw)
+            .collect();
 
         let (
             (
@@ -95,6 +100,7 @@ impl Processable for ParquetDefaultExtractor {
             " - BlockMetadataTransactions: {}",
             parquet_block_metadata_transactions.len()
         );
+        debug!(" - TableMetadata: {}", parquet_table_metadata.len());
 
         let mut map: HashMap<ParquetTypeEnum, ParquetTypeStructs> = HashMap::new();
 
@@ -134,6 +140,11 @@ impl Processable for ParquetDefaultExtractor {
                 TableFlags::BLOCK_METADATA_TRANSACTIONS,
                 ParquetTypeEnum::BlockMetadataTransaction,
                 ParquetTypeStructs::BlockMetadataTransaction(parquet_block_metadata_transactions),
+            ),
+            (
+                TableFlags::TABLE_METADATAS,
+                ParquetTypeEnum::TableMetadata,
+                ParquetTypeStructs::TableMetadata(parquet_table_metadata),
             ),
         ];
 

--- a/rust/sdk-processor/src/steps/parquet_default_processor/parquet_default_extractor.rs
+++ b/rust/sdk-processor/src/steps/parquet_default_processor/parquet_default_extractor.rs
@@ -108,37 +108,37 @@ impl Processable for ParquetDefaultExtractor {
         let data_types = [
             (
                 TableFlags::MOVE_RESOURCES,
-                ParquetTypeEnum::MoveResource,
+                ParquetTypeEnum::MoveResources,
                 ParquetTypeStructs::MoveResource(move_resources),
             ),
             (
                 TableFlags::WRITE_SET_CHANGES,
-                ParquetTypeEnum::WriteSetChange,
+                ParquetTypeEnum::WriteSetChanges,
                 ParquetTypeStructs::WriteSetChange(write_set_changes),
             ),
             (
                 TableFlags::TRANSACTIONS,
-                ParquetTypeEnum::Transaction,
+                ParquetTypeEnum::Transactions,
                 ParquetTypeStructs::Transaction(parquet_transactions),
             ),
             (
                 TableFlags::TABLE_ITEMS,
-                ParquetTypeEnum::TableItem,
+                ParquetTypeEnum::TableItems,
                 ParquetTypeStructs::TableItem(parquet_table_items),
             ),
             (
                 TableFlags::MOVE_MODULES,
-                ParquetTypeEnum::MoveModule,
+                ParquetTypeEnum::MoveModules,
                 ParquetTypeStructs::MoveModule(move_modules),
             ),
             (
                 TableFlags::CURRENT_TABLE_ITEMS,
-                ParquetTypeEnum::CurrentTableItem,
+                ParquetTypeEnum::CurrentTableItems,
                 ParquetTypeStructs::CurrentTableItem(parquet_current_table_items),
             ),
             (
                 TableFlags::BLOCK_METADATA_TRANSACTIONS,
-                ParquetTypeEnum::BlockMetadataTransaction,
+                ParquetTypeEnum::BlockMetadataTransactions,
                 ParquetTypeStructs::BlockMetadataTransaction(parquet_block_metadata_transactions),
             ),
             (

--- a/rust/sdk-processor/src/utils/parquet_processor_table_mapping.rs
+++ b/rust/sdk-processor/src/utils/parquet_processor_table_mapping.rs
@@ -15,3 +15,8 @@ lazy_static! {
         map
     };
 }
+
+/// helper function to format the table name with the processor name.
+pub fn format_table_name(prefix: &str, table_name: &str) -> String {
+    format!("{}.{}", prefix, table_name)
+}

--- a/rust/sdk-processor/src/utils/starting_version.rs
+++ b/rust/sdk-processor/src/utils/starting_version.rs
@@ -27,7 +27,7 @@ pub async fn get_starting_version(
     indexer_processor_config: &IndexerProcessorConfig,
     conn_pool: ArcDbPool,
 ) -> Result<u64> {
-    // Check if there's a checkpoint in the approrpiate processor status table.
+    // Check if there's a checkpoint in the appropriate processor status table.
     let latest_processed_version =
         get_starting_version_from_db(indexer_processor_config, conn_pool)
             .await


### PR DESCRIPTION
### Description
 As a part of sdk migration effort, we are migrating all the tables we didn't migrate from default processor.

Tables we are migrating:
1. current_table_items
2. table_metadata
3. block_metadata_transaction
in addition to what we were previously handling with non-sdk parquet processor

no schemas updated except `block_metadata_transaction`, where we added a new field: a bigint since unix epoch. granularity here is ns not ms. also renamed `id` -> `block_id`

###Test Plan
<img width="1473" alt="Screenshot 2024-12-05 at 11 07 13 AM" src="https://github.com/user-attachments/assets/6062ded3-284a-46e3-98f4-b80a5df8d5ee">
