### PR TITLE
Return None when no entry found in processor_status

### DIFF
--- a/rust/sdk-processor/src/utils/starting_version.rs
+++ b/rust/sdk-processor/src/utils/starting_version.rs
@@ -115,7 +115,7 @@ async fn get_min_processed_version_from_db(
                     Some(status.last_success_version as u64)
                 },
                 // Handle specific cases where `Ok` contains `None` (no status found)
-                Ok(None) => Some(0),
+                Ok(None) => None,
                 // TODO: If the result is an `Err`, what should we do?
                 Err(e) => {
                     eprintln!("Error fetching processor status: {:?}", e);


### PR DESCRIPTION
### Purpose
This will now use `starting_version` when there's no checkpoint in `processor_status`.

### Testing
![image](https://github.com/user-attachments/assets/3782f1f5-3a8b-4c62-83f5-3db260f99b4b)
