### PR TITLE
Add columns to `user_transactions` table

### DIFF
--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_ed25519/user_transactions.json
@@ -11,8 +11,8 @@
     "timestamp": "2022-10-18T23:10:04.331016",
     "entry_function_id_str": "0xa3f6a53c57395401ce64f09a188e2259dc9b156387e76c88a7a80a8fe5254476::momentum_safe::register",
     "epoch": 75,
-    "contract_address": "0xa3f6a53c57395401ce64f09a188e2259dc9b156387e76c88a7a80a8fe5254476",
-    "module_name": "momentum_safe",
-    "function_name": "register"
+    "entry_function_contract_address": "0xa3f6a53c57395401ce64f09a188e2259dc9b156387e76c88a7a80a8fe5254476",
+    "entry_function_module_name": "momentum_safe",
+    "entry_function_function_name": "register"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_ed25519/user_transactions.json
@@ -10,6 +10,9 @@
     "gas_unit_price": "100",
     "timestamp": "2022-10-18T23:10:04.331016",
     "entry_function_id_str": "0xa3f6a53c57395401ce64f09a188e2259dc9b156387e76c88a7a80a8fe5254476::momentum_safe::register",
-    "epoch": 75
+    "epoch": 75,
+    "contract_address": "0xa3f6a53c57395401ce64f09a188e2259dc9b156387e76c88a7a80a8fe5254476",
+    "module_name": "momentum_safe",
+    "function_name": "register"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_key_keyless_signature/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_key_keyless_signature/user_transactions.json
@@ -11,7 +11,7 @@
     "timestamp": "2024-10-16T17:07:21.987832",
     "entry_function_id_str": "0x1::aptos_account::transfer",
     "epoch": 8870,
-    "contract_address": "0x1",
+    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
     "module_name": "aptos_account",
     "function_name": "transfer"
   }

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_key_keyless_signature/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_key_keyless_signature/user_transactions.json
@@ -10,6 +10,9 @@
     "gas_unit_price": "100",
     "timestamp": "2024-10-16T17:07:21.987832",
     "entry_function_id_str": "0x1::aptos_account::transfer",
-    "epoch": 8870
+    "epoch": 8870,
+    "contract_address": "0x1",
+    "module_name": "aptos_account",
+    "function_name": "transfer"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_key_keyless_signature/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_multi_key_keyless_signature/user_transactions.json
@@ -11,8 +11,8 @@
     "timestamp": "2024-10-16T17:07:21.987832",
     "entry_function_id_str": "0x1::aptos_account::transfer",
     "epoch": 8870,
-    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "module_name": "aptos_account",
-    "function_name": "transfer"
+    "entry_function_contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "entry_function_module_name": "aptos_account",
+    "entry_function_function_name": "transfer"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_ed25519/user_transactions.json
@@ -11,8 +11,8 @@
     "timestamp": "2022-10-12T21:26:20.299882",
     "entry_function_id_str": "0x1::stake::update_network_and_fullnode_addresses",
     "epoch": 2,
-    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "module_name": "stake",
-    "function_name": "update_network_and_fullnode_addresses"
+    "entry_function_contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "entry_function_module_name": "stake",
+    "entry_function_function_name": "update_network_and_fullnode_addresses"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_ed25519/user_transactions.json
@@ -10,6 +10,9 @@
     "gas_unit_price": "100",
     "timestamp": "2022-10-12T21:26:20.299882",
     "entry_function_id_str": "0x1::stake::update_network_and_fullnode_addresses",
-    "epoch": 2
+    "epoch": 2,
+    "contract_address": "0x1",
+    "module_name": "stake",
+    "function_name": "update_network_and_fullnode_addresses"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_ed25519/user_transactions.json
@@ -11,7 +11,7 @@
     "timestamp": "2022-10-12T21:26:20.299882",
     "entry_function_id_str": "0x1::stake::update_network_and_fullnode_addresses",
     "epoch": 2,
-    "contract_address": "0x1",
+    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
     "module_name": "stake",
     "function_name": "update_network_and_fullnode_addresses"
   }

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_ed25519/user_transactions.json
@@ -10,6 +10,9 @@
     "gas_unit_price": "100",
     "timestamp": "2024-02-23T22:21:53.482262",
     "entry_function_id_str": "0x1::coin::transfer",
