### PR TITLE
[parquet-sdk][token_v2] migrate CurrentTokenRoyaltyV1

### DIFF
--- a/rust/processor/src/db/common/models/token_v2_models/mod.rs
+++ b/rust/processor/src/db/common/models/token_v2_models/mod.rs
@@ -1,1 +1,2 @@
 pub mod raw_token_claims;
+pub mod raw_v1_token_royalty;

--- a/rust/processor/src/db/common/models/token_v2_models/raw_v1_token_royalty.rs
+++ b/rust/processor/src/db/common/models/token_v2_models/raw_v1_token_royalty.rs
@@ -1,0 +1,97 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::db::postgres::models::token_models::token_utils::TokenWriteSet;
+use aptos_protos::transaction::v1::WriteTableItem;
+use bigdecimal::BigDecimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RawCurrentTokenRoyaltyV1 {
+    pub token_data_id: String,
+    pub payee_address: String,
+    pub royalty_points_numerator: BigDecimal,
+    pub royalty_points_denominator: BigDecimal,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl Ord for RawCurrentTokenRoyaltyV1 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id.cmp(&other.token_data_id)
+    }
+}
+impl PartialOrd for RawCurrentTokenRoyaltyV1 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl RawCurrentTokenRoyaltyV1 {
+    pub fn pk(&self) -> String {
+        self.token_data_id.clone()
+    }
+
+    // Royalty for v2 token is more complicated and not supported yet. For token v2, royalty can be on the collection (default) or on
+    // the token (override).
+    pub fn get_v1_from_write_table_item(
+        write_table_item: &WriteTableItem,
+        transaction_version: i64,
+        transaction_timestamp: chrono::NaiveDateTime,
+    ) -> anyhow::Result<Option<Self>> {
+        let table_item_data = write_table_item.data.as_ref().unwrap();
+
+        let maybe_token_data = match TokenWriteSet::from_table_item_type(
+            table_item_data.value_type.as_str(),
+            &table_item_data.value,
+            transaction_version,
+        )? {
+            Some(TokenWriteSet::TokenData(inner)) => Some(inner),
+            _ => None,
+        };
+
+        if let Some(token_data) = maybe_token_data {
+            let maybe_token_data_id = match TokenWriteSet::from_table_item_type(
+                table_item_data.key_type.as_str(),
+                &table_item_data.key,
+                transaction_version,
+            )? {
+                Some(TokenWriteSet::TokenDataId(inner)) => Some(inner),
+                _ => None,
+            };
+            if let Some(token_data_id_struct) = maybe_token_data_id {
+                // token data id is the 0x{hash} version of the creator, collection name, and token name
+                let token_data_id = token_data_id_struct.to_id();
+                let payee_address = token_data.royalty.get_payee_address();
+                let royalty_points_numerator = token_data.royalty.royalty_points_numerator.clone();
+                let royalty_points_denominator =
+                    token_data.royalty.royalty_points_denominator.clone();
+
+                return Ok(Some(Self {
+                    token_data_id,
+                    payee_address,
+                    royalty_points_numerator,
+                    royalty_points_denominator,
+                    last_transaction_version: transaction_version,
+                    last_transaction_timestamp: transaction_timestamp,
+                }));
+            } else {
+                tracing::warn!(
+                    transaction_version,
+                    key_type = table_item_data.key_type,
+                    key = table_item_data.key,
+                    "Expecting token_data_id as key for value = token_data"
+                );
+            }
+        }
+        Ok(None)
+    }
+}
+
+pub trait CurrentTokenRoyaltyV1Convertible {
+    fn from_raw(raw_item: RawCurrentTokenRoyaltyV1) -> Self;
+}

--- a/rust/processor/src/db/parquet/models/token_v2_models/mod.rs
+++ b/rust/processor/src/db/parquet/models/token_v2_models/mod.rs
@@ -1,1 +1,2 @@
 pub mod token_claims;
+pub mod v1_token_royalty;

