### PR TITLE
Retain order for property maps

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1710,7 +1710,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1729,7 +1729,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2231,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.0",
@@ -2247,7 +2247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "is-terminal",
  "itoa",
  "log",
@@ -2960,7 +2960,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -3157,7 +3157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
 ]
 
 [[package]]
@@ -3398,6 +3398,7 @@ dependencies = [
  "google-cloud-storage",
  "hex",
  "hyper 0.14.30",
+ "indexmap 2.7.0",
  "itertools 0.12.1",
  "jemallocator",
  "kanal",
@@ -3505,7 +3506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -4262,7 +4263,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
@@ -4321,7 +4322,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5011,7 +5012,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -78,6 +78,7 @@ google-cloud-googleapis = "0.10.0"
 google-cloud-pubsub = "0.18.0"
 hex = "0.4.3"
 itertools = "0.12.1"
+indexmap = { version = "2.7.0", features = ["serde"] }
 jemallocator = { version = "0.5.0", features = [
     "profiling",
     "unprefixed_malloc_on_supported_platforms",

--- a/rust/processor/Cargo.toml
+++ b/rust/processor/Cargo.toml
@@ -39,6 +39,7 @@ google-cloud-pubsub = { workspace = true }
 google-cloud-storage = { workspace = true }
 hex = { workspace = true }
 hyper = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 kanal = { workspace = true }
 lazy_static = { workspace = true }

--- a/rust/processor/src/db/postgres/models/property_map.rs
+++ b/rust/processor/src/db/postgres/models/property_map.rs
@@ -3,6 +3,7 @@
 
 use crate::utils::util;
 use ahash::AHashMap;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::{Result, Value};
 
@@ -21,14 +22,14 @@ pub fn create_property_value(typ: String, value: String) -> Result<PropertyValue
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PropertyMap {
-    data: AHashMap<String, PropertyValue>,
+    data: IndexMap<String, PropertyValue>,
 }
 
 impl PropertyMap {
     /// Deserializes PropertyValue from bcs encoded json
     pub fn from_bcs_encode_str(val: Value) -> Option<Value> {
         let mut pm = PropertyMap {
-            data: AHashMap::new(),
+            data: IndexMap::new(),
         };
         let records: &Vec<Value> = val.get("map")?.get("data")?.as_array()?;
         for entry in records {
@@ -71,14 +72,14 @@ pub fn create_token_object_property_value(
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TokenObjectPropertyMap {
-    data: AHashMap<String, TokenObjectPropertyValue>,
+    data: IndexMap<String, TokenObjectPropertyValue>,
 }
 
 impl TokenObjectPropertyMap {
     /// Deserializes PropertyValue from bcs encoded json
     pub fn from_bcs_encode_str(val: Value) -> Option<Value> {
         let mut pm = TokenObjectPropertyMap {
-            data: AHashMap::new(),
+            data: IndexMap::new(),
         };
         let records: &Vec<Value> = val.get("data")?.as_array()?;
         for entry in records {
@@ -95,7 +96,7 @@ impl TokenObjectPropertyMap {
     /// For example: Object {"data": Object {"creation_time_sec": Object {"value": String("1666125588")}}}
     /// becomes Object {"creation_time_sec": "1666125588"}
     fn to_flat_json_new(val: TokenObjectPropertyMap) -> Value {
-        let mut map = AHashMap::new();
+        let mut map = IndexMap::new();
         for (k, v) in val.data {
             map.insert(k, v.value);
         }


### PR DESCRIPTION
Ensure that the property maps from tokens maintain their order, to prevent deltas between different versions due to different keys (but with same data)