-    "epoch": 6013
+    "epoch": 6013,
+    "contract_address": "0x1",
+    "module_name": "coin",
+    "function_name": "transfer"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_ed25519/user_transactions.json
@@ -11,8 +11,8 @@
     "timestamp": "2024-02-23T22:21:53.482262",
     "entry_function_id_str": "0x1::coin::transfer",
     "epoch": 6013,
-    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "module_name": "coin",
-    "function_name": "transfer"
+    "entry_function_contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "entry_function_module_name": "coin",
+    "entry_function_function_name": "transfer"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_ed25519/user_transactions.json
@@ -11,7 +11,7 @@
     "timestamp": "2024-02-23T22:21:53.482262",
     "entry_function_id_str": "0x1::coin::transfer",
     "epoch": 6013,
-    "contract_address": "0x1",
+    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
     "module_name": "coin",
     "function_name": "transfer"
   }

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_secp/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_secp/user_transactions.json
@@ -11,8 +11,8 @@
     "timestamp": "2024-01-16T09:35:08.981259",
     "entry_function_id_str": "0x1::coin::transfer",
     "epoch": 5547,
-    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "module_name": "coin",
-    "function_name": "transfer"
+    "entry_function_contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "entry_function_module_name": "coin",
+    "entry_function_function_name": "transfer"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_secp/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_secp/user_transactions.json
@@ -10,6 +10,9 @@
     "gas_unit_price": "100",
     "timestamp": "2024-01-16T09:35:08.981259",
     "entry_function_id_str": "0x1::coin::transfer",
-    "epoch": 5547
+    "epoch": 5547,
+    "contract_address": "0x1",
+    "module_name": "coin",
+    "function_name": "transfer"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_secp/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_key_secp/user_transactions.json
@@ -11,7 +11,7 @@
     "timestamp": "2024-01-16T09:35:08.981259",
     "entry_function_id_str": "0x1::coin::transfer",
     "epoch": 5547,
-    "contract_address": "0x1",
+    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
     "module_name": "coin",
     "function_name": "transfer"
   }

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_ed25519/user_transactions.json
@@ -10,6 +10,9 @@
     "gas_unit_price": "100",
     "timestamp": "2024-05-09T01:18:59.975711",
     "entry_function_id_str": "0x1::aptos_account::transfer_coins",
-    "epoch": 6924
+    "epoch": 6924,
+    "contract_address": "0x1",
+    "module_name": "aptos_account",
+    "function_name": "transfer_coins"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_ed25519/user_transactions.json
@@ -11,8 +11,8 @@
     "timestamp": "2024-05-09T01:18:59.975711",
     "entry_function_id_str": "0x1::aptos_account::transfer_coins",
     "epoch": 6924,
-    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "module_name": "aptos_account",
-    "function_name": "transfer_coins"
+    "entry_function_contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "entry_function_module_name": "aptos_account",
+    "entry_function_function_name": "transfer_coins"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_ed25519/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_ed25519/user_transactions.json
@@ -11,7 +11,7 @@
     "timestamp": "2024-05-09T01:18:59.975711",
     "entry_function_id_str": "0x1::aptos_account::transfer_coins",
     "epoch": 6924,
-    "contract_address": "0x1",
+    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
     "module_name": "aptos_account",
     "function_name": "transfer_coins"
   }

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_keyless/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_keyless/user_transactions.json
@@ -11,7 +11,7 @@
     "timestamp": "2024-06-10T15:51:10.170250",
     "entry_function_id_str": "0x1::aptos_account::transfer_coins",
     "epoch": 7324,
-    "contract_address": "0x1",
+    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
     "module_name": "aptos_account",
     "function_name": "transfer_coins"
   }

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_keyless/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_keyless/user_transactions.json
@@ -10,6 +10,9 @@
     "gas_unit_price": "100",
     "timestamp": "2024-06-10T15:51:10.170250",
     "entry_function_id_str": "0x1::aptos_account::transfer_coins",
