### PR TITLE
ci: harden GitHub Actions workflows (zizmor audit)

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -28,7 +28,9 @@ jobs:
         example: [rust]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/docker-setup
         with:
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
@@ -38,7 +40,7 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/copy-processor-images-to-dockerhub-release.yaml
+++ b/.github/workflows/copy-processor-images-to-dockerhub-release.yaml
@@ -18,4 +18,8 @@ jobs:
       processor_language: ${{ matrix.language }}
       version_tag: ${{ github.ref_name }}
       GIT_SHA: ${{ github.sha }}
-    secrets: inherit
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+      ENV_DOCKERHUB_USERNAME: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
+      ENV_DOCKERHUB_PASSWORD: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}

--- a/.github/workflows/copy-processor-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-processor-images-to-dockerhub.yaml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          persist-credentials: false
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
@@ -53,7 +55,7 @@ jobs:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: .node-version
 
@@ -79,5 +81,7 @@ jobs:
           FORCE_COLOR: 3 # Force color output as per https://github.com/google/zx#using-github-actions
           GIT_SHA: ${{ inputs.GIT_SHA }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}
-        run: pnpm release-processor-images --language=${{ inputs.processor_language }} --version-tag=${{ inputs.version_tag }} --wait-for-image-seconds=3600
+          PROCESSOR_LANGUAGE: ${{ inputs.processor_language }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: pnpm release-processor-images --language="$PROCESSOR_LANGUAGE" --version-tag="$VERSION_TAG" --wait-for-image-seconds=3600
         working-directory: scripts

--- a/.github/workflows/create-release-tag.yaml
+++ b/.github/workflows/create-release-tag.yaml
@@ -14,9 +14,11 @@ on:
 jobs:
   create-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Fetch all history for all tags and branches
 
@@ -58,7 +60,7 @@ jobs:
           git push origin "$new_tag"
       # TODO: roll docker image release into this workflow.
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: aptos-indexer-processors-v${{ steps.generate_version.outputs.new_version }}
           name: Release ${{ steps.generate_version.outputs.new_version }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,12 +18,15 @@ on:
 jobs:
   Integration-tests:
     runs-on: runs-on,runner=2cpu-linux-x64,run-id=${{ github.run_id }}
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ github.head_ref }} # check out the code from the pull request branch:
+          persist-credentials: false
 
       # Install toml-cli using cargo
       - name: Install toml-cli
