### PR TITLE
[RFC] Support orderless transactions in Indexer

### DIFF
--- a/hasura-api/metadata-json/unified.json
+++ b/hasura-api/metadata-json/unified.json
@@ -2335,7 +2335,8 @@
                     "sender",
                     "sequence_number",
                     "timestamp",
-                    "version"
+                    "version",
+                    "replay_protection_nonce"
                   ],
                   "filter": {},
                   "limit": 100

--- a/hasura-api/metadata-json/unified_transition.json
+++ b/hasura-api/metadata-json/unified_transition.json
@@ -2384,7 +2384,8 @@
                     "sender",
                     "sequence_number",
                     "timestamp",
-                    "version"
+                    "version",
+                    "replay_protection_nonce"
                   ],
                   "filter": {},
                   "limit": 100

--- a/python/utils/transaction_utils.py
+++ b/python/utils/transaction_utils.py
@@ -31,7 +31,8 @@ def get_sender(
     user_transaction_request = get_user_transaction_request(user_transaction)
     return user_transaction_request.sender
 
-
+# Question: Multisig transactions could also have an entry function payload inside them.
+# Is it okay to ignore that entry function payload here?
 def get_entry_function_payload(
     user_transaction: transaction_pb2.UserTransaction,
 ) -> transaction_pb2.EntryFunctionPayload:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -319,6 +319,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-protos"
+version = "1.3.1"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=f3bbed37ea0fbd31c6ad56361724247e1a417d9b#f3bbed37ea0fbd31c6ad56361724247e1a417d9b"
+dependencies = [
+ "futures-core",
+ "pbjson",
+ "prost 0.12.6",
+ "serde",
+ "tonic 0.11.0",
+]
+
+[[package]]
 name = "aptos-system-utils"
 version = "0.1.0"
 source = "git+https://github.com/aptos-labs/aptos-core.git?rev=202bdccff2b2d333a385ae86a4fcf23e89da9f62#202bdccff2b2d333a385ae86a4fcf23e89da9f62"
@@ -2286,7 +2298,7 @@ dependencies = [
  "aptos-indexer-processor-sdk",
  "aptos-indexer-test-transactions",
  "aptos-indexer-testing-framework",
- "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=f3bbed37ea0fbd31c6ad56361724247e1a417d9b)",
  "assert-json-diff",
  "bigdecimal",
  "chrono",
@@ -3377,7 +3389,7 @@ dependencies = [
  "allocative_derive",
  "anyhow",
  "aptos-moving-average 0.1.0",
- "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=f3bbed37ea0fbd31c6ad56361724247e1a417d9b)",
  "async-trait",
  "bcs",
  "bigdecimal",
@@ -4729,7 +4741,7 @@ dependencies = [
 name = "testing-transactions"
 version = "0.1.0"
 dependencies = [
- "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=f3bbed37ea0fbd31c6ad56361724247e1a417d9b)",
  "serde_json",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,7 +32,7 @@ ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.86"
 aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "e6867c50a2c30ef16ad6f82e02313b2ba5ce361a" }
 aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "e6867c50a2c30ef16ad6f82e02313b2ba5ce361a" }
-aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
+aptos-protos = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "f3bbed37ea0fbd31c6ad56361724247e1a417d9b" }
 aptos-system-utils = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "202bdccff2b2d333a385ae86a4fcf23e89da9f62" }
 aptos-indexer-test-transactions = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "8bb628129ff48241c650178caf1ff8bf53a44e5e" }
 aptos-indexer-testing-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "e6867c50a2c30ef16ad6f82e02313b2ba5ce361a" }

--- a/rust/integration-tests/src/models/user_transactions_models.rs
+++ b/rust/integration-tests/src/models/user_transactions_models.rs
@@ -51,4 +51,6 @@ pub struct UserTransaction {
     pub entry_function_contract_address: Option<String>,
     pub entry_function_module_name: Option<String>,
     pub entry_function_function_name: Option<String>,
+    // Question: Is it okay to use i64 here, even though replay_protection_nonce is defined as u64 in aptos-core?
+    pub replay_protection_nonce: Option<i64>,
 }

--- a/rust/integration-tests/src/sdk_tests/user_transaction_processor_tests.rs
+++ b/rust/integration-tests/src/sdk_tests/user_transaction_processor_tests.rs
@@ -48,6 +48,7 @@ mod sdk_user_txn_processor_tests {
             run_processor_test, setup_test_environment, validate_json, DEFAULT_OUTPUT_FOLDER,
         },
     };
