### PR TITLE
Remove null constraint on new user_transaction rows

### DIFF
--- a/rust/integration-tests/src/models/user_transactions_models.rs
+++ b/rust/integration-tests/src/models/user_transactions_models.rs
@@ -48,7 +48,7 @@ pub struct UserTransaction {
     pub entry_function_id_str: String,
     pub inserted_at: chrono::NaiveDateTime,
     pub epoch: i64,
-    pub entry_function_contract_address: String,
-    pub entry_function_module_name: String,
-    pub entry_function_function_name: String,
+    pub entry_function_contract_address: Option<String>,
+    pub entry_function_module_name: Option<String>,
+    pub entry_function_function_name: Option<String>,
 }

--- a/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
@@ -1,6 +1,6 @@
 -- Your SQL goes here
 ALTER TABLE user_transactions
-ADD COLUMN entry_function_contract_address VARCHAR(66) NOT NULL,
-ADD COLUMN entry_function_module_name VARCHAR(255) NOT NULL,
-ADD COLUMN entry_function_function_name VARCHAR(255) NOT NULL;
+ADD COLUMN entry_function_contract_address VARCHAR(66),
+ADD COLUMN entry_function_module_name VARCHAR(255),
+ADD COLUMN entry_function_function_name VARCHAR(255);
 CREATE INDEX IF NOT EXISTS user_transactions_contract_info_index ON user_transactions (entry_function_contract_address, entry_function_module_name, entry_function_function_name);

--- a/rust/processor/src/db/postgres/models/user_transactions_models/user_transactions.rs
+++ b/rust/processor/src/db/postgres/models/user_transactions_models/user_transactions.rs
@@ -40,9 +40,9 @@ pub struct UserTransaction {
     pub timestamp: chrono::NaiveDateTime,
     pub entry_function_id_str: String,
     pub epoch: i64,
-    pub entry_function_contract_address: String,
-    pub entry_function_module_name: String,
-    pub entry_function_function_name: String,
+    pub entry_function_contract_address: Option<String>,
+    pub entry_function_module_name: Option<String>,
+    pub entry_function_function_name: Option<String>,
 }
 
 impl UserTransaction {
@@ -84,17 +84,18 @@ impl UserTransaction {
                 entry_function_id_str: get_entry_function_from_user_request(user_request)
                     .unwrap_or_default(),
                 epoch,
-                entry_function_contract_address:
+                entry_function_contract_address: Some(
                     get_entry_function_contract_address_from_user_request(user_request)
                         .unwrap_or_default(),
-                entry_function_module_name: get_entry_function_module_name_from_user_request(
-                    user_request,
-                )
-                .unwrap_or_default(),
-                entry_function_function_name: get_entry_function_function_name_from_user_request(
-                    user_request,
-                )
-                .unwrap_or_default(),
+                ),
+                entry_function_module_name: Some(
+                    get_entry_function_module_name_from_user_request(user_request)
+                        .unwrap_or_default(),
+                ),
+                entry_function_function_name: Some(
+                    get_entry_function_function_name_from_user_request(user_request)
+                        .unwrap_or_default(),
+                ),
             },
             Self::get_signatures(user_request, version, block_height),
         )

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -1266,11 +1266,11 @@ diesel::table! {
         inserted_at -> Timestamp,
         epoch -> Int8,
         #[max_length = 66]
-        entry_function_contract_address -> Varchar,
+        entry_function_contract_address -> Nullable<Varchar>,
         #[max_length = 255]
-        entry_function_module_name -> Varchar,
+        entry_function_module_name -> Nullable<Varchar>,
         #[max_length = 255]
-        entry_function_function_name -> Varchar,
+        entry_function_function_name -> Nullable<Varchar>,
     }
 }
 


### PR DESCRIPTION
Fixes a db migration error where existing rows had null values for the new columns