### PR TITLE
Fix untransferable parsing

### DIFF
--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -15,7 +15,7 @@ use crate::{
             v2_fungible_metadata::{FungibleAssetMetadataMapping, FungibleAssetMetadataModel},
         },
         object_models::v2_object_utils::{
-            ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata, Untransferable,
+            ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata,
         },
         resources::{FromWriteResource, V2FungibleAssetResource},
     },
@@ -593,11 +593,6 @@ pub async fn parse_v2_coin(
                                         Some(concurrent_fungible_asset_balance);
                                 },
                             }
-                        }
-                        if let Some(untransferable) =
-                            Untransferable::from_write_resource(write_resource).unwrap()
-                        {
-                            aggregated_data.untransferable = Some(untransferable);
                         }
                     }
                 } else if let Change::DeleteResource(delete_resource) = wsc.change.as_ref().unwrap()


### PR DESCRIPTION
## Description 
1. Add Untransferable resource parsing to objects processor. It uses the `objects_metadata_helper.untransferable` but not actually parsing/inserting it into `objects_metadata_helper` so this fixes that.
2. Delete Untransferable parsing from fa processor since it doesn't use the field. fa processor indexes `is_frozen` which is not about objects transferability, but whether the store itself is frozen. 

## Testing
Run objects and fa processor. Integration tests will be added later since merging to aptos-core is currently broken. 