--- a/rust/processor/src/db/parquet/models/token_v2_models/v1_token_royalty.rs
+++ b/rust/processor/src/db/parquet/models/token_v2_models/v1_token_royalty.rs
@@ -6,47 +6,53 @@
 #![allow(clippy::unused_unit)]
 
 use crate::{
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
     db::common::models::token_v2_models::raw_v1_token_royalty::{
         CurrentTokenRoyaltyV1Convertible, RawCurrentTokenRoyaltyV1,
     },
-    schema::current_token_royalty_v1,
 };
-use bigdecimal::BigDecimal;
+use allocative_derive::Allocative;
 use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
 use serde::{Deserialize, Serialize};
 
 #[derive(
-    Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, PartialEq, Eq,
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
 )]
-#[diesel(primary_key(token_data_id))]
-#[diesel(table_name = current_token_royalty_v1)]
 pub struct CurrentTokenRoyaltyV1 {
     pub token_data_id: String,
     pub payee_address: String,
-    pub royalty_points_numerator: BigDecimal,
-    pub royalty_points_denominator: BigDecimal,
+    pub royalty_points_numerator: String, // String format of BigDecimal
+    pub royalty_points_denominator: String, // String format of BigDecimal
     pub last_transaction_version: i64,
+    #[allocative(skip)]
     pub last_transaction_timestamp: chrono::NaiveDateTime,
 }
 
-impl Ord for CurrentTokenRoyaltyV1 {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.token_data_id.cmp(&other.token_data_id)
+impl NamedTable for CurrentTokenRoyaltyV1 {
+    const TABLE_NAME: &'static str = "current_token_royalties_v1";
+}
+
+impl HasVersion for CurrentTokenRoyaltyV1 {
+    fn version(&self) -> i64 {
+        self.last_transaction_version
     }
 }
-impl PartialOrd for CurrentTokenRoyaltyV1 {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
+
+impl GetTimeStamp for CurrentTokenRoyaltyV1 {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.last_transaction_timestamp
     }
 }
 
 impl CurrentTokenRoyaltyV1Convertible for CurrentTokenRoyaltyV1 {
+    // TODO: consider returning a Result
     fn from_raw(raw_item: RawCurrentTokenRoyaltyV1) -> Self {
         Self {
             token_data_id: raw_item.token_data_id,
             payee_address: raw_item.payee_address,
-            royalty_points_numerator: raw_item.royalty_points_numerator,
-            royalty_points_denominator: raw_item.royalty_points_denominator,
+            royalty_points_numerator: raw_item.royalty_points_numerator.to_string(),
+            royalty_points_denominator: raw_item.royalty_points_denominator.to_string(),
             last_transaction_version: raw_item.last_transaction_version,
             last_transaction_timestamp: raw_item.last_transaction_timestamp,
         }

--- a/rust/processor/src/utils/table_flags.rs
+++ b/rust/processor/src/utils/table_flags.rs
@@ -52,6 +52,7 @@ bitflags! {
         const COLLECTIONS_V2 = 1 << 57;
         const TOKEN_OWNERSHIPS_V2 = 1 << 58;
         const TOKEN_DATAS_V2 = 1 << 59;
+        const CURRENT_TOKEN_ROYALTY_V1 = 1 << 60;
 
         // User Transactions and Signatures: 61-70
         const USER_TRANSACTIONS = 1 << 61;

--- a/rust/sdk-processor/src/config/processor_config.rs
+++ b/rust/sdk-processor/src/config/processor_config.rs
@@ -27,7 +27,9 @@ use processor::{
             },
             parquet_v2_fungible_metadata::FungibleAssetMetadataModel,
         },
-        token_v2_models::token_claims::CurrentTokenPendingClaim,
+        token_v2_models::{
+            token_claims::CurrentTokenPendingClaim, v1_token_royalty::CurrentTokenRoyaltyV1,
+        },
         transaction_metadata_model::parquet_write_set_size_info::WriteSetSize,
         user_transaction_models::parquet_user_transactions::UserTransaction,
     },
@@ -166,9 +168,10 @@ impl ProcessorConfig {
             ProcessorName::ParquetAccountTransactionsProcessor => {
                 HashSet::from([AccountTransaction::TABLE_NAME.to_string()])
             },
-            ProcessorName::ParquetTokenV2Processor => {
-                HashSet::from([CurrentTokenPendingClaim::TABLE_NAME.to_string()])
-            },
+            ProcessorName::ParquetTokenV2Processor => HashSet::from([
+                CurrentTokenPendingClaim::TABLE_NAME.to_string(),
+                CurrentTokenRoyaltyV1::TABLE_NAME.to_string(),
+            ]),
             _ => HashSet::new(), // Default case for unsupported processors
         }
     }

--- a/rust/sdk-processor/src/parquet_processors/mod.rs
+++ b/rust/sdk-processor/src/parquet_processors/mod.rs
@@ -33,7 +33,9 @@ use processor::{
             },
             parquet_v2_fungible_metadata::FungibleAssetMetadataModel,
         },
