### PR TITLE
ci: fix template injection in workflow files

### DIFF
--- a/.github/workflows/copy-processor-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-processor-images-to-dockerhub.yaml
@@ -79,5 +79,7 @@ jobs:
           FORCE_COLOR: 3 # Force color output as per https://github.com/google/zx#using-github-actions
           GIT_SHA: ${{ inputs.GIT_SHA }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}
-        run: pnpm release-processor-images --language=${{ inputs.processor_language }} --version-tag=${{ inputs.version_tag }} --wait-for-image-seconds=3600
+          PROCESSOR_LANGUAGE: ${{ inputs.processor_language }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: pnpm release-processor-images --language="$PROCESSOR_LANGUAGE" --version-tag="$VERSION_TAG" --wait-for-image-seconds=3600
         working-directory: scripts

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -36,17 +36,18 @@ jobs:
       # Update aptos-system-utils dependency using toml-cli
       - name: Update aptos-system-utils dependency
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+        env:
+          COMMIT_HASH: ${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
         run: |
-          COMMIT_HASH=${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
           echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash $COMMIT_HASH"
           toml set rust/Cargo.toml workspace.dependencies.aptos-system-utils.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 
       # Update aptos-indexer-test-transactions dependency using toml-cli
       - name: Update aptos-indexer-test-transactions dependency
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+        env:
+          COMMIT_HASH: ${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
         run: |
-          COMMIT_HASH=${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
-
           echo "Updating aptos-indexer-test-transactions dependency in Cargo.toml to use commit hash $COMMIT_HASH"
           toml set rust/Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 

--- a/.github/workflows/update-sdk-dependency.yaml
+++ b/.github/workflows/update-sdk-dependency.yaml
@@ -48,20 +48,20 @@ jobs:
       - name: Install toml
         run: cargo install toml-cli
       - name: Update the dependency
+        env:
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}
+          APTOS_PROTOS_COMMIT_HASH: ${{ github.event.inputs.aptos_protos_commit_hash || github.event.client_payload.aptos_protos_commit_hash }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
         run: |
           set -e
           # Use workflow_dispatch inputs if available, otherwise use repository_dispatch values
-          commit_hash="${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}"
-          aptos_protos_commit_hash="${{ github.event.inputs.aptos_protos_commit_hash || github.event.client_payload.aptos_protos_commit_hash }}"
-          branch_name="${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}"
-          
           # SDK commit hash SDK + framework + testing.
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk.rev "$commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk-server-framework.rev "$commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-testing-framework.rev "$commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk-server-framework.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-testing-framework.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
           # Protos commit hash
-          toml set Cargo.toml workspace.dependencies.aptos-protos.rev "$aptos_protos_commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml 
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$aptos_protos_commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-protos.rev "$APTOS_PROTOS_COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$APTOS_PROTOS_COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
           cargo build || true
         working-directory: rust/
       - name: Configure Git user
@@ -69,28 +69,30 @@ jobs:
           git config --global user.name "Aptos Bot"
           git config --global user.email "aptos-bot@aptoslabs.com"
       - name: Commit and Push Changes
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}
         run: |
            set -e
-           branch_name="${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}-update-sdk"
-           commit_hash="${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}"
+           branch_name="${BRANCH_NAME}-update-sdk"
            git checkout -b "$branch_name"
            git add Cargo.toml
            git add Cargo.lock
-           git commit -m "Update sdk to $commit_hash"
+           git commit -m "Update sdk to $COMMIT_HASH"
            git push origin "$branch_name" --force
-        env:
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
         working-directory: rust/
       - name: Create Pull Request
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
         run: |
-          branch_name="${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}-update-sdk"
-          gh pr create --title "Update sdk to upstream branch ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}" \
+          branch_name="${BRANCH_NAME}-update-sdk"
+          gh pr create --title "Update sdk to upstream branch $BRANCH_NAME" \
                        --body "This PR updates sdk to new version." \
                        --base main \
                        --head "$branch_name" \
                        --label "indexer-sdk-update"
-        env:
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
       - name: Run Integration Tests
         run: cargo test --manifest-path integration-tests/Cargo.toml
         working-directory: rust


### PR DESCRIPTION
## Summary

Fixes shell injection vulnerabilities in three GitHub Actions workflow files identified by [zizmor](https://github.com/woodruffw/zizmor).

**Vulnerability:** `${{ expr }}` expressions were interpolated directly into `run:` shell scripts. GitHub Actions substitutes these values before the shell parses the script, so event payload values containing shell metacharacters could execute arbitrary commands in the runner.

**Fix:** Moved all affected expressions into `env:` blocks. The shell then expands them as environment variables, which is safe regardless of the value.

## Files changed

| File | Expressions fixed | Trigger exposure |
|---|---|---|
| `integration-tests.yaml` | `github.event.client_payload.commit_hash` | `repository_dispatch` (write access required) |
| `update-sdk-dependency.yaml` | `commit_hash`, `aptos_protos_commit_hash`, `branch_name` | `repository_dispatch` / `workflow_dispatch` (write access required) — runner has `contents: write` + `pull-requests: write` |
| `copy-processor-images-to-dockerhub.yaml` | `inputs.version_tag`, `inputs.processor_language` | `workflow_dispatch` / `workflow_call` (write access required) |

## Test plan

- [ ] Verify all three workflow files are syntactically valid YAML
- [ ] Confirm `update-sdk-dependency` still creates PRs correctly on a test dispatch
- [ ] Confirm `integration-tests` still resolves `COMMIT_HASH` from payload
- [ ] Confirm zizmor no longer reports `template-injection` on these files