@@ -36,17 +39,18 @@ jobs:
       # Update aptos-system-utils dependency using toml-cli
       - name: Update aptos-system-utils dependency
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+        env:
+          COMMIT_HASH: ${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
         run: |
-          COMMIT_HASH=${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
           echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash $COMMIT_HASH"
           toml set rust/Cargo.toml workspace.dependencies.aptos-system-utils.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 
       # Update aptos-indexer-test-transactions dependency using toml-cli
       - name: Update aptos-indexer-test-transactions dependency
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+        env:
+          COMMIT_HASH: ${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
         run: |
-          COMMIT_HASH=${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
-
           echo "Updating aptos-indexer-test-transactions dependency in Cargo.toml to use commit hash $COMMIT_HASH"
           toml set rust/Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp rust/Cargo.toml
 
@@ -63,7 +67,7 @@ jobs:
 
       # Cache Cargo
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/bin/
@@ -97,7 +101,7 @@ jobs:
 
       - name: Send Slack Notification to oncall
         if: ${{ steps.sanity-check.outcome == 'failure' && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'indexer-sdk-update') }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           # eco-infra-oncall channel.
           channel-id: 'C0468USBLQJ'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 # cancel redundant builds
 concurrency:
   # for push and workflow_dispatch events we use `github.sha` in the concurrency group and don't really cancel each other out/limit concurrency
@@ -17,8 +20,12 @@ concurrency:
 jobs:
   Python:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/python-setup
         with:
           pyproject_directory: python
@@ -27,8 +34,12 @@ jobs:
 
   Rust:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
       - name: Install deps and run linter
         run: |
           sudo apt update && sudo apt install libdw-dev

--- a/.github/workflows/nightly-integration-tests.yaml
+++ b/.github/workflows/nightly-integration-tests.yaml
@@ -9,10 +9,14 @@ jobs:
 
   nightly-run:
     runs-on: runs-on,runner=2cpu-linux-x64,run-id=${{ github.run_id }}
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Dependencies and Run Linter
         uses: ./.github/actions/dep_install_and_lint

--- a/.github/workflows/publish-protos-python.yaml
+++ b/.github/workflows/publish-protos-python.yaml
@@ -15,10 +15,13 @@ on:
 jobs:
   publish-crate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
+          persist-credentials: false
 
       - uses: ./.github/actions/python-setup
         with:

--- a/.github/workflows/publish-protos-rust.yaml
+++ b/.github/workflows/publish-protos-rust.yaml
@@ -15,10 +15,13 @@ on:
 jobs:
   publish-crate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
+          persist-credentials: false
 
       - uses: ./.github/actions/rust-setup
 
@@ -40,14 +43,14 @@ jobs:
         run: echo "Version of crate in repo matches version on crates.io, exiting..." && exit 1
 
       # Generate code from the proto files.
-      - uses: arduino/setup-protoc@v2
+      - uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
       - name: Install rust prost plugins
         run: |
           cargo install protoc-gen-prost
           cargo install protoc-gen-prost-serde
           cargo install protoc-gen-prost-crate
           cargo install protoc-gen-tonic
-      - uses: bufbuild/buf-setup-action@v1.24.0
+      - uses: bufbuild/buf-setup-action@d5f79ca09dab494736bae6976ce973d76d8853e1 # v1.24.0
       - run: buf generate --template buf.rust.gen.yaml
 
       # Publish the crate.

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
@@ -25,10 +28,13 @@ jobs:
   rust-unit-coverage:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+          persist-credentials: false
 
       - name: rust setup
         run: |
@@ -54,7 +60,7 @@ jobs:
         working-directory: rust
       - run: ls -R
         working-directory: rust
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: lcov_unit
           path: rust/lcov_unit.info
@@ -62,12 +68,16 @@ jobs:
   upload-to-codecov:
     runs-on: ubuntu-latest
     continue-on-error: true # Don't fail if the codecov upload fails
+    permissions:
+      contents: read
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     needs: [ rust-unit-coverage ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: lcov_unit
       - run: ls -R

--- a/.github/workflows/update-sdk-dependency.yaml
+++ b/.github/workflows/update-sdk-dependency.yaml
@@ -24,44 +24,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
       - name: Get Secret Manager Secrets
         id: secrets
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        uses: 'google-github-actions/get-secretmanager-secrets@2b5f97c5a4b9c105e64646762ad4fc3f5128e6f5' # v2
         with:
           secrets: |-
             token:aptos-ci/github-actions-repository-dispatch
       - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld libdw-dev --no-install-recommends --assume-yes
         shell: bash
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.secrets.outputs.token }}
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           rustflags: --cfg tokio_unstable
           components: cargo clippy rustc rust-docs rust-std
       - name: Install toml
         run: cargo install toml-cli
       - name: Update the dependency
+        env:
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}
+          APTOS_PROTOS_COMMIT_HASH: ${{ github.event.inputs.aptos_protos_commit_hash || github.event.client_payload.aptos_protos_commit_hash }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
         run: |
           set -e
-          # Use workflow_dispatch inputs if available, otherwise use repository_dispatch values
-          commit_hash="${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}"
-          aptos_protos_commit_hash="${{ github.event.inputs.aptos_protos_commit_hash || github.event.client_payload.aptos_protos_commit_hash }}"
-          branch_name="${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}"
-          
           # SDK commit hash SDK + framework + testing.
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk.rev "$commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk-server-framework.rev "$commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-testing-framework.rev "$commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk-server-framework.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-testing-framework.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
           # Protos commit hash
-          toml set Cargo.toml workspace.dependencies.aptos-protos.rev "$aptos_protos_commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml 
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$aptos_protos_commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-protos.rev "$APTOS_PROTOS_COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$APTOS_PROTOS_COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
           cargo build || true
         working-directory: rust/
       - name: Configure Git user
@@ -69,28 +68,30 @@ jobs:
           git config --global user.name "Aptos Bot"
           git config --global user.email "aptos-bot@aptoslabs.com"
       - name: Commit and Push Changes
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}
         run: |
            set -e
-           branch_name="${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}-update-sdk"
-           commit_hash="${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}"
+           branch_name="${BRANCH_NAME}-update-sdk"
            git checkout -b "$branch_name"
            git add Cargo.toml
            git add Cargo.lock
-           git commit -m "Update sdk to $commit_hash"
+           git commit -m "Update sdk to $COMMIT_HASH"
            git push origin "$branch_name" --force
-        env:
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
         working-directory: rust/
       - name: Create Pull Request
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
         run: |
-          branch_name="${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}-update-sdk"
-          gh pr create --title "Update sdk to upstream branch ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}" \
+          branch_name="${BRANCH_NAME}-update-sdk"
+          gh pr create --title "Update sdk to upstream branch $BRANCH_NAME" \
                        --body "This PR updates sdk to new version." \
                        --base main \
                        --head "$branch_name" \
                        --label "indexer-sdk-update"
-        env:
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
       - name: Run Integration Tests
         run: cargo test --manifest-path integration-tests/Cargo.toml
         working-directory: rust


### PR DESCRIPTION
## Summary

Security hardening of GitHub Actions workflows based on a zizmor audit of the aptos-labs org.

## Changes

| Rule | Count | Fix applied |
|---|---|---|
| `unpinned-uses` | 24 | Pinned mutable action refs to commit SHAs; tag immutability verified via GitHub rulesets API — no active deletion/non_fast_forward rulesets found on any action repo, so all tags are mutable and replaced with SHA pins |
| `excessive-permissions` | 11 | Added `permissions: contents: read` at workflow and job level; `create-release-tag` job gets `contents: write` (needed for `git push`) |
| `artipacked` | 12 | Added `persist-credentials: false` to checkout steps that do not require pushing back to the repo (`create-release-tag` and `update-sdk-dependency` intentionally excluded — they run `git push`) |
| `secrets-inherit` | 1 | Replaced `secrets: inherit` in `copy-processor-images-to-dockerhub-release.yaml` with explicit secret mapping |

## SHA pins applied

| Action | Tag | Commit SHA |
|---|---|---|
| `actions/checkout` | v3 | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/cache` | v4 | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| `actions/upload-artifact` | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | v4 | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `actions/setup-node` | v3 | `3235b876344d2a9aa001b8d1453c930bba69e610` |
| `actions-rust-lang/setup-rust-toolchain` | v1 | `46268bd060767258de96ed93c1251119784f2ab6` |
| `softprops/action-gh-release` | v1 | `de2c0eb89ae2a093876385947365aca7b0e5f844` |
| `slackapi/slack-github-action` | v1.24.0 | `e28cf165c92ffef168d23c5c9000cffc8a25e117` |
| `bufbuild/buf-setup-action` | v1.24.0 | `d5f79ca09dab494736bae6976ce973d76d8853e1` |
| `arduino/setup-protoc` | v2 (→ v2.1.0) | `a8b67ba40b37d35169e222f3bb352603327985b6` |
| `google-github-actions/auth` | v2 | `c200f3691d83b41bf9bbd8638997a462592937ed` |
| `google-github-actions/get-secretmanager-secrets` | v2 | `2b5f97c5a4b9c105e64646762ad4fc3f5128e6f5` |

## Tag immutability verification

Each flagged action repo was queried via `gh api repos/OWNER/REPO/rulesets`. No repos had active `deletion` or `non_fast_forward` rulesets, so all tag refs are mutable and have been replaced with commit SHAs.

Already SHA-pinned actions left unchanged:
- `actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8` (copy-processor-images-to-dockerhub.yaml)
- `docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b`
- `pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2`
- `taiki-e/install-action@4fedbddde88aab767a45a011661f832d68202716`
- `codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70`

## Test plan
- [ ] All YAML files parse without errors (validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI passes on this branch
- [ ] No remaining zizmor findings at error severity for the addressed rules