-        token_v2_models::token_claims::CurrentTokenPendingClaim,
+        token_v2_models::{
+            token_claims::CurrentTokenPendingClaim, v1_token_royalty::CurrentTokenRoyaltyV1,
+        },
         transaction_metadata_model::parquet_write_set_size_info::WriteSetSize,
         user_transaction_models::parquet_user_transactions::UserTransaction,
     },
@@ -109,6 +111,7 @@ pub enum ParquetTypeEnum {
     AccountTransactions,
     // token v2
     CurrentTokenPendingClaims,
+    CurrentTokenRoyaltiesV1,
 }
 
 /// Trait for handling various Parquet types.
@@ -191,6 +194,10 @@ impl_parquet_trait!(
     CurrentTokenPendingClaim,
     ParquetTypeEnum::CurrentTokenPendingClaims
 );
+impl_parquet_trait!(
+    CurrentTokenRoyaltyV1,
+    ParquetTypeEnum::CurrentTokenRoyaltiesV1
+);
 
 #[derive(Debug, Clone)]
 #[enum_dispatch(ParquetTypeTrait)]
@@ -214,6 +221,7 @@ pub enum ParquetTypeStructs {
     WriteSetSize(Vec<WriteSetSize>),
     AccountTransaction(Vec<AccountTransaction>),
     CurrentTokenPendingClaim(Vec<CurrentTokenPendingClaim>),
+    CurrentTokenRoyaltyV1(Vec<CurrentTokenRoyaltyV1>),
 }
 
 impl ParquetTypeStructs {
@@ -253,6 +261,9 @@ impl ParquetTypeStructs {
             },
             ParquetTypeEnum::CurrentTokenPendingClaims => {
                 ParquetTypeStructs::CurrentTokenPendingClaim(Vec::new())
+            },
+            ParquetTypeEnum::CurrentTokenRoyaltiesV1 => {
+                ParquetTypeStructs::CurrentTokenRoyaltyV1(Vec::new())
             },
         }
     }
