### PR TITLE
[parquet-sdk][token_v2] migrate TokenDataV2 and CurrentTokenDataV2

### DIFF
--- a/rust/processor/src/db/common/models/token_v2_models/mod.rs
+++ b/rust/processor/src/db/common/models/token_v2_models/mod.rs
@@ -1,4 +1,5 @@
 pub mod raw_token_claims;
 pub mod raw_v1_token_royalty;
 pub mod raw_v2_token_activities;
+pub mod raw_v2_token_datas;
 pub mod raw_v2_token_metadata;

--- a/rust/processor/src/db/common/models/token_v2_models/raw_v2_token_datas.rs
+++ b/rust/processor/src/db/common/models/token_v2_models/raw_v2_token_datas.rs
@@ -6,63 +6,69 @@
 #![allow(clippy::unused_unit)]
 
 use crate::{
-    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
     db::postgres::models::{
         object_models::v2_object_utils::ObjectAggregatedDataMapping,
         resources::FromWriteResource,
         token_models::token_utils::TokenWriteSet,
-        token_v2_models::{
-            v2_token_datas::CurrentTokenDataV2,
-            v2_token_utils::{TokenStandard, TokenV2, TokenV2Burned},
-        },
+        token_v2_models::v2_token_utils::{TokenStandard, TokenV2, TokenV2Burned},
     },
     utils::util::standardize_address,
 };
-use allocative_derive::Allocative;
-use anyhow::Context;
 use aptos_protos::transaction::v1::{DeleteResource, WriteResource, WriteTableItem};
-use bigdecimal::ToPrimitive;
-use field_count::FieldCount;
-use parquet_derive::ParquetRecordWriter;
+use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};
 