+    // TODO: Add some orderless transactions here
     use aptos_indexer_test_transactions::{
         IMPORTED_MAINNET_TXNS_1803170308_USER_TXN_MULTI_KEY_KEYLESS,
         IMPORTED_MAINNET_TXNS_2175935_USER_TXN_MULTI_ED25519,

--- a/rust/processor/src/db/postgres/migrations/2022-08-08-043603_core_tables/up.sql
+++ b/rust/processor/src/db/postgres/migrations/2022-08-08-043603_core_tables/up.sql
@@ -163,13 +163,15 @@ CREATE TABLE user_transactions (
   -- from UserTransaction
   "timestamp" TIMESTAMP NOT NULL,
   entry_function_id_str text NOT NULL,
+  replay_protection_nonce BIGINT,
   -- Default time columns
   inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
   -- Constraints
   CONSTRAINT fk_versions FOREIGN KEY (version) REFERENCES transactions (version),
-  UNIQUE (sender, sequence_number)
+  UNIQUE (sender, sequence_number, replay_protection_nonce)
 );
-CREATE INDEX ut_sender_seq_index ON user_transactions (sender, sequence_number);
+/* Question: Is it okay to change this index by adding `replay_protection_nonce` in the key? */
+CREATE INDEX ut_sender_seq_index ON user_transactions (sender, sequence_number, replay_protection_nonce);
 CREATE INDEX ut_insat_index ON user_transactions (inserted_at);
 -- tracks signatures for user transactions
 CREATE TABLE signatures (

--- a/rust/processor/src/db/postgres/models/events_models/events.rs
+++ b/rust/processor/src/db/postgres/models/events_models/events.rs
@@ -11,6 +11,7 @@ use aptos_protos::transaction::v1::Event as EventPB;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
+// Question: Do we have to add a replay_protection_nonce here?
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(transaction_version, event_index))]
 #[diesel(table_name = events)]

--- a/rust/processor/src/db/postgres/models/token_models/token_activities.rs
+++ b/rust/processor/src/db/postgres/models/token_models/token_activities.rs
@@ -30,6 +30,7 @@ pub struct TokenActivity {
     pub transaction_version: i64,
     pub event_account_address: String,
     pub event_creation_number: i64,
+    // Question: Do we need to add a replay_protection_nonce here?
     pub event_sequence_number: i64,
     pub token_data_id_hash: String,
     pub property_version: BigDecimal,

--- a/rust/processor/src/db/postgres/schema.rs
+++ b/rust/processor/src/db/postgres/schema.rs
@@ -1271,6 +1271,7 @@ diesel::table! {
         entry_function_module_name -> Nullable<Varchar>,
         #[max_length = 255]
         entry_function_function_name -> Nullable<Varchar>,
+        replay_protection_nonce -> Nullable<Int8>,
     }
 }
 

--- a/rust/processor/src/transaction_filter.rs
+++ b/rust/processor/src/transaction_filter.rs
@@ -60,6 +60,8 @@ impl TransactionFilter {
 
                 if let Some(focus_contract_addresses) = &self.focus_contract_addresses {
                     // Skip if focus contract addresses are set and the transaction isn't in the list
+                    // Question: Entry function transactions and Multisig transactions with entry function payload are treated
+                    // the same way. Is this okay?
                     if let Some(payload) = utr.payload.as_ref() {
                         if let Some(Payload::EntryFunctionPayload(efp)) = payload.payload.as_ref() {
                             if let Some(function) = efp.function.as_ref() {

--- a/rust/sdk-processor/src/db/common/models/events_models/events.rs
+++ b/rust/sdk-processor/src/db/common/models/events_models/events.rs
@@ -21,6 +21,7 @@ const EVENT_TYPE_MAX_LENGTH: usize = 300;
 #[diesel(primary_key(transaction_version, event_index))]
 #[diesel(table_name = events)]
 pub struct Event {
+    // Question: Do we need to add a replay_protection_nonce here?
     pub sequence_number: i64,
     pub creation_number: i64,
     pub account_address: String,

--- a/rust/testing-transactions/src/lib.rs
+++ b/rust/testing-transactions/src/lib.rs
@@ -3,6 +3,8 @@
 
 include!(concat!(env!("OUT_DIR"), "/generate_transactions.rs"));
 
+// TODO: Add some orderless transactions here for testing.
+// Question: Should we do it after the orderless tranactions feature is deployed?
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Support orderless transactions in Indexer. 
To support orderless transactions, in aptos-core repo, we've added a new variant in `TransactionPayload` enum, to additionally store a nonce and multisig address. 
Also, in aptos.transaction.v1.rs in aptos-core, we've added `ExtraConfig` containing nonce and multisig address.

This PR modifies the indexer to support the changes in transaction structure of UserTransaction.