@@ -375,6 +386,12 @@ impl ParquetTypeStructs {
             (
                 ParquetTypeStructs::CurrentTokenPendingClaim(self_data),
                 ParquetTypeStructs::CurrentTokenPendingClaim(other_data),
+            ) => {
+                handle_append!(self_data, other_data)
+            },
+            (
+                ParquetTypeStructs::CurrentTokenRoyaltyV1(self_data),
+                ParquetTypeStructs::CurrentTokenRoyaltyV1(other_data),
             ) => {
                 handle_append!(self_data, other_data)
             },

--- a/rust/sdk-processor/src/parquet_processors/parquet_token_v2_processor.rs
+++ b/rust/sdk-processor/src/parquet_processors/parquet_token_v2_processor.rs
@@ -30,7 +30,9 @@ use aptos_indexer_processor_sdk::{
 use parquet::schema::types::Type;
 use processor::{
     bq_analytics::generic_parquet_processor::HasParquetSchema,
-    db::parquet::models::token_v2_models::token_claims::CurrentTokenPendingClaim,
+    db::parquet::models::token_v2_models::{
+        token_claims::CurrentTokenPendingClaim, v1_token_royalty::CurrentTokenRoyaltyV1,
+    },
 };
 use std::{collections::HashMap, sync::Arc};
 use tracing::{debug, info};
@@ -121,10 +123,16 @@ impl ProcessorTrait for ParquetTokenV2Processor {
             initialize_gcs_client(parquet_db_config.google_application_credentials.clone()).await;
 
         // TODO: Update this
-        let parquet_type_to_schemas: HashMap<ParquetTypeEnum, Arc<Type>> = [(
-            ParquetTypeEnum::CurrentTokenPendingClaims,
-            CurrentTokenPendingClaim::schema(),
-        )]
+        let parquet_type_to_schemas: HashMap<ParquetTypeEnum, Arc<Type>> = [
+            (
+                ParquetTypeEnum::CurrentTokenPendingClaims,
+                CurrentTokenPendingClaim::schema(),
+            ),
+            (
+                ParquetTypeEnum::CurrentTokenRoyaltiesV1,
+                CurrentTokenRoyaltyV1::schema(),
+            ),
+        ]
         .into_iter()
         .collect();
 

--- a/rust/sdk-processor/src/steps/token_v2_processor/token_v2_extractor.rs
+++ b/rust/sdk-processor/src/steps/token_v2_processor/token_v2_extractor.rs
@@ -8,7 +8,10 @@ use aptos_indexer_processor_sdk::{
 use async_trait::async_trait;
 use processor::{
     db::{
-        common::models::token_v2_models::raw_token_claims::CurrentTokenPendingClaimConvertible,
+        common::models::token_v2_models::{
+            raw_token_claims::CurrentTokenPendingClaimConvertible,
+            raw_v1_token_royalty::CurrentTokenRoyaltyV1Convertible,
+        },
         postgres::models::{
             token_models::{token_claims::CurrentTokenPendingClaim, tokens::TableMetadataForToken},
             token_v2_models::{
@@ -69,9 +72,9 @@ impl Processable for TokenV2Extractor {
     ) -> Result<
         Option<
             TransactionContext<(
-                Vec<CollectionV2>,
-                Vec<TokenDataV2>,
-                Vec<TokenOwnershipV2>,
+                Vec<CollectionV2>,     // TODO: Deprecate this
+                Vec<TokenDataV2>,      // TODO: Deprecate this
+                Vec<TokenOwnershipV2>, // TODO: Deprecate this
                 Vec<CurrentCollectionV2>,
                 Vec<CurrentTokenDataV2>,
                 Vec<CurrentTokenDataV2>,
@@ -110,7 +113,7 @@ impl Processable for TokenV2Extractor {
             current_deleted_token_ownerships_v2,
             token_activities_v2,
             current_token_v2_metadata,
-            current_token_royalties_v1,
+            raw_current_token_royalties_v1,
             raw_current_token_claims,
         ) = parse_v2_token(
             &transactions.data,
@@ -126,6 +129,12 @@ impl Processable for TokenV2Extractor {
             .map(CurrentTokenPendingClaim::from_raw)
             .collect();
 
+        let postgres_current_token_royalties_v1: Vec<CurrentTokenRoyaltyV1> =
+            raw_current_token_royalties_v1
+                .into_iter()
+                .map(CurrentTokenRoyaltyV1::from_raw)
+                .collect();
+
         Ok(Some(TransactionContext {
             data: (
                 collections_v2,
@@ -138,7 +147,7 @@ impl Processable for TokenV2Extractor {
                 current_deleted_token_ownerships_v2,
                 token_activities_v2,
                 current_token_v2_metadata,
-                current_token_royalties_v1,
+                postgres_current_token_royalties_v1,
                 postgres_current_token_claims,
             ),
             metadata: transactions.metadata,


### PR DESCRIPTION
### Description
- added RawCurrentTokenRoyalty models
-
### TestPlan
ran both legacy and sdk postgres processor .. num of rows match for all three.

![Screenshot 2024-12-11 at 7 57 48 PM](https://github.com/user-attachments/assets/efb35ab7-1863-4702-8db2-9d4c9692c5c5)
![Screenshot 2024-12-11 at 9 29 45 PM](https://github.com/user-attachments/assets/3f2b22a6-3def-41db-b886-fec8662209eb)