-#[derive(
-    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
-)]
-pub struct TokenDataV2 {
-    pub txn_version: i64,
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct RawTokenDataV2 {
+    pub transaction_version: i64,
     pub write_set_change_index: i64,
     pub token_data_id: String,
     pub collection_id: String,
     pub token_name: String,
-    pub largest_property_version_v1: Option<u64>,
+    pub maximum: Option<BigDecimal>,
+    pub supply: Option<BigDecimal>,
+    pub largest_property_version_v1: Option<BigDecimal>,
     pub token_uri: String,
-    pub token_properties: String,
+    pub token_properties: serde_json::Value,
     pub description: String,
     pub token_standard: String,
     pub is_fungible_v2: Option<bool>,
-    #[allocative(skip)]
-    pub block_timestamp: chrono::NaiveDateTime,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+    // Deprecated, but still here for backwards compatibility
+    pub decimals: Option<i64>,
+    // Here for consistency but we don't need to actually fill it
     pub is_deleted_v2: Option<bool>,
 }
 
-impl NamedTable for TokenDataV2 {
-    const TABLE_NAME: &'static str = "token_datas_v2";
+pub trait TokenDataV2Convertible {
+    fn from_raw(raw_item: RawTokenDataV2) -> Self;
 }
 
-impl HasVersion for TokenDataV2 {
-    fn version(&self) -> i64 {
-        self.txn_version
-    }
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RawCurrentTokenDataV2 {
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub maximum: Option<BigDecimal>,
+    pub supply: Option<BigDecimal>,
+    pub largest_property_version_v1: Option<BigDecimal>,
+    pub token_uri: String,
+    pub token_properties: serde_json::Value,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    // Deprecated, but still here for backwards compatibility
+    pub decimals: Option<i64>,
+    pub is_deleted_v2: Option<bool>,
 }
 
-impl GetTimeStamp for TokenDataV2 {
-    fn get_timestamp(&self) -> chrono::NaiveDateTime {
-        self.block_timestamp
-    }
+pub trait CurrentTokenDataV2Convertible {
+    fn from_raw(raw_item: RawCurrentTokenDataV2) -> Self;
 }
 
-impl TokenDataV2 {
+impl RawTokenDataV2 {
     // TODO: remove the useless_asref lint when new clippy nighly is released.
     #[allow(clippy::useless_asref)]
     pub fn get_v2_from_write_resource(
@@ -71,7 +77,7 @@ impl TokenDataV2 {
         write_set_change_index: i64,
         txn_timestamp: chrono::NaiveDateTime,
         object_metadatas: &ObjectAggregatedDataMapping,
-    ) -> anyhow::Result<Option<Self>> {
+    ) -> anyhow::Result<Option<(Self, RawCurrentTokenDataV2)>> {
         if let Some(inner) = &TokenV2::from_write_resource(write_resource)? {
             let token_data_id = standardize_address(&write_resource.address.to_string());
             let mut token_name = inner.get_name_trunc();
@@ -102,22 +108,43 @@ impl TokenDataV2 {
             let collection_id = inner.get_collection_address();
             let token_uri = inner.get_uri_trunc();
 
-            Ok(Some(Self {
-                txn_version,
-                write_set_change_index,
-                token_data_id: token_data_id.clone(),
-                collection_id: collection_id.clone(),
-                token_name: token_name.clone(),
-                largest_property_version_v1: None,
-                token_uri: token_uri.clone(),
-                token_properties: canonical_json::to_string(&token_properties.clone())
-                    .context("Failed to serialize token properties")?,
-                description: inner.description.clone(),
-                token_standard: TokenStandard::V2.to_string(),
-                is_fungible_v2,
-                block_timestamp: txn_timestamp,
-                is_deleted_v2: None,
-            }))
+            Ok(Some((
+                Self {
+                    transaction_version: txn_version,
+                    write_set_change_index,
+                    token_data_id: token_data_id.clone(),
+                    collection_id: collection_id.clone(),
+                    token_name: token_name.clone(),
+                    maximum: None,
+                    supply: None,
+                    largest_property_version_v1: None,
+                    token_uri: token_uri.clone(),
+                    token_properties: token_properties.clone(),
+                    description: inner.description.clone(),
+                    token_standard: TokenStandard::V2.to_string(),
+                    is_fungible_v2,
+                    transaction_timestamp: txn_timestamp,
+                    decimals: None,
+                    is_deleted_v2: None,
+                },
+                RawCurrentTokenDataV2 {
+                    token_data_id,
+                    collection_id,
+                    token_name,
+                    maximum: None,
+                    supply: None,
+                    largest_property_version_v1: None,
+                    token_uri,
+                    token_properties,
+                    description: inner.description.clone(),
+                    token_standard: TokenStandard::V2.to_string(),
+                    is_fungible_v2,
+                    last_transaction_version: txn_version,
+                    last_transaction_timestamp: txn_timestamp,
+                    decimals: None,
+                    is_deleted_v2: Some(false),
+                },
+            )))
         } else {
             Ok(None)
         }
@@ -129,11 +156,11 @@ impl TokenDataV2 {
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
         tokens_burned: &TokenV2Burned,
-    ) -> anyhow::Result<Option<CurrentTokenDataV2>> {
+    ) -> anyhow::Result<Option<RawCurrentTokenDataV2>> {
         let token_data_id = standardize_address(&write_resource.address.to_string());
         // reminder that v1 events won't get to this codepath
         if let Some(burn_event_v2) = tokens_burned.get(&standardize_address(&token_data_id)) {
-            Ok(Some(CurrentTokenDataV2 {
+            Ok(Some(RawCurrentTokenDataV2 {
                 token_data_id,
                 collection_id: burn_event_v2.get_collection_address(),
                 token_name: "".to_string(),
@@ -161,11 +188,11 @@ impl TokenDataV2 {
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
         tokens_burned: &TokenV2Burned,
-    ) -> anyhow::Result<Option<CurrentTokenDataV2>> {
+    ) -> anyhow::Result<Option<RawCurrentTokenDataV2>> {
         let token_data_id = standardize_address(&delete_resource.address.to_string());
         // reminder that v1 events won't get to this codepath
         if let Some(burn_event_v2) = tokens_burned.get(&standardize_address(&token_data_id)) {
-            Ok(Some(CurrentTokenDataV2 {
+            Ok(Some(RawCurrentTokenDataV2 {
                 token_data_id,
                 collection_id: burn_event_v2.get_collection_address(),
                 token_name: "".to_string(),
@@ -192,7 +219,7 @@ impl TokenDataV2 {
         txn_version: i64,
         write_set_change_index: i64,
         txn_timestamp: chrono::NaiveDateTime,
-    ) -> anyhow::Result<Option<Self>> {
+    ) -> anyhow::Result<Option<(Self, RawCurrentTokenDataV2)>> {
         let table_item_data = table_item.data.as_ref().unwrap();
 
         let maybe_token_data = match TokenWriteSet::from_table_item_type(
@@ -219,30 +246,45 @@ impl TokenDataV2 {
                 let token_name = token_data_id_struct.get_name_trunc();
                 let token_uri = token_data.get_uri_trunc();
 
-                return Ok(Some(Self {
-                    txn_version,
-                    write_set_change_index,
-                    token_data_id: token_data_id.clone(),
-                    collection_id: collection_id.clone(),
-                    token_name: token_name.clone(),
-                    largest_property_version_v1: Some(
-                        token_data
-                            .largest_property_version
-                            .clone()
-                            .to_u64()
-                            .unwrap(),
-                    ),
-                    token_uri: token_uri.clone(),
-                    token_properties: canonical_json::to_string(
-                        &token_data.default_properties.clone(),
-                    )
-                    .context("Failed to serialize token properties")?,
-                    description: token_data.description.clone(),
-                    token_standard: TokenStandard::V1.to_string(),
-                    is_fungible_v2: None,
-                    block_timestamp: txn_timestamp,
-                    is_deleted_v2: None,
-                }));
+                return Ok(Some((
+                    Self {
+                        transaction_version: txn_version,
+                        write_set_change_index,
+                        token_data_id: token_data_id.clone(),
+                        collection_id: collection_id.clone(),
+                        token_name: token_name.clone(),
+                        maximum: Some(token_data.maximum.clone()),
+                        supply: Some(token_data.supply.clone()),
+                        largest_property_version_v1: Some(
+                            token_data.largest_property_version.clone(),
+                        ),
+                        token_uri: token_uri.clone(),
+                        token_properties: token_data.default_properties.clone(),
+                        description: token_data.description.clone(),
+                        token_standard: TokenStandard::V1.to_string(),
+                        is_fungible_v2: None,
+                        transaction_timestamp: txn_timestamp,
+                        decimals: None,
+                        is_deleted_v2: None,
+                    },
+                    RawCurrentTokenDataV2 {
+                        token_data_id,
+                        collection_id,
+                        token_name,
+                        maximum: Some(token_data.maximum),
+                        supply: Some(token_data.supply),
+                        largest_property_version_v1: Some(token_data.largest_property_version),
+                        token_uri,
+                        token_properties: token_data.default_properties,
+                        description: token_data.description,
+                        token_standard: TokenStandard::V1.to_string(),
+                        is_fungible_v2: None,
+                        last_transaction_version: txn_version,
+                        last_transaction_timestamp: txn_timestamp,
+                        decimals: None,
+                        is_deleted_v2: None,
+                    },
+                )));
             } else {
                 tracing::warn!(
                     transaction_version = txn_version,

--- a/rust/processor/src/db/parquet/models/mod.rs
+++ b/rust/processor/src/db/parquet/models/mod.rs
@@ -6,3 +6,5 @@ pub mod fungible_asset_models;
 pub mod token_v2_models;
 pub mod transaction_metadata_model;
 pub mod user_transaction_models;
+
+const DEFAULT_NONE: &str = "NULL";

--- a/rust/processor/src/db/parquet/models/token_v2_models/mod.rs
+++ b/rust/processor/src/db/parquet/models/token_v2_models/mod.rs
@@ -1,6 +1,6 @@
 pub mod token_claims;
 pub mod v1_token_royalty;
 pub mod v2_token_activities;
+pub mod v2_token_datas;
 pub mod v2_token_metadata;
-
 pub mod v2_token_ownerships;

--- a/rust/processor/src/db/parquet/models/token_v2_models/v2_token_datas.rs
+++ b/rust/processor/src/db/parquet/models/token_v2_models/v2_token_datas.rs
@@ -1,0 +1,150 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    bq_analytics::generic_parquet_processor::{GetTimeStamp, HasVersion, NamedTable},
+    db::{
+        common::models::token_v2_models::raw_v2_token_datas::{
+            CurrentTokenDataV2Convertible, RawCurrentTokenDataV2, RawTokenDataV2,
+            TokenDataV2Convertible,
+        },
+        parquet::models::DEFAULT_NONE,
+    },
+};
+use allocative_derive::Allocative;
+use anyhow::Context;
+use bigdecimal::ToPrimitive;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
+pub struct TokenDataV2 {
+    pub txn_version: i64,
+    pub write_set_change_index: i64,
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub largest_property_version_v1: Option<u64>,
+    pub token_uri: String,
+    pub token_properties: String,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    #[allocative(skip)]
+    pub block_timestamp: chrono::NaiveDateTime,
+    pub is_deleted_v2: Option<bool>,
+}
+
+impl NamedTable for TokenDataV2 {
+    const TABLE_NAME: &'static str = "token_datas_v2";
+}
+
+impl HasVersion for TokenDataV2 {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl GetTimeStamp for TokenDataV2 {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
+    }
+}
+
+impl TokenDataV2Convertible for TokenDataV2 {
+    fn from_raw(raw_item: RawTokenDataV2) -> Self {
+        Self {
+            txn_version: raw_item.transaction_version,
+            write_set_change_index: raw_item.write_set_change_index,
+            token_data_id: raw_item.token_data_id,
+            collection_id: raw_item.collection_id,
+            token_name: raw_item.token_name,
+            largest_property_version_v1: Some(
+                raw_item
+                    .largest_property_version_v1
+                    .unwrap()
+                    .to_u64()
+                    .unwrap(),
+            ),
+            token_uri: raw_item.token_uri,
+            token_properties: canonical_json::to_string(&raw_item.token_properties.clone())
+                .context("Failed to serialize token properties")
+                .unwrap(),
+            description: raw_item.description,
+            token_standard: raw_item.token_standard,
+            is_fungible_v2: raw_item.is_fungible_v2,
+            block_timestamp: raw_item.transaction_timestamp,
+            is_deleted_v2: raw_item.is_deleted_v2,
+        }
+    }
+}
+
+#[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
+pub struct CurrentTokenDataV2 {
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub maximum: Option<String>, // BigDecimal
+    pub supply: Option<String>,
+    pub largest_property_version_v1: Option<u64>,
+    pub token_uri: String,
+    pub token_properties: String, // serde_json::Value,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub last_transaction_version: i64,
+    #[allocative(skip)]
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    // Deprecated, but still here for backwards compatibility
+    pub decimals: Option<i64>,
+    pub is_deleted_v2: Option<bool>,
+}
+
+impl NamedTable for CurrentTokenDataV2 {
+    const TABLE_NAME: &'static str = "current_token_datas_v2";
+}
+
+impl HasVersion for CurrentTokenDataV2 {
+    fn version(&self) -> i64 {
+        self.last_transaction_version
+    }
+}
+
+impl GetTimeStamp for CurrentTokenDataV2 {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.last_transaction_timestamp
+    }
+}
+
+impl CurrentTokenDataV2Convertible for CurrentTokenDataV2 {
+    fn from_raw(raw_item: RawCurrentTokenDataV2) -> Self {
+        Self {
+            token_data_id: raw_item.token_data_id,
+            collection_id: raw_item.collection_id,
+            token_name: raw_item.token_name,
+            maximum: raw_item
+                .maximum
+                .map_or(Some(DEFAULT_NONE.to_string()), |v| Some(v.to_string())),
+            supply: raw_item
+                .supply
+                .map_or(Some(DEFAULT_NONE.to_string()), |v| Some(v.to_string())),
+            largest_property_version_v1: raw_item
+                .largest_property_version_v1
+                .map(|v| v.to_u64().unwrap_or(0)),
+            token_uri: raw_item.token_uri,
+            token_properties: canonical_json::to_string(&raw_item.token_properties)
+                .unwrap_or_else(|_| DEFAULT_NONE.to_string()),
+            description: raw_item.description,
+            token_standard: raw_item.token_standard,
+            is_fungible_v2: raw_item.is_fungible_v2.or(Some(false)), // Defaulting to false if None
+            last_transaction_version: raw_item.last_transaction_version,
+            last_transaction_timestamp: raw_item.last_transaction_timestamp,
+            decimals: raw_item.decimals,
+            is_deleted_v2: raw_item.is_deleted_v2.or(Some(false)), // Defaulting to false if None
+        }
+    }
+}

--- a/rust/processor/src/db/postgres/models/token_v2_models/mod.rs
+++ b/rust/processor/src/db/postgres/models/token_v2_models/mod.rs
@@ -8,7 +8,3 @@ pub mod v2_token_datas;
 pub mod v2_token_metadata;
 pub mod v2_token_ownerships;
 pub mod v2_token_utils;
-
-// parquet models
-// pub mod parquet_v2_collections; // revisit this
-pub mod parquet_v2_token_datas;

--- a/rust/processor/src/db/postgres/models/token_v2_models/v2_token_datas.rs
+++ b/rust/processor/src/db/postgres/models/token_v2_models/v2_token_datas.rs
@@ -5,16 +5,13 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::v2_token_utils::{TokenStandard, TokenV2, TokenV2Burned};
 use crate::{
-    db::postgres::models::{
-        object_models::v2_object_utils::ObjectAggregatedDataMapping, resources::FromWriteResource,
-        token_models::token_utils::TokenWriteSet,
+    db::common::models::token_v2_models::raw_v2_token_datas::{
+        CurrentTokenDataV2Convertible, RawCurrentTokenDataV2, RawTokenDataV2,
+        TokenDataV2Convertible,
     },
     schema::{current_token_datas_v2, token_datas_v2},
-    utils::util::standardize_address,
 };
-use aptos_protos::transaction::v1::{DeleteResource, WriteResource, WriteTableItem};
 use bigdecimal::BigDecimal;
 use diesel::prelude::*;
 use field_count::FieldCount;
@@ -47,6 +44,28 @@ pub struct TokenDataV2 {
     // pub is_deleted_v2: Option<bool>,
 }
 
+impl TokenDataV2Convertible for TokenDataV2 {
+    fn from_raw(raw_item: RawTokenDataV2) -> Self {
+        Self {
+            transaction_version: raw_item.transaction_version,
+            write_set_change_index: raw_item.write_set_change_index,
+            token_data_id: raw_item.token_data_id,
+            collection_id: raw_item.collection_id,
+            token_name: raw_item.token_name,
+            maximum: raw_item.maximum,
+            supply: raw_item.supply,
+            largest_property_version_v1: raw_item.largest_property_version_v1,
+            token_uri: raw_item.token_uri,
+            token_properties: raw_item.token_properties,
+            description: raw_item.description,
+            token_standard: raw_item.token_standard,
+            is_fungible_v2: raw_item.is_fungible_v2,
+            transaction_timestamp: raw_item.transaction_timestamp,
+            decimals: raw_item.decimals,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(token_data_id))]
 #[diesel(table_name = current_token_datas_v2)]
@@ -69,230 +88,24 @@ pub struct CurrentTokenDataV2 {
     pub is_deleted_v2: Option<bool>,
 }
 
-impl TokenDataV2 {
-    // TODO: remove the useless_asref lint when new clippy nighly is released.
-    #[allow(clippy::useless_asref)]
-    pub fn get_v2_from_write_resource(
-        write_resource: &WriteResource,
-        txn_version: i64,
-        write_set_change_index: i64,
-        txn_timestamp: chrono::NaiveDateTime,
-        object_metadatas: &ObjectAggregatedDataMapping,
-    ) -> anyhow::Result<Option<(Self, CurrentTokenDataV2)>> {
-        if let Some(inner) = &TokenV2::from_write_resource(write_resource)? {
-            let token_data_id = standardize_address(&write_resource.address.to_string());
-            let mut token_name = inner.get_name_trunc();
-            let is_fungible_v2;
-            // Get token properties from 0x4::property_map::PropertyMap
-            let mut token_properties = serde_json::Value::Null;
-            if let Some(object_metadata) = object_metadatas.get(&token_data_id) {
-                let fungible_asset_metadata = object_metadata.fungible_asset_metadata.as_ref();
-                if fungible_asset_metadata.is_some() {
-                    is_fungible_v2 = Some(true);
-                } else {
-                    is_fungible_v2 = Some(false);
-                }
-                token_properties = object_metadata
-                    .property_map
-                    .as_ref()
-                    .map(|m| m.inner.clone())
-                    .unwrap_or(token_properties);
-                // In aggregator V2 name is now derived from a separate struct
-                if let Some(token_identifier) = object_metadata.token_identifier.as_ref() {
-                    token_name = token_identifier.get_name_trunc();
-                }
-            } else {
-                // ObjectCore should not be missing, returning from entire function early
-                return Ok(None);
-            }
-
-            let collection_id = inner.get_collection_address();
-            let token_uri = inner.get_uri_trunc();
-
-            Ok(Some((
-                Self {
-                    transaction_version: txn_version,
-                    write_set_change_index,
-                    token_data_id: token_data_id.clone(),
-                    collection_id: collection_id.clone(),
-                    token_name: token_name.clone(),
-                    maximum: None,
-                    supply: None,
-                    largest_property_version_v1: None,
-                    token_uri: token_uri.clone(),
-                    token_properties: token_properties.clone(),
-                    description: inner.description.clone(),
-                    token_standard: TokenStandard::V2.to_string(),
-                    is_fungible_v2,
-                    transaction_timestamp: txn_timestamp,
-                    decimals: None,
-                },
-                CurrentTokenDataV2 {
-                    token_data_id,
-                    collection_id,
-                    token_name,
-                    maximum: None,
-                    supply: None,
-                    largest_property_version_v1: None,
-                    token_uri,
-                    token_properties,
-                    description: inner.description.clone(),
-                    token_standard: TokenStandard::V2.to_string(),
-                    is_fungible_v2,
-                    last_transaction_version: txn_version,
-                    last_transaction_timestamp: txn_timestamp,
-                    decimals: None,
-                    is_deleted_v2: Some(false),
-                },
-            )))
-        } else {
-            Ok(None)
+impl CurrentTokenDataV2Convertible for CurrentTokenDataV2 {
+    fn from_raw(raw_item: RawCurrentTokenDataV2) -> Self {
+        Self {
+            token_data_id: raw_item.token_data_id,
+            collection_id: raw_item.collection_id,
+            token_name: raw_item.token_name,
+            maximum: raw_item.maximum,
+            supply: raw_item.supply,
+            largest_property_version_v1: raw_item.largest_property_version_v1,
+            token_uri: raw_item.token_uri,
+            token_properties: raw_item.token_properties,
+            description: raw_item.description,
+            token_standard: raw_item.token_standard,
+            is_fungible_v2: raw_item.is_fungible_v2,
+            last_transaction_version: raw_item.last_transaction_version,
+            last_transaction_timestamp: raw_item.last_transaction_timestamp,
+            decimals: raw_item.decimals,
+            is_deleted_v2: raw_item.is_deleted_v2,
         }
-    }
-
-    /// This handles the case where token is burned but objectCore is still there
-    pub async fn get_burned_nft_v2_from_write_resource(
-        write_resource: &WriteResource,
-        txn_version: i64,
-        txn_timestamp: chrono::NaiveDateTime,
-        tokens_burned: &TokenV2Burned,
-    ) -> anyhow::Result<Option<CurrentTokenDataV2>> {
-        let token_data_id = standardize_address(&write_resource.address.to_string());
-        // reminder that v1 events won't get to this codepath
-        if let Some(burn_event_v2) = tokens_burned.get(&standardize_address(&token_data_id)) {
-            Ok(Some(CurrentTokenDataV2 {
-                token_data_id,
-                collection_id: burn_event_v2.get_collection_address(),
-                token_name: "".to_string(),
-                maximum: None,
-                supply: None,
-                largest_property_version_v1: None,
-                token_uri: "".to_string(),
-                token_properties: serde_json::Value::Null,
-                description: "".to_string(),
-                token_standard: TokenStandard::V2.to_string(),
-                is_fungible_v2: Some(false),
-                last_transaction_version: txn_version,
-                last_transaction_timestamp: txn_timestamp,
-                decimals: None,
-                is_deleted_v2: Some(true),
-            }))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// This handles the case where token is burned and objectCore is deleted
-    pub async fn get_burned_nft_v2_from_delete_resource(
-        delete_resource: &DeleteResource,
-        txn_version: i64,
-        txn_timestamp: chrono::NaiveDateTime,
-        tokens_burned: &TokenV2Burned,
-    ) -> anyhow::Result<Option<CurrentTokenDataV2>> {
-        let token_data_id = standardize_address(&delete_resource.address.to_string());
-        // reminder that v1 events won't get to this codepath
-        if let Some(burn_event_v2) = tokens_burned.get(&standardize_address(&token_data_id)) {
-            Ok(Some(CurrentTokenDataV2 {
-                token_data_id,
-                collection_id: burn_event_v2.get_collection_address(),
-                token_name: "".to_string(),
-                maximum: None,
-                supply: None,
-                largest_property_version_v1: None,
-                token_uri: "".to_string(),
-                token_properties: serde_json::Value::Null,
-                description: "".to_string(),
-                token_standard: TokenStandard::V2.to_string(),
-                is_fungible_v2: Some(false),
-                last_transaction_version: txn_version,
-                last_transaction_timestamp: txn_timestamp,
-                decimals: None,
-                is_deleted_v2: Some(true),
-            }))
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub fn get_v1_from_write_table_item(
-        table_item: &WriteTableItem,
-        txn_version: i64,
-        write_set_change_index: i64,
-        txn_timestamp: chrono::NaiveDateTime,
-    ) -> anyhow::Result<Option<(Self, CurrentTokenDataV2)>> {
-        let table_item_data = table_item.data.as_ref().unwrap();
-
-        let maybe_token_data = match TokenWriteSet::from_table_item_type(
-            table_item_data.value_type.as_str(),
-            &table_item_data.value,
-            txn_version,
-        )? {
-            Some(TokenWriteSet::TokenData(inner)) => Some(inner),
-            _ => None,
-        };
-
-        if let Some(token_data) = maybe_token_data {
-            let maybe_token_data_id = match TokenWriteSet::from_table_item_type(
-                table_item_data.key_type.as_str(),
-                &table_item_data.key,
-                txn_version,
-            )? {
-                Some(TokenWriteSet::TokenDataId(inner)) => Some(inner),
-                _ => None,
-            };
-            if let Some(token_data_id_struct) = maybe_token_data_id {
-                let collection_id = token_data_id_struct.get_collection_id();
-                let token_data_id = token_data_id_struct.to_id();
-                let token_name = token_data_id_struct.get_name_trunc();
-                let token_uri = token_data.get_uri_trunc();
-
-                return Ok(Some((
-                    Self {
-                        transaction_version: txn_version,
-                        write_set_change_index,
-                        token_data_id: token_data_id.clone(),
-                        collection_id: collection_id.clone(),
-                        token_name: token_name.clone(),
-                        maximum: Some(token_data.maximum.clone()),
-                        supply: Some(token_data.supply.clone()),
-                        largest_property_version_v1: Some(
-                            token_data.largest_property_version.clone(),
-                        ),
-                        token_uri: token_uri.clone(),
-                        token_properties: token_data.default_properties.clone(),
-                        description: token_data.description.clone(),
-                        token_standard: TokenStandard::V1.to_string(),
-                        is_fungible_v2: None,
-                        transaction_timestamp: txn_timestamp,
-                        decimals: None,
-                    },
-                    CurrentTokenDataV2 {
-                        token_data_id,
-                        collection_id,
-                        token_name,
-                        maximum: Some(token_data.maximum),
-                        supply: Some(token_data.supply),
-                        largest_property_version_v1: Some(token_data.largest_property_version),
-                        token_uri,
-                        token_properties: token_data.default_properties,
-                        description: token_data.description,
-                        token_standard: TokenStandard::V1.to_string(),
-                        is_fungible_v2: None,
-                        last_transaction_version: txn_version,
-                        last_transaction_timestamp: txn_timestamp,
-                        decimals: None,
-                        is_deleted_v2: None,
-                    },
-                )));
-            } else {
-                tracing::warn!(
-                    transaction_version = txn_version,
-                    key_type = table_item_data.key_type,
-                    key = table_item_data.key,
-                    "Expecting token_data_id as key for value = token_data"
-                );
-            }
-        }
-        Ok(None)
     }
 }

--- a/rust/sdk-processor/src/config/processor_config.rs
+++ b/rust/sdk-processor/src/config/processor_config.rs
@@ -28,8 +28,11 @@ use processor::{
             parquet_v2_fungible_metadata::FungibleAssetMetadataModel,
         },
         token_v2_models::{
-            token_claims::CurrentTokenPendingClaim, v1_token_royalty::CurrentTokenRoyaltyV1,
-            v2_token_activities::TokenActivityV2, v2_token_metadata::CurrentTokenV2Metadata,
+            token_claims::CurrentTokenPendingClaim,
+            v1_token_royalty::CurrentTokenRoyaltyV1,
+            v2_token_activities::TokenActivityV2,
+            v2_token_datas::{CurrentTokenDataV2, TokenDataV2},
+            v2_token_metadata::CurrentTokenV2Metadata,
         },
         transaction_metadata_model::parquet_write_set_size_info::WriteSetSize,
         user_transaction_models::parquet_user_transactions::UserTransaction,
@@ -174,6 +177,8 @@ impl ProcessorConfig {
                 CurrentTokenRoyaltyV1::TABLE_NAME.to_string(),
                 CurrentTokenV2Metadata::TABLE_NAME.to_string(),
                 TokenActivityV2::TABLE_NAME.to_string(),
+                TokenDataV2::TABLE_NAME.to_string(),
+                CurrentTokenDataV2::TABLE_NAME.to_string(),
             ]),
             _ => HashSet::new(), // Default case for unsupported processors
         }

--- a/rust/sdk-processor/src/parquet_processors/mod.rs
+++ b/rust/sdk-processor/src/parquet_processors/mod.rs
@@ -34,8 +34,11 @@ use processor::{
             parquet_v2_fungible_metadata::FungibleAssetMetadataModel,
         },
         token_v2_models::{
-            token_claims::CurrentTokenPendingClaim, v1_token_royalty::CurrentTokenRoyaltyV1,
-            v2_token_activities::TokenActivityV2, v2_token_metadata::CurrentTokenV2Metadata,
+            token_claims::CurrentTokenPendingClaim,
+            v1_token_royalty::CurrentTokenRoyaltyV1,
+            v2_token_activities::TokenActivityV2,
+            v2_token_datas::{CurrentTokenDataV2, TokenDataV2},
+            v2_token_metadata::CurrentTokenV2Metadata,
         },
         transaction_metadata_model::parquet_write_set_size_info::WriteSetSize,
         user_transaction_models::parquet_user_transactions::UserTransaction,
@@ -115,6 +118,8 @@ pub enum ParquetTypeEnum {
     CurrentTokenRoyaltiesV1,
     CurrentTokenV2Metadata,
     TokenActivitiesV2,
+    TokenDatasV2,
+    CurrentTokenDatasV2,
 }
 
 /// Trait for handling various Parquet types.
@@ -206,6 +211,8 @@ impl_parquet_trait!(
     ParquetTypeEnum::CurrentTokenV2Metadata
 );
 impl_parquet_trait!(TokenActivityV2, ParquetTypeEnum::TokenActivitiesV2);
+impl_parquet_trait!(TokenDataV2, ParquetTypeEnum::TokenDatasV2);
+impl_parquet_trait!(CurrentTokenDataV2, ParquetTypeEnum::CurrentTokenDatasV2);
 
 #[derive(Debug, Clone)]
 #[enum_dispatch(ParquetTypeTrait)]
@@ -232,6 +239,8 @@ pub enum ParquetTypeStructs {
     CurrentTokenRoyaltyV1(Vec<CurrentTokenRoyaltyV1>),
     CurrentTokenV2Metadata(Vec<CurrentTokenV2Metadata>),
     TokenActivityV2(Vec<TokenActivityV2>),
+    TokenDataV2(Vec<TokenDataV2>),
+    CurrentTokenDataV2(Vec<CurrentTokenDataV2>),
 }
 
 impl ParquetTypeStructs {
@@ -279,6 +288,10 @@ impl ParquetTypeStructs {
                 ParquetTypeStructs::CurrentTokenV2Metadata(Vec::new())
             },
             ParquetTypeEnum::TokenActivitiesV2 => ParquetTypeStructs::TokenActivityV2(Vec::new()),
+            ParquetTypeEnum::TokenDatasV2 => ParquetTypeStructs::TokenDataV2(Vec::new()),
+            ParquetTypeEnum::CurrentTokenDatasV2 => {
+                ParquetTypeStructs::CurrentTokenDataV2(Vec::new())
+            },
         }
     }
 
@@ -418,6 +431,18 @@ impl ParquetTypeStructs {
             (
                 ParquetTypeStructs::TokenActivityV2(self_data),
                 ParquetTypeStructs::TokenActivityV2(other_data),
+            ) => {
+                handle_append!(self_data, other_data)
+            },
+            (
+                ParquetTypeStructs::TokenDataV2(self_data),
+                ParquetTypeStructs::TokenDataV2(other_data),
+            ) => {
+                handle_append!(self_data, other_data)
+            },
+            (
+                ParquetTypeStructs::CurrentTokenDataV2(self_data),
+                ParquetTypeStructs::CurrentTokenDataV2(other_data),
             ) => {
                 handle_append!(self_data, other_data)
             },

--- a/rust/sdk-processor/src/parquet_processors/parquet_token_v2_processor.rs
+++ b/rust/sdk-processor/src/parquet_processors/parquet_token_v2_processor.rs
@@ -31,8 +31,11 @@ use parquet::schema::types::Type;
 use processor::{
     bq_analytics::generic_parquet_processor::HasParquetSchema,
     db::parquet::models::token_v2_models::{
-        token_claims::CurrentTokenPendingClaim, v1_token_royalty::CurrentTokenRoyaltyV1,
-        v2_token_activities::TokenActivityV2, v2_token_metadata::CurrentTokenV2Metadata,
+        token_claims::CurrentTokenPendingClaim,
+        v1_token_royalty::CurrentTokenRoyaltyV1,
+        v2_token_activities::TokenActivityV2,
+        v2_token_datas::{CurrentTokenDataV2, TokenDataV2},
+        v2_token_metadata::CurrentTokenV2Metadata,
     },
 };
 use std::{collections::HashMap, sync::Arc};
@@ -140,6 +143,15 @@ impl ProcessorTrait for ParquetTokenV2Processor {
             (
                 ParquetTypeEnum::TokenActivitiesV2,
                 TokenActivityV2::schema(),
+            ),
+            (ParquetTypeEnum::TokenDatasV2, TokenDataV2::schema()),
+            (
+                ParquetTypeEnum::CurrentTokenDatasV2,
+                CurrentTokenDataV2::schema(),
+            ),
+            (
+                ParquetTypeEnum::CurrentTokenDatasV2,
+                CurrentTokenDataV2::schema(),
             ),
         ]
         .into_iter()

--- a/rust/sdk-processor/src/steps/token_v2_processor/token_v2_extractor.rs
+++ b/rust/sdk-processor/src/steps/token_v2_processor/token_v2_extractor.rs
@@ -12,6 +12,7 @@ use processor::{
             raw_token_claims::CurrentTokenPendingClaimConvertible,
             raw_v1_token_royalty::CurrentTokenRoyaltyV1Convertible,
             raw_v2_token_activities::TokenActivityV2Convertible,
+            raw_v2_token_datas::{CurrentTokenDataV2Convertible, TokenDataV2Convertible},
             raw_v2_token_metadata::CurrentTokenV2MetadataConvertible,
         },
         postgres::models::{
@@ -106,11 +107,11 @@ impl Processable for TokenV2Extractor {
 
         let (
             collections_v2,
-            token_datas_v2,
+            raw_token_datas_v2,
             token_ownerships_v2,
             current_collections_v2,
-            current_token_datas_v2,
-            current_deleted_token_datas_v2,
+            raw_current_token_datas_v2,
+            raw_current_deleted_token_datas_v2,
             current_token_ownerships_v2,
             current_deleted_token_ownerships_v2,
             raw_token_activities_v2,
@@ -148,14 +149,30 @@ impl Processable for TokenV2Extractor {
             .map(TokenActivityV2::from_raw)
             .collect();
 
+        let postgres_token_datas_v2: Vec<TokenDataV2> = raw_token_datas_v2
+            .into_iter()
+            .map(TokenDataV2::from_raw)
+            .collect();
+
+        let postgres_current_token_datas_v2: Vec<CurrentTokenDataV2> = raw_current_token_datas_v2
+            .into_iter()
+            .map(CurrentTokenDataV2::from_raw)
+            .collect();
+
+        let postgress_current_deleted_token_datas_v2: Vec<CurrentTokenDataV2> =
+            raw_current_deleted_token_datas_v2
+                .into_iter()
+                .map(CurrentTokenDataV2::from_raw)
+                .collect();
+
         Ok(Some(TransactionContext {
             data: (
                 collections_v2,
-                token_datas_v2,
+                postgres_token_datas_v2,
                 token_ownerships_v2,
                 current_collections_v2,
-                current_token_datas_v2,
-                current_deleted_token_datas_v2,
+                postgres_current_token_datas_v2,
+                postgress_current_deleted_token_datas_v2,
                 current_token_ownerships_v2,
                 current_deleted_token_ownerships_v2,
                 postgres_token_activities_v2,


### PR DESCRIPTION
### Description

### TestPlan
- Compared the number of rows from DE teams BigQuery table, testing BigQuery table, legacy processor table, and sdk processor table 

### Current Token Datas

![Screenshot 2024-12-11 at 7 56 31 PM](https://github.com/user-attachments/assets/a30cb49b-94a6-4d98-9ef1-98aaa6c1003d)
<img width="1126" alt="Screenshot 2024-12-11 at 7 56 25 PM" src="https://github.com/user-attachments/assets/1b65ac92-3694-421a-af6f-2e8df283b814" />

### test table

![Screenshot 2024-12-11 at 9 40 36 PM](https://github.com/user-attachments/assets/01fee736-ac5d-4a87-a883-a626061a17c0)


### Token Datas
<img width="920" alt="Screenshot 2024-12-11 at 7 55 41 PM" src="https://github.com/user-attachments/assets/4a156b15-2903-4359-9217-979395347497" />

![Screenshot 2024-12-11 at 7 55 39 PM](https://github.com/user-attachments/assets/c62412e8-2866-4d16-ac89-0c63156776c6)

### test table
![Screenshot 2024-12-11 at 9 39 33 PM](https://github.com/user-attachments/assets/16d4208d-fdb4-43bf-ab2a-f2b6caac98cd)

