### PR TITLE
[deps] Move linux dependency to crate instead of workspace

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,6 @@ anyhow = "1.0.86"
 aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "a56b641a6aaca60092fcc9bbd98252f3cd703299" }
 aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "a56b641a6aaca60092fcc9bbd98252f3cd703299" }
 aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "6116af69aa173ca49e1761daabd6fe103fe2c65e" }
-aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }
 aptos-indexer-test-transactions = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "6116af69aa173ca49e1761daabd6fe103fe2c65e" }
 aptos-indexer-testing-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "a56b641a6aaca60092fcc9bbd98252f3cd703299" }
 async-trait = "0.1.53"

--- a/rust/server-framework/Cargo.toml
+++ b/rust/server-framework/Cargo.toml
@@ -27,4 +27,4 @@ tracing-subscriber = { workspace = true }
 warp = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-aptos-system-utils = { workspace = true }
+aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }


### PR DESCRIPTION
This dependency causes some build issues, because it's expected to exist at the workspace level.  So, even though it's not required for anything, it still has to be downloaded.

Now, this prevents this from occurring, making sure it's only loaded for linux.

This is what happened before:
```
Run scripts/cli/build_cli_release.sh "macOS" "6.0.1"
Building release 6.0.1 of aptos-cli for Darwin-macOS on arm64
    Updating git repository `https://github.com/aptos-labs/futures-rs`
    Updating git repository `https://github.com/aptos-labs/merlin`
    Updating git repository `https://github.com/aptos-labs/serde-reflection`
    Updating git repository `https://github.com/aptos-labs/x2551[9](https://github.com/gregnazario/aptos-core/actions/runs/12774871815/job/35609926121#step:4:10)-dalek`
    Updating git repository `https://github.com/aptos-labs/bcs.git`
    Updating crates.io index
    Updating git repository `https://github.com/poem-web/poem.git`
    Updating git repository `https://github.com/arnaucube/poseidon-ark.git`
    Updating git repository `https://github.com/aptos-labs/aptos-indexer-processors.git`
    Updating git submodule `https://github.com/banool/aptos-tontine.git`
    Updating git repository `https://github.com/weiznich/diesel_async.git`
    Updating crates.io index
    Updating git submodule `https://github.com/banool/aptos-tontine.git`
    Updating git repository `https://github.com/banool/self_update.git`
    Updating git repository `https://github.com/aptos-labs/firebase-token`
    Updating git repository `https://github.com/aptos-labs/aptos-indexer-processor-sdk.git`
    Updating git repository `https://github.com/aptos-labs/aptos-core.git`
    Updating git submodule `https://github.com/aptos-labs/aptos-indexer-processors.git`
    Updating git submodule `https://github.com/banool/aptos-tontine.git`
    Updating git repository `https://github.com/aptos-labs/aptos-core.git`
error: failed to get `aptos-system-utils` as a dependency of package `server-framework v1.0.0 (https://github.com/aptos-labs/aptos-indexer-processors.git?rev=51a34901b40d7f75767ac907b4d2478[10](https://github.com/gregnazario/aptos-core/actions/runs/12774871815/job/35609926121#step:4:11)4d6a515#51a34901)`
    ... which satisfies git dependency `server-framework` (locked to 1.0.0) of package `aptos v6.0.1 (/Users/runner/work/aptos-core/aptos-core/crates/aptos)`
    ... which satisfies path dependency `aptos` of package `aptos-release-builder v0.1.0 (/Users/runner/work/aptos-core/aptos-core/aptos-move/aptos-release-builder)`

Caused by:
  failed to load source for dependency `aptos-system-utils`

Caused by:
  Unable to update https://github.com/aptos-labs/aptos-core.git?rev=[20](https://github.com/gregnazario/aptos-core/actions/runs/12774871815/job/35609926121#step:4:21)2bdccff2b2d333a385ae86a4fcf23e89da9f62#202bdccf

Caused by:
  revspec '202bdccff2b2d333a385ae86a4fcf[23](https://github.com/gregnazario/aptos-core/actions/runs/12774871815/job/35609926121#step:4:24)e89da9f62' not found; class=Reference (4); code=NotFound (-3)
```