-    "epoch": 7324
+    "epoch": 7324,
+    "contract_address": "0x1",
+    "module_name": "aptos_account",
+    "function_name": "transfer_coins"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_keyless/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_keyless/user_transactions.json
@@ -11,8 +11,8 @@
     "timestamp": "2024-06-10T15:51:10.170250",
     "entry_function_id_str": "0x1::aptos_account::transfer_coins",
     "epoch": 7324,
-    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "module_name": "aptos_account",
-    "function_name": "transfer_coins"
+    "entry_function_contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "entry_function_module_name": "aptos_account",
+    "entry_function_function_name": "transfer_coins"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_secp/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_secp/user_transactions.json
@@ -11,8 +11,8 @@
     "timestamp": "2024-03-29T13:51:13.448212",
     "entry_function_id_str": "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12::scripts_v2::swap",
     "epoch": 6429,
-    "contract_address": "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12",
-    "module_name": "scripts_v2",
-    "function_name": "swap"
+    "entry_function_contract_address": "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12",
+    "entry_function_module_name": "scripts_v2",
+    "entry_function_function_name": "swap"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_secp/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_secp/user_transactions.json
@@ -10,6 +10,9 @@
     "gas_unit_price": "100",
     "timestamp": "2024-03-29T13:51:13.448212",
     "entry_function_id_str": "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12::scripts_v2::swap",
-    "epoch": 6429
+    "epoch": 6429,
+    "contract_address": "0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12",
+    "module_name": "scripts_v2",
+    "function_name": "swap"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_webauth/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_webauth/user_transactions.json
@@ -10,6 +10,9 @@
     "gas_unit_price": "100",
     "timestamp": "2024-04-13T17:59:30.751467",
     "entry_function_id_str": "0x1::aptos_account::transfer_coins",
-    "epoch": 6620
+    "epoch": 6620,
+    "contract_address": "0x1",
+    "module_name": "aptos_account",
+    "function_name": "transfer_coins"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_webauth/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_webauth/user_transactions.json
@@ -11,8 +11,8 @@
     "timestamp": "2024-04-13T17:59:30.751467",
     "entry_function_id_str": "0x1::aptos_account::transfer_coins",
     "epoch": 6620,
-    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "module_name": "aptos_account",
-    "function_name": "transfer_coins"
+    "entry_function_contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "entry_function_module_name": "aptos_account",
+    "entry_function_function_name": "transfer_coins"
   }
 ]

--- a/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_webauth/user_transactions.json
+++ b/rust/integration-tests/sdk_expected_db_output_files/user_transaction_processor/test_single_sender_webauth/user_transactions.json
@@ -11,7 +11,7 @@
     "timestamp": "2024-04-13T17:59:30.751467",
     "entry_function_id_str": "0x1::aptos_account::transfer_coins",
     "epoch": 6620,
-    "contract_address": "0x1",
+    "contract_address": "0x0000000000000000000000000000000000000000000000000000000000000001",
     "module_name": "aptos_account",
     "function_name": "transfer_coins"
   }

--- a/rust/integration-tests/src/models/user_transactions_models.rs
+++ b/rust/integration-tests/src/models/user_transactions_models.rs
@@ -48,4 +48,7 @@ pub struct UserTransaction {
     pub entry_function_id_str: String,
     pub inserted_at: chrono::NaiveDateTime,
     pub epoch: i64,
+    pub contract_address: String,
+    pub module_name: String,
+    pub function_name: String,
 }

--- a/rust/integration-tests/src/models/user_transactions_models.rs
+++ b/rust/integration-tests/src/models/user_transactions_models.rs
@@ -48,7 +48,7 @@ pub struct UserTransaction {
     pub entry_function_id_str: String,
     pub inserted_at: chrono::NaiveDateTime,
     pub epoch: i64,
-    pub contract_address: String,
-    pub module_name: String,
-    pub function_name: String,
+    pub entry_function_contract_address: String,
+    pub entry_function_module_name: String,
+    pub entry_function_function_name: String,
 }

--- a/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/down.sql
@@ -1,5 +1,5 @@
 -- This file should undo anything in `up.sql`
 ALTER TABLE user_transactions
