### PR TITLE
fix asset_type_v1 null issue

### DIFF
--- a/rust/processor/src/processors/fungible_asset_processor.rs
+++ b/rust/processor/src/processors/fungible_asset_processor.rs
@@ -50,8 +50,10 @@ use aptos_protos::transaction::v1::{transaction::TxnData, write_set_change::Chan
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
 use diesel::{
+    dsl::sql,
     pg::{upsert::excluded, Pg},
     query_builder::QueryFragment,
+    sql_types::{Nullable, Text},
     ExpressionMethods,
 };
 use rayon::prelude::*;
@@ -276,7 +278,8 @@ pub fn insert_current_unified_fungible_asset_balances_v2_query(
             .set(
                 (
                     owner_address.eq(excluded(owner_address)),
-                    asset_type_v1.eq(excluded(asset_type_v1)),
+                    // This guarantees that asset_type_v1 will not be overridden to null
+                    asset_type_v1.eq(sql::<Nullable<Text>>("COALESCE(EXCLUDED.asset_type_v1, current_fungible_asset_balances.asset_type_v1)")),
                     asset_type_v2.eq(excluded(asset_type_v2)),
                     is_primary.eq(excluded(is_primary)),
                     is_frozen.eq(excluded(is_frozen)),


### PR DESCRIPTION
## Summary
Not sure why diesel is being weird here and overriding field with null even though `treat_none_as_null` is false. 

## Backfill
When first v2 only apt was created.
Testnet: 2598047902
Mainnet: 1669115601

## Test
asset_type_v1 was null before
![image](https://github.com/user-attachments/assets/80700bce-06ec-4c19-86ff-d2d127de28ba)