-DROP COLUMN IF EXISTS contract_address,
-DROP COLUMN IF EXISTS module_name,
-DROP COLUMN IF EXISTS function_name;
+DROP COLUMN IF EXISTS entry_function_contract_address,
+DROP COLUMN IF EXISTS entry_function_module_name,
+DROP COLUMN IF EXISTS entry_function_function_name;

--- a/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE user_transactions
+DROP COLUMN IF EXISTS contract_address,
+DROP COLUMN IF EXISTS module_name,
+DROP COLUMN IF EXISTS function_name;

--- a/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/down.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/down.sql
@@ -3,3 +3,4 @@ ALTER TABLE user_transactions
 DROP COLUMN IF EXISTS entry_function_contract_address,
 DROP COLUMN IF EXISTS entry_function_module_name,
 DROP COLUMN IF EXISTS entry_function_function_name;
+DROP INDEX IF EXISTS user_transactions_contract_info_index;

--- a/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
@@ -3,3 +3,4 @@ ALTER TABLE user_transactions
 ADD COLUMN contract_address VARCHAR(66) NOT NULL,
 ADD COLUMN module_name VARCHAR(255) NOT NULL,
 ADD COLUMN function_name VARCHAR(255) NOT NULL;
+CREATE INDEX IF NOT EXISTS user_transactions_contract_info_index ON user_transactions (contract_address, module_name, function_name);

--- a/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
@@ -1,6 +1,6 @@
 -- Your SQL goes here
 ALTER TABLE user_transactions
-ADD COLUMN contract_address VARCHAR(66) NOT NULL,
-ADD COLUMN module_name VARCHAR(255) NOT NULL,
-ADD COLUMN function_name VARCHAR(255) NOT NULL;
-CREATE INDEX IF NOT EXISTS user_transactions_contract_info_index ON user_transactions (contract_address, module_name, function_name);
+ADD COLUMN entry_function_contract_address VARCHAR(66) NOT NULL,
+ADD COLUMN entry_function_module_name VARCHAR(255) NOT NULL,
+ADD COLUMN entry_function_function_name VARCHAR(255) NOT NULL;
+CREATE INDEX IF NOT EXISTS user_transactions_contract_info_index ON user_transactions (entry_function_contract_address, entry_function_module_name, entry_function_function_name);

--- a/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE user_transactions
+ADD COLUMN contract_address VARCHAR(66) NOT NULL,
+ADD COLUMN module_name VARCHAR(255) NOT NULL,
+ADD COLUMN function_name VARCHAR(255) NOT NULL;

--- a/rust/processor/src/db/postgres/models/user_transactions_models/user_transactions.rs
+++ b/rust/processor/src/db/postgres/models/user_transactions_models/user_transactions.rs
@@ -11,7 +11,9 @@ use super::signatures::Signature;
 use crate::{
     schema::user_transactions,
     utils::util::{
-        get_entry_function_from_user_request, parse_timestamp, standardize_address,
+        get_entry_function_contract_address_from_user_request,
+        get_entry_function_from_user_request, get_entry_function_function_name_from_user_request,
+        get_entry_function_module_name_from_user_request, parse_timestamp, standardize_address,
         u64_to_bigdecimal,
     },
 };
@@ -38,6 +40,9 @@ pub struct UserTransaction {
     pub timestamp: chrono::NaiveDateTime,
     pub entry_function_id_str: String,
     pub epoch: i64,
+    pub contract_address: String,
+    pub module_name: String,
+    pub function_name: String,
 }
 
 impl UserTransaction {
@@ -79,6 +84,14 @@ impl UserTransaction {
                 entry_function_id_str: get_entry_function_from_user_request(user_request)
                     .unwrap_or_default(),
                 epoch,
+                contract_address: get_entry_function_contract_address_from_user_request(
+                    user_request,
+                )
+                .unwrap_or_default(),
+                module_name: get_entry_function_module_name_from_user_request(user_request)
+                    .unwrap_or_default(),
+                function_name: get_entry_function_function_name_from_user_request(user_request)
+                    .unwrap_or_default(),
             },
             Self::get_signatures(user_request, version, block_height),
         )

--- a/rust/processor/src/db/postgres/models/user_transactions_models/user_transactions.rs
+++ b/rust/processor/src/db/postgres/models/user_transactions_models/user_transactions.rs
@@ -40,9 +40,9 @@ pub struct UserTransaction {
     pub timestamp: chrono::NaiveDateTime,
     pub entry_function_id_str: String,
     pub epoch: i64,
-    pub contract_address: String,
-    pub module_name: String,
-    pub function_name: String,
+    pub entry_function_contract_address: String,
+    pub entry_function_module_name: String,
+    pub entry_function_function_name: String,
 }
 
 impl UserTransaction {
@@ -84,14 +84,17 @@ impl UserTransaction {
                 entry_function_id_str: get_entry_function_from_user_request(user_request)
                     .unwrap_or_default(),
                 epoch,
-                contract_address: get_entry_function_contract_address_from_user_request(
+                entry_function_contract_address:
+                    get_entry_function_contract_address_from_user_request(user_request)
+                        .unwrap_or_default(),
+                entry_function_module_name: get_entry_function_module_name_from_user_request(
                     user_request,
                 )
                 .unwrap_or_default(),
-                module_name: get_entry_function_module_name_from_user_request(user_request)
-                    .unwrap_or_default(),
-                function_name: get_entry_function_function_name_from_user_request(user_request)
-                    .unwrap_or_default(),
+                entry_function_function_name: get_entry_function_function_name_from_user_request(
+                    user_request,
+                )
+                .unwrap_or_default(),
             },
             Self::get_signatures(user_request, version, block_height),
         )

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -1265,6 +1265,12 @@ diesel::table! {
         entry_function_id_str -> Varchar,
         inserted_at -> Timestamp,
         epoch -> Int8,
+        #[max_length = 66]
+        contract_address -> Varchar,
+        #[max_length = 255]
+        module_name -> Varchar,
+        #[max_length = 255]
+        function_name -> Varchar,
     }
 }
 

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -1266,11 +1266,11 @@ diesel::table! {
         inserted_at -> Timestamp,
         epoch -> Int8,
         #[max_length = 66]
-        contract_address -> Varchar,
+        entry_function_contract_address -> Varchar,
         #[max_length = 255]
-        module_name -> Varchar,
+        entry_function_module_name -> Varchar,
         #[max_length = 255]
-        function_name -> Varchar,
+        entry_function_function_name -> Varchar,
     }
 }
 

--- a/rust/processor/src/utils/util.rs
+++ b/rust/processor/src/utils/util.rs
@@ -147,6 +147,34 @@ pub fn get_entry_function_from_user_request(
     entry_function_id_str.map(|s| truncate_str(&s, MAX_ENTRY_FUNCTION_LENGTH))
 }
 
+pub fn get_entry_function_contract_address_from_user_request(
+    user_request: &UserTransactionRequest,
+) -> Option<String> {
+    get_entry_function_from_user_request(user_request).and_then(|s| {
+        s.split("::").next().map(String::from) // Get the first element (contract address)
+    })
+}
+
+pub fn get_entry_function_module_name_from_user_request(
+    user_request: &UserTransactionRequest,
+) -> Option<String> {
+    get_entry_function_from_user_request(user_request).and_then(|s| {
+        s.split("::")
+            .nth(1) // Get the second element (module name)
+            .map(String::from)
+    })
+}
+
+pub fn get_entry_function_function_name_from_user_request(
+    user_request: &UserTransactionRequest,
+) -> Option<String> {
+    get_entry_function_from_user_request(user_request).and_then(|s| {
+        s.split("::")
+            .nth(2) // Get the third element (function name)
+            .map(String::from)
+    })
+}
+
 pub fn get_payload_type(payload: &TransactionPayload) -> String {
     payload.r#type().as_str_name().to_string()
 }


### PR DESCRIPTION
Following https://aptos-org.slack.com/archives/C03MN5F7WUV/p1734539332759199 , adding `contract_address`, `module_name`, and `function_name` columns to the `user_transactions` table to index each of the entry function string data separately. 

<img width="1341" alt="image" src="https://github.com/user-attachments/assets/175b95d0-7dd5-4d10-ba64-9a0d3306